### PR TITLE
fix: dedupe confirmed thread events and preserve media auth cookies

### DIFF
--- a/src/app/features/room/threadEventCache.test.ts
+++ b/src/app/features/room/threadEventCache.test.ts
@@ -73,6 +73,19 @@ describe('normalizeCachedThreadEvents', () => {
       },
     ]);
   });
+
+  it('deduplicates identical cached remote events when one copy still includes the transaction id', () => {
+    expect(
+      normalizeCachedThreadEvents([
+        {
+          event_id: '$remote',
+          origin_server_ts: 200,
+          unsigned: { transaction_id: 'txn-2' },
+        },
+        { event_id: '$remote', origin_server_ts: 200 },
+      ])
+    ).toEqual([{ event_id: '$remote', origin_server_ts: 200 }]);
+  });
 });
 
 describe('filterPageableCachedThreadEvents', () => {

--- a/src/app/features/room/threadEventCache.ts
+++ b/src/app/features/room/threadEventCache.ts
@@ -72,15 +72,19 @@ const getRawTransactionId = (rawEvent: Partial<IEvent>): string | undefined => {
   return txnId;
 };
 
-const getRawEventKey = (rawEvent: Partial<IEvent>): string | undefined => {
-  const txnId = getRawTransactionId(rawEvent);
-  if (txnId) return `txn:${txnId}`;
+const getRawEventKeys = (rawEvent: Partial<IEvent>): string[] => {
+  const keys: string[] = [];
 
   if (typeof rawEvent.event_id === 'string' && rawEvent.event_id.length > 0) {
-    return `event:${rawEvent.event_id}`;
+    keys.push(`event:${rawEvent.event_id}`);
   }
 
-  return undefined;
+  const txnId = getRawTransactionId(rawEvent);
+  if (txnId) {
+    keys.push(`txn:${txnId}`);
+  }
+
+  return keys;
 };
 
 const isRawLocalEchoEvent = (rawEvent: Partial<IEvent>): boolean =>
@@ -125,27 +129,40 @@ export const normalizeCachedThreadEvents = (
 ): CachedThreadEvent[] => {
   const eventMap = new Map<string, CachedThreadEvent>();
 
+  const setEventForKeys = (keys: string[], mEvent: CachedThreadEvent) => {
+    keys.forEach((key) => {
+      eventMap.set(key, mEvent);
+    });
+  };
+
+  const findExistingEvent = (keys: string[]): CachedThreadEvent | undefined =>
+    keys.map((key) => eventMap.get(key)).find((mEvent): mEvent is CachedThreadEvent => !!mEvent);
+
   rawEvents.forEach((rawEvent) => {
     const normalized = toCachedThreadEvent(rawEvent);
     if (!normalized) return;
-    const eventKey = getRawEventKey(normalized);
-    if (!eventKey) return;
-    const existingEvent = eventMap.get(eventKey);
-    eventMap.set(
-      eventKey,
-      existingEvent ? pickPreferredCachedThreadEvent(existingEvent, normalized) : normalized
-    );
+    const incomingKeys = getRawEventKeys(normalized);
+    if (incomingKeys.length === 0) return;
+    const existingEvent = findExistingEvent(incomingKeys);
+    if (!existingEvent) {
+      setEventForKeys(incomingKeys, normalized);
+      return;
+    }
+
+    const preferredEvent = pickPreferredCachedThreadEvent(existingEvent, normalized);
+    const mergedKeys = Array.from(new Set([...getRawEventKeys(existingEvent), ...incomingKeys]));
+    setEventForKeys(mergedKeys, preferredEvent);
   });
 
   const normalizedRoot = rootEvent ? toCachedThreadEvent(rootEvent) : undefined;
   if (normalizedRoot) {
-    const rootKey = getRawEventKey(normalizedRoot);
-    if (rootKey && !eventMap.has(rootKey)) {
-      eventMap.set(rootKey, normalizedRoot);
+    const rootKeys = getRawEventKeys(normalizedRoot);
+    if (rootKeys.length > 0 && !findExistingEvent(rootKeys)) {
+      setEventForKeys(rootKeys, normalizedRoot);
     }
   }
 
-  return Array.from(eventMap.values()).sort(sortThreadEvents);
+  return Array.from(new Set(eventMap.values())).sort(sortThreadEvents);
 };
 
 export const getThreadCursorAnchor = (

--- a/src/app/features/room/threadRenderUtils.test.ts
+++ b/src/app/features/room/threadRenderUtils.test.ts
@@ -179,4 +179,17 @@ describe('mergeThreadRenderEvents', () => {
     expect(mergeThreadRenderEvents([localEcho], [remoteEcho])).toEqual([remoteEcho]);
     expect(mergeThreadRenderEvents([remoteEcho], [localEcho])).toEqual([remoteEcho]);
   });
+
+  it('deduplicates identical remote events even when only one copy still carries the transaction id', () => {
+    const confirmedWithTxn = makeMessageEvent('$remote', 10);
+    confirmedWithTxn.event.unsigned = { transaction_id: 'txn-3' };
+    const confirmedWithoutTxn = makeMessageEvent('$remote', 10);
+
+    expect(mergeThreadRenderEvents([confirmedWithTxn], [confirmedWithoutTxn])).toEqual([
+      confirmedWithoutTxn,
+    ]);
+    expect(mergeThreadRenderEvents([confirmedWithoutTxn], [confirmedWithTxn])).toEqual([
+      confirmedWithTxn,
+    ]);
+  });
 });

--- a/src/app/features/room/threadRenderUtils.ts
+++ b/src/app/features/room/threadRenderUtils.ts
@@ -44,15 +44,20 @@ const getThreadRenderTransactionId = (mEvent: MatrixEvent): string | undefined =
   return typeof txnId === 'string' && txnId.length > 0 ? txnId : undefined;
 };
 
-export const getThreadRenderEventKey = (mEvent: MatrixEvent): string | undefined => {
-  const txnId = getThreadRenderTransactionId(mEvent);
-  if (txnId) return `txn:${txnId}`;
+const getThreadRenderEventKeys = (mEvent: MatrixEvent): string[] => {
+  const keys: string[] = [];
 
   const eventId = getThreadRenderEventId(mEvent);
-  if (eventId) return `event:${eventId}`;
+  if (eventId) keys.push(`event:${eventId}`);
 
-  return undefined;
+  const txnId = getThreadRenderTransactionId(mEvent);
+  if (txnId) keys.push(`txn:${txnId}`);
+
+  return keys;
 };
+
+export const getThreadRenderEventKey = (mEvent: MatrixEvent): string | undefined =>
+  getThreadRenderEventKeys(mEvent)[0];
 
 const isLocalEchoEvent = (mEvent: MatrixEvent): boolean => {
   const eventId = getThreadRenderEventId(mEvent);
@@ -66,9 +71,9 @@ export const pickPreferredThreadRenderEvent = (
 ): MatrixEvent => {
   if (existingEvent === incomingEvent) return existingEvent;
 
-  const existingKey = getThreadRenderEventKey(existingEvent);
-  const incomingKey = getThreadRenderEventKey(incomingEvent);
-  if (existingKey && existingKey === incomingKey) {
+  const existingKeys = new Set(getThreadRenderEventKeys(existingEvent));
+  const incomingKeys = getThreadRenderEventKeys(incomingEvent);
+  if (incomingKeys.some((key) => existingKeys.has(key))) {
     const existingLocalEcho = isLocalEchoEvent(existingEvent);
     const incomingLocalEcho = isLocalEchoEvent(incomingEvent);
     if (existingLocalEcho !== incomingLocalEcho) {
@@ -105,24 +110,39 @@ export const mergeThreadRenderEvents = (
 ): MatrixEvent[] => {
   const eventMap = new Map<string, MatrixEvent>();
 
+  const setEventForKeys = (keys: string[], mEvent: MatrixEvent) => {
+    keys.forEach((key) => {
+      eventMap.set(key, mEvent);
+    });
+  };
+
+  const findExistingEvent = (keys: string[]): MatrixEvent | undefined =>
+    keys.map((key) => eventMap.get(key)).find((mEvent): mEvent is MatrixEvent => !!mEvent);
+
   existingEvents.forEach((mEvent) => {
-    const eventKey = getThreadRenderEventKey(mEvent);
-    if (!eventKey) return;
-    eventMap.set(eventKey, mEvent);
+    const keys = getThreadRenderEventKeys(mEvent);
+    if (keys.length === 0) return;
+    setEventForKeys(keys, mEvent);
   });
 
   incomingEvents.forEach((mEvent) => {
-    const eventKey = getThreadRenderEventKey(mEvent);
-    if (!eventKey) return;
+    const incomingKeys = getThreadRenderEventKeys(mEvent);
+    if (incomingKeys.length === 0) return;
 
-    const existingEvent = eventMap.get(eventKey);
-    eventMap.set(
-      eventKey,
-      existingEvent ? pickPreferredThreadRenderEvent(existingEvent, mEvent) : mEvent
+    const existingEvent = findExistingEvent(incomingKeys);
+    if (!existingEvent) {
+      setEventForKeys(incomingKeys, mEvent);
+      return;
+    }
+
+    const preferredEvent = pickPreferredThreadRenderEvent(existingEvent, mEvent);
+    const mergedKeys = Array.from(
+      new Set([...getThreadRenderEventKeys(existingEvent), ...incomingKeys])
     );
+    setEventForKeys(mergedKeys, preferredEvent);
   });
 
-  return Array.from(eventMap.values()).sort((a, b) => {
+  return Array.from(new Set(eventMap.values())).sort((a, b) => {
     const tsDiff = a.getTs() - b.getTs();
     if (tsDiff !== 0) return tsDiff;
     return (a.getId() ?? '').localeCompare(b.getId() ?? '');

--- a/src/app/features/room/useThreadRenderState.test.ts
+++ b/src/app/features/room/useThreadRenderState.test.ts
@@ -186,6 +186,42 @@ describe('useThreadRenderState', () => {
     renderer.unmount();
   });
 
+  it('deduplicates a confirmed thread event when cached and live copies disagree on transaction metadata', () => {
+    const rootEvent = makeMessageEvent('$root', 1);
+    const cachedReply = makeMessageEvent('$reply', 2);
+    cachedReply.event.unsigned = { transaction_id: 'txn-4' };
+    const liveReply = makeMessageEvent('$reply', 2);
+    const room = makeRoom(rootEvent);
+    const roomTimelineSet = makeTimelineSet();
+    const thread = makeThread(rootEvent, [liveReply]);
+
+    const { getSnapshot, update, renderer } = renderHookHarness({
+      room,
+      roomTimelineSet,
+      threadTimelineSet: undefined,
+      threadId: '$root',
+      thread,
+      threadInitialCacheHydrated: false,
+    });
+
+    act(() => {
+      getSnapshot().setSupplementalThreadEvents('$root', [cachedReply]);
+    });
+
+    update({
+      room,
+      roomTimelineSet,
+      threadTimelineSet: undefined,
+      threadId: '$root',
+      thread,
+      threadInitialCacheHydrated: true,
+    });
+
+    expect(getSnapshot().threadEvents.map((event) => event.getId())).toEqual(['$root', '$reply']);
+
+    renderer.unmount();
+  });
+
   it('resets supplemental thread state cleanly', () => {
     const rootEvent = makeMessageEvent('$root', 1);
     const replyEvent = makeMessageEvent('$reply', 2);

--- a/src/app/features/room/useThreadRenderState.ts
+++ b/src/app/features/room/useThreadRenderState.ts
@@ -3,9 +3,7 @@ import { EventTimelineSet, MatrixEvent, Room, Thread } from 'matrix-js-sdk';
 import { aggregateCachedRelationEvents, hydrateCachedEvents } from './eventCacheEditUtils';
 import {
   getThreadInitialRenderMode,
-  getThreadRenderEventKey,
   mergeThreadRenderEvents,
-  pickPreferredThreadRenderEvent,
   ThreadInitialRenderMode,
 } from './threadRenderUtils';
 import { eventBelongsToThread } from './threadUtils';
@@ -47,8 +45,7 @@ const buildThreadEvents = ({
   events: MatrixEvent[];
   indexMap: Map<string, number>;
 } => {
-  const eventsMap = new Map<string, MatrixEvent>();
-  const eventOrderMap = new Map<string, number>();
+  const collectedEvents: MatrixEvent[] = [];
   const initialRenderMode = getThreadInitialRenderMode({
     threadId,
     initialCacheHydrated: threadInitialCacheHydrated,
@@ -59,19 +56,7 @@ const buildThreadEvents = ({
     const eventId = mEvent?.getId();
     if (!eventId) return;
     if (requireThreadMatch && eventId !== threadId && !eventBelongsToThread(mEvent, threadId)) return;
-    const eventKey = getThreadRenderEventKey(mEvent);
-    if (!eventKey) return;
-    if (!eventsMap.has(eventKey)) {
-      eventOrderMap.set(eventKey, eventOrderMap.size);
-      eventsMap.set(eventKey, mEvent);
-      return;
-    }
-
-    const existingEvent = eventsMap.get(eventKey);
-    eventsMap.set(
-      eventKey,
-      existingEvent ? pickPreferredThreadRenderEvent(existingEvent, mEvent) : mEvent
-    );
+    collectedEvents.push(mEvent);
   };
 
   if (initialRenderMode === 'live') {
@@ -86,15 +71,7 @@ const buildThreadEvents = ({
     fallbackEvents.forEach((mEvent) => addThreadEvent(mEvent, false));
   }
 
-  const sortedEvents = Array.from(eventsMap.values()).sort((a, b) => {
-    const timeDiff = a.getTs() - b.getTs();
-    if (timeDiff !== 0) return timeDiff;
-    const aId = a.getId();
-    const bId = b.getId();
-    const aOrder = (aId && eventOrderMap.get(aId)) ?? 0;
-    const bOrder = (bId && eventOrderMap.get(bId)) ?? 0;
-    return aOrder - bOrder;
-  });
+  const sortedEvents = mergeThreadRenderEvents([], collectedEvents);
 
   hydrateCachedEvents({
     room,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,6 +1,7 @@
 /// <reference lib="WebWorker" />
 
 import { looksLikeMediaRequest, validMediaRequest } from './swMediaAuth';
+import { buildAuthenticatedMediaRequestInit } from './swMediaFetch';
 
 export type {};
 declare const self: ServiceWorkerGlobalScope;
@@ -127,36 +128,9 @@ async function askForAccessToken(client: Client): Promise<string | undefined> {
   });
 }
 
-const normalizeRequestCache = (request: Request): RequestCache =>
-  request.cache === 'only-if-cached' ? 'default' : request.cache;
-
-const authHeaders = (request: Request, token: string): Headers => {
-  const headers = new Headers(request.headers);
-  headers.set('Authorization', `Bearer ${token}`);
-  return headers;
-};
-
 const fetchAuthenticatedMedia = async (request: Request, token: string): Promise<Response> => {
-  const headers = authHeaders(request, token);
-  const cache = normalizeRequestCache(request);
-
-  if (request.mode === 'no-cors') {
-    // no-cors requests cannot carry Authorization; upgrade to CORS for authenticated media.
-    return fetch(request.url, {
-      method: request.method,
-      headers,
-      mode: 'cors',
-      credentials: 'omit',
-      cache,
-      redirect: request.redirect,
-      referrer: request.referrer,
-      referrerPolicy: request.referrerPolicy,
-      integrity: request.integrity,
-      keepalive: request.keepalive,
-    });
-  }
-
-  return fetch(request, { headers, cache });
+  const init = buildAuthenticatedMediaRequestInit(request, token);
+  return request.mode === 'no-cors' ? fetch(request.url, init) : fetch(request, init);
 };
 
 const fetchAuthenticatedMediaWithFallback = async (

--- a/src/swMediaFetch.test.ts
+++ b/src/swMediaFetch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildAuthenticatedMediaRequestInit } from './swMediaFetch';
+
+describe('buildAuthenticatedMediaRequestInit', () => {
+  it('upgrades no-cors media requests to cors while preserving same-origin credentials', () => {
+    const request = new Request('https://example.com/mindroom/_matrix/client/v1/media/download/s/id', {
+      method: 'GET',
+      mode: 'no-cors',
+      credentials: 'same-origin',
+      cache: 'default',
+    });
+
+    const init = buildAuthenticatedMediaRequestInit(request, 'secret-token');
+
+    expect(init.mode).toBe('cors');
+    expect(init.credentials).toBe('same-origin');
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer secret-token');
+  });
+
+  it('normalizes only-if-cached requests and preserves headers for regular fetches', () => {
+    const request = new Request('https://example.com/mindroom/_matrix/client/v1/media/thumbnail/s/id', {
+      method: 'GET',
+      mode: 'same-origin',
+      cache: 'only-if-cached',
+    });
+
+    const init = buildAuthenticatedMediaRequestInit(request, 'secret-token');
+
+    expect(init.cache).toBe('default');
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer secret-token');
+  });
+});

--- a/src/swMediaFetch.ts
+++ b/src/swMediaFetch.ts
@@ -1,0 +1,28 @@
+const normalizeRequestCache = (request: Request): RequestCache =>
+  request.cache === 'only-if-cached' ? 'default' : request.cache;
+
+export const buildAuthenticatedMediaRequestInit = (
+  request: Request,
+  token: string
+): RequestInit => {
+  const headers = new Headers(request.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  const cache = normalizeRequestCache(request);
+
+  if (request.mode === 'no-cors') {
+    return {
+      method: request.method,
+      headers,
+      mode: 'cors',
+      credentials: 'same-origin',
+      cache,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      integrity: request.integrity,
+      keepalive: request.keepalive,
+    };
+  }
+
+  return { headers, cache };
+};


### PR DESCRIPTION
## Summary
- dedupe confirmed thread events when one copy still carries transaction metadata
- keep same-origin credentials when upgrading authenticated media fetches from no-cors to cors
- add targeted regression tests for both paths

## Testing
- npm exec -- vitest run src/app/features/room/threadRenderUtils.test.ts src/app/features/room/threadEventCache.test.ts src/app/features/room/useThreadRenderState.test.ts src/swMediaFetch.test.ts src/swMediaAuth.test.ts