### PR TITLE
feat(auth): support sso-only login config

### DIFF
--- a/src/app/hooks/useClientConfig.ts
+++ b/src/app/hooks/useClientConfig.ts
@@ -44,6 +44,7 @@ export type ClientConfig = {
   auth?: {
     hideServerPickerWhenSingle?: boolean;
     allowRegistration?: boolean;
+    disablePasswordLogin?: boolean;
     requireAppleProvider?: boolean;
     supportUrl?: string;
     privacyPolicyUrl?: string;

--- a/src/app/pages/auth/login/Login.tsx
+++ b/src/app/pages/auth/login/Login.tsx
@@ -65,7 +65,7 @@ export function Login() {
   const parsedFlows = useParsedLoginFlows(loginFlows.flows);
   const serverWithoutScheme = server.replace(/^https?:\/\//i, '').replace(/\/+$/, '');
   const isMindroomServer = serverWithoutScheme.toLowerCase() === 'mindroom.chat';
-  const disablePasswordLogin = isMindroomServer;
+  const disablePasswordLogin = auth?.disablePasswordLogin === true || isMindroomServer;
   const showPasswordLogin = parsedFlows.password !== undefined && !disablePasswordLogin;
   const registrationAllowed = auth?.allowRegistration !== false;
   const requireAppleProvider = auth?.requireAppleProvider === true;


### PR DESCRIPTION
## Summary
- add an `auth.disablePasswordLogin` client config flag
- use that flag to hide password login on the login screen
- keep registration hidden when `auth.allowRegistration` is false

## Testing
- not run