### PR TITLE
fix: thread badge not appearing until hard refresh

### DIFF
--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -858,10 +858,13 @@ export function RoomTimeline({ room, eventId, threadId, roomInputRef, editor }: 
   );
 
   // Re-render when threads are created or updated so ThreadIndicator badges appear.
+  // Skip when already inside a thread view — that path uses threadTimelineTick instead.
   useThreadUpdate(
     room,
     useCallback(() => {
-      setTimeline((ct) => ({ ...ct }));
+      if (!threadIdRef.current) {
+        setTimeline((ct) => ({ ...ct }));
+      }
     }, [])
   );
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -22,6 +22,7 @@ import {
   Room,
   RoomEvent,
   RoomEventHandlerMap,
+  ThreadEvent,
 } from 'matrix-js-sdk';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import classNames from 'classnames';
@@ -434,6 +435,23 @@ const useLiveTimelineRefresh = (room: Room, onRefresh: () => void) => {
   }, [room, onRefresh]);
 };
 
+/**
+ * Re-render the main timeline when a thread is created or receives a new reply
+ * so that ThreadIndicator badges update in real time.
+ */
+const useThreadUpdate = (room: Room, onUpdate: () => void) => {
+  useEffect(() => {
+    room.on(ThreadEvent.New, onUpdate);
+    room.on(ThreadEvent.NewReply, onUpdate);
+    room.on(ThreadEvent.Update, onUpdate);
+    return () => {
+      room.removeListener(ThreadEvent.New, onUpdate);
+      room.removeListener(ThreadEvent.NewReply, onUpdate);
+      room.removeListener(ThreadEvent.Update, onUpdate);
+    };
+  }, [room, onUpdate]);
+};
+
 const getInitialTimeline = (room: Room) => {
   const linkedTimelines = getLinkedTimelines(getLiveTimeline(room));
   const evLength = getTimelinesEventsCount(linkedTimelines);
@@ -837,6 +855,14 @@ export function RoomTimeline({ room, eventId, threadId, roomInputRef, editor }: 
         setTimeline(getInitialTimeline(room));
       }
     }, [room, liveTimelineLinked])
+  );
+
+  // Re-render when threads are created or updated so ThreadIndicator badges appear.
+  useThreadUpdate(
+    room,
+    useCallback(() => {
+      setTimeline((ct) => ({ ...ct }));
+    }, [])
   );
 
   // Stay at bottom when room editor resize


### PR DESCRIPTION
## Summary

- Thread badges (the "Thread · N replies" indicator) on root messages were not appearing in real time when someone replied in a thread. They only showed after a hard refresh.
- Root cause: the component only listened for `RoomEvent.Timeline`, but the SDK routes thread replies to the thread's own timeline (`shouldLiveInRoom: false`), so no re-render was triggered on the main timeline.
- Fix: add a `useThreadUpdate` hook that listens for `ThreadEvent.New`, `ThreadEvent.NewReply`, and `ThreadEvent.Update` on the room object. These events fire after the SDK has registered the Thread and populated it, so `room.getThread(id)?.length` returns the correct count during the re-render.

## Test plan

- [ ] Send a message in a room
- [ ] From another account, reply to that message in a thread
- [ ] Verify the thread badge appears immediately on the root message without refreshing
- [ ] Verify the reply count updates as more replies are added
- [ ] Verify no regression: entering/exiting thread view still works correctly