### PR TITLE
Avoid persisting local echo thread ids

### DIFF
--- a/src/app/mindroom/recent-threads/recentThreads.test.ts
+++ b/src/app/mindroom/recent-threads/recentThreads.test.ts
@@ -5,6 +5,7 @@ import {
   clearRecentThreadsStore,
   makeRecentThreadsAtom,
   registerRecentThreadsAtom,
+  rekeyRecentThread,
 } from './recentThreads';
 import { setImperativeJotaiStore } from '../../state/jotaiStore';
 
@@ -78,6 +79,51 @@ describe('recentThreads', () => {
     ]);
   });
 
+  it('ignores local-echo thread ids when bumping recent threads', () => {
+    const recentThreadsAtom = makeRecentThreadsAtom(USER_ID);
+    const store = getDefaultStore();
+
+    store.set(recentThreadsAtom, {
+      type: 'BUMP',
+      roomId: '!room:example.org',
+      threadId: '~pending',
+      openedAt: 100,
+    });
+
+    expect(store.get(recentThreadsAtom)).toEqual([]);
+  });
+
+  it('drops legacy local-echo thread ids from stored recent threads', () => {
+    localStorage.setItem(
+      'recentThreads:@alice:example.org',
+      JSON.stringify({
+        v: 1,
+        entries: [
+          {
+            roomId: '!room:example.org',
+            threadId: '~pending',
+            openedAt: 200,
+          },
+          {
+            roomId: '!room:example.org',
+            threadId: '$confirmed',
+            openedAt: 100,
+          },
+        ],
+      })
+    );
+
+    const recentThreadsAtom = makeRecentThreadsAtom(USER_ID);
+
+    expect(getDefaultStore().get(recentThreadsAtom)).toEqual([
+      {
+        roomId: '!room:example.org',
+        threadId: '$confirmed',
+        openedAt: 100,
+      },
+    ]);
+  });
+
   it('rekeys reply ids to canonical roots without downgrading a newer canonical entry', () => {
     const recentThreadsAtom = makeRecentThreadsAtom(USER_ID);
     const store = getDefaultStore();
@@ -147,6 +193,33 @@ describe('recentThreads', () => {
         openedAt: 125,
       },
     ]);
+  });
+
+  it('does not rekey a recent thread to a local-echo id', () => {
+    const providerStore = createStore();
+    const recentThreadsAtom = makeRecentThreadsAtom(USER_ID);
+    const unregisterStore = setImperativeJotaiStore(providerStore);
+    const unregisterAtom = registerRecentThreadsAtom(recentThreadsAtom);
+
+    providerStore.set(recentThreadsAtom, {
+      type: 'BUMP',
+      roomId: '!room:example.org',
+      threadId: '$confirmed',
+      openedAt: 100,
+    });
+
+    rekeyRecentThread('!room:example.org', '$confirmed', '~pending');
+
+    expect(providerStore.get(recentThreadsAtom)).toEqual([
+      {
+        roomId: '!room:example.org',
+        threadId: '$confirmed',
+        openedAt: 100,
+      },
+    ]);
+
+    unregisterAtom();
+    unregisterStore();
   });
 
   it('writes imperative recent-thread bumps into the registered provider store', () => {

--- a/src/app/mindroom/recent-threads/recentThreads.ts
+++ b/src/app/mindroom/recent-threads/recentThreads.ts
@@ -7,6 +7,7 @@ import {
 import { getActiveSession } from '../../state/sessions';
 import { isRecord } from '../../utils/isRecord';
 import { getImperativeJotaiStore } from '../../state/jotaiStore';
+import { isConfirmedMatrixEventId } from '../threads/threadRouteUtils';
 
 const RECENT_THREADS = 'recentThreads';
 const RECENT_THREADS_STORE_VERSION = 1;
@@ -50,8 +51,7 @@ const isRecentThreadItem = (value: unknown): value is RecentThreadItem =>
   isRecord(value) &&
   typeof value.roomId === 'string' &&
   value.roomId.length > 0 &&
-  typeof value.threadId === 'string' &&
-  value.threadId.length > 0 &&
+  isConfirmedMatrixEventId(value.threadId) &&
   typeof value.openedAt === 'number' &&
   Number.isFinite(value.openedAt) &&
   value.openedAt > 0 &&
@@ -124,6 +124,7 @@ export const makeRecentThreadsAtom = (userId: string): RecentThreadsAtom => {
 
       if (action.type === 'REKEY') {
         if (!action.roomId || !action.threadId || !action.nextThreadId) return;
+        if (!isConfirmedMatrixEventId(action.nextThreadId)) return;
         if (action.threadId === action.nextThreadId) return;
 
         const existingEntry = current.find(
@@ -154,7 +155,7 @@ export const makeRecentThreadsAtom = (userId: string): RecentThreadsAtom => {
         return;
       }
 
-      if (!action.roomId || !action.threadId) return;
+      if (!action.roomId || !isConfirmedMatrixEventId(action.threadId)) return;
 
       const openedAt =
         typeof action.openedAt === 'number' && Number.isFinite(action.openedAt) && action.openedAt > 0

--- a/src/app/mindroom/threads/__tests__/Room.test.ts
+++ b/src/app/mindroom/threads/__tests__/Room.test.ts
@@ -201,6 +201,17 @@ describe('Room', () => {
     expect(setLastOpenThreadMock).toHaveBeenCalledWith('!room:example.org', '$explicit');
   });
 
+  it('does not persist explicit local-echo thread ids from the URL', async () => {
+    roomState.search = '?threadId=~pending';
+    const { Room } = await import('../../../features/room/Room');
+
+    await act(async () => {
+      create(React.createElement(Room));
+    });
+
+    expect(setLastOpenThreadMock).not.toHaveBeenCalled();
+  });
+
   it('does not override an explicit event permalink', async () => {
     roomState.eventId = '$event';
     getLastOpenThreadMock.mockReturnValue('$saved');

--- a/src/app/mindroom/threads/__tests__/RoomView.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomView.test.ts
@@ -685,4 +685,21 @@ describe('RoomView', () => {
       undefined
     );
   });
+
+  it('does not persist unresolved local-echo ids in the recent-thread list', async () => {
+    const { RoomView } = await import('../../../features/room/RoomView');
+    const room = makeRoom(nextRoomId('room-a'));
+    useThreadRootEventMock.mockReturnValue('~pending-thread');
+
+    await act(async () => {
+      create(
+        React.createElement(RoomView, {
+          room: room as never,
+          threadId: '~pending-thread',
+        })
+      );
+    });
+
+    expect(bumpRecentThreadMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/mindroom/threads/lastOpenThread.test.ts
+++ b/src/app/mindroom/threads/lastOpenThread.test.ts
@@ -48,6 +48,42 @@ describe('lastOpenThread', () => {
     unregister();
   });
 
+  it('ignores local-echo thread ids when storing restore targets', () => {
+    const atom = makeLastOpenThreadAtom('@alice:example.org');
+    const unregister = registerLastOpenThreadAtom(atom);
+
+    setLastOpenThread('!room:example.org', '~pending');
+
+    expect(getLastOpenThread('!room:example.org')).toBeUndefined();
+    expect(storage.get('lastOpenThread@alice:example.org')).toBeUndefined();
+
+    unregister();
+  });
+
+  it('drops legacy local-echo thread ids from stored restore targets', () => {
+    storage.set(
+      'lastOpenThread@alice:example.org',
+      '{"!room:example.org":"~pending","!other:example.org":"$confirmed"}'
+    );
+    const atom = makeLastOpenThreadAtom('@alice:example.org');
+    const unregister = registerLastOpenThreadAtom(atom);
+
+    expect(getLastOpenThread('!room:example.org')).toBeUndefined();
+    expect(getLastOpenThread('!other:example.org')).toBe('$confirmed');
+
+    unregister();
+  });
+
+  it('ignores malformed stored restore targets', () => {
+    storage.set('lastOpenThread@alice:example.org', 'null');
+    const atom = makeLastOpenThreadAtom('@alice:example.org');
+    const unregister = registerLastOpenThreadAtom(atom);
+
+    expect(getLastOpenThread('!room:example.org')).toBeUndefined();
+
+    unregister();
+  });
+
   it('clears the user-scoped store and active registration', () => {
     const atom = makeLastOpenThreadAtom('@alice:example.org');
     registerLastOpenThreadAtom(atom);

--- a/src/app/mindroom/threads/lastOpenThread.ts
+++ b/src/app/mindroom/threads/lastOpenThread.ts
@@ -6,6 +6,8 @@ import {
 } from '../../state/utils/atomWithLocalStorage';
 import { getActiveSession } from '../../state/sessions';
 import { getImperativeJotaiStore } from '../../state/jotaiStore';
+import { isRecord } from '../../utils/isRecord';
+import { isConfirmedMatrixEventId } from './threadRouteUtils';
 
 const LAST_OPEN_THREAD = 'lastOpenThread';
 
@@ -24,6 +26,17 @@ type LastOpenThreadAtom = WritableAtom<Map<string, string>, [LastOpenThreadActio
 
 const getStoreKey = (userId: string): string => `${LAST_OPEN_THREAD}${userId}`;
 
+const sanitizeLastOpenThreadEntries = (value: unknown): Map<string, string> => {
+  if (!isRecord(value)) return new Map();
+
+  return new Map(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] =>
+        entry[0].length > 0 && isConfirmedMatrixEventId(entry[1])
+    )
+  );
+};
+
 let activeLastOpenThreadAtom: LastOpenThreadAtom | undefined;
 const lastOpenThreadAtoms = new Map<string, LastOpenThreadAtom>();
 
@@ -35,7 +48,7 @@ export const makeLastOpenThreadAtom = (userId: string): LastOpenThreadAtom => {
 
   const baseLastOpenThreadAtom = atomWithLocalStorage<Map<string, string>>(
     storeKey,
-    (key) => new Map(Object.entries(getLocalStorageItem<Record<string, string>>(key, {}))),
+    (key) => sanitizeLastOpenThreadEntries(getLocalStorageItem<unknown | null>(key, null)),
     (key, value) => setLocalStorageItem(key, Object.fromEntries(value))
   );
 
@@ -52,6 +65,7 @@ export const makeLastOpenThreadAtom = (userId: string): LastOpenThreadAtom => {
         return;
       }
 
+      if (!action.roomId || !isConfirmedMatrixEventId(action.threadId)) return;
       if (current.get(action.roomId) === action.threadId) return;
 
       const next = new Map(current);

--- a/src/app/mindroom/threads/threadRouteUtils.test.ts
+++ b/src/app/mindroom/threads/threadRouteUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getEffectiveThreadRootActivityTs,
+  isConfirmedMatrixEventId,
   isPendingLocalEchoThreadRoot,
   isPendingLocalEchoThreadRootEvent,
   resolveCanonicalThreadRootId,
@@ -51,6 +52,13 @@ const makeRoom = ({
   }) as never;
 
 describe('threadRouteUtils', () => {
+  it('recognizes only confirmed Matrix event ids as persistable ids', () => {
+    expect(isConfirmedMatrixEventId('$confirmed')).toBe(true);
+    expect(isConfirmedMatrixEventId('~pending')).toBe(false);
+    expect(isConfirmedMatrixEventId('!room:example.org')).toBe(false);
+    expect(isConfirmedMatrixEventId(undefined)).toBe(false);
+  });
+
   it('resolves reply event ids back to their thread root ids', () => {
     const replyEvent = makeEvent('$reply', { threadRootId: '$root' });
     const room = makeRoom({

--- a/src/app/mindroom/threads/threadRouteUtils.ts
+++ b/src/app/mindroom/threads/threadRouteUtils.ts
@@ -5,6 +5,9 @@ import { buildResolveConfirmedEventId } from './threadRenderUtils';
 export const isLocalEchoEventId = (eventId: string | undefined): boolean =>
   typeof eventId === 'string' && eventId.startsWith('~');
 
+export const isConfirmedMatrixEventId = (eventId: unknown): eventId is string =>
+  typeof eventId === 'string' && eventId.startsWith('$');
+
 const getEventTxnId = (event: Pick<MatrixEvent, 'getTxnId' | 'getUnsigned'>): string | undefined => {
   const txnId = event.getTxnId?.() ?? event.getUnsigned()?.transaction_id;
   return typeof txnId === 'string' && txnId.length > 0 ? txnId : undefined;

--- a/src/app/mindroom/threads/useRoomThreadRouteRestore.ts
+++ b/src/app/mindroom/threads/useRoomThreadRouteRestore.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useRoomNavigate } from '../../hooks/useRoomNavigate';
 import { removeRecentThread } from '../recent-threads/recentThreads';
 import { clearLastOpenThread, getLastOpenThread, setLastOpenThread } from './lastOpenThread';
+import { isConfirmedMatrixEventId } from './threadRouteUtils';
 
 type UseRoomThreadRouteRestoreOptions = {
   eventId?: string;
@@ -21,7 +22,7 @@ export const useRoomThreadRouteRestore = ({
   const autoRestoredThreadIdRef = useRef<string>();
 
   useEffect(() => {
-    if (!threadId) return;
+    if (!isConfirmedMatrixEventId(threadId)) return;
     setLastOpenThread(roomId, threadId);
   }, [roomId, threadId]);
 

--- a/src/app/mindroom/threads/useRoomViewThreadState.ts
+++ b/src/app/mindroom/threads/useRoomViewThreadState.ts
@@ -38,6 +38,7 @@ import {
 } from './threadFilterDsl';
 import { useRoomThreadSummaryState } from './threadSummaryStore';
 import { useThreadRootEvent } from './useThreadRootEvent';
+import { isConfirmedMatrixEventId } from './threadRouteUtils';
 
 type UseRoomViewThreadStateOptions = {
   eventId?: string;
@@ -235,7 +236,7 @@ export const useRoomViewThreadState = ({
   }, [effectiveThreadId, eventId, navigateRoomThread, room.roomId, threadId]);
 
   useEffect(() => {
-    if (!effectiveThreadId) return;
+    if (!isConfirmedMatrixEventId(effectiveThreadId)) return;
 
     bumpRecentThread(room.roomId, effectiveThreadId, undefined, recentThreadSummaryText);
   }, [effectiveThreadId, recentThreadSummaryText, room.roomId]);


### PR DESCRIPTION
## Summary
- Treat only confirmed Matrix event ids as persistable thread restore ids
- Drop legacy local echo ids from recent-thread and last-open-thread storage
- Skip recent-thread and restore writes while a thread id is still an unresolved local echo

## Testing
- npm test -- src/app/mindroom/threads/threadRouteUtils.test.ts src/app/mindroom/recent-threads/recentThreads.test.ts src/app/mindroom/threads/lastOpenThread.test.ts src/app/mindroom/threads/__tests__/Room.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts
- npm run typecheck
- npx eslint src/app/mindroom/recent-threads/recentThreads.ts src/app/mindroom/recent-threads/recentThreads.test.ts src/app/mindroom/threads/lastOpenThread.ts src/app/mindroom/threads/lastOpenThread.test.ts src/app/mindroom/threads/threadRouteUtils.ts src/app/mindroom/threads/threadRouteUtils.test.ts src/app/mindroom/threads/useRoomThreadRouteRestore.ts src/app/mindroom/threads/useRoomViewThreadState.ts src/app/mindroom/threads/__tests__/Room.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts