### PR TITLE
Display AI run cache token metadata

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -67,6 +67,23 @@
   - `git diff --check`
   - `just ios-phone` synced Capacitor, built the signed Debug app, installed it on `basnijholt-iphone-15-pro`, and launched `chat.mindroom.app`.
 
+### AI run cache token metadata display (2026-05-03)
+
+- Summary:
+  - AI run metadata parsing now includes cumulative `usage.cache_read_tokens` and `usage.cache_write_tokens` from final backend responses.
+  - The token-usage dialog shows those cumulative counters as `Run Cache`, separate from `Tokens`.
+  - Latest-request context parsing now includes `context.cache_read_input_tokens`, `context.cache_write_input_tokens`, and `context.uncached_input_tokens`.
+  - The same dialog shows those latest-request counters as `Request Cache`, separate from `Request Context`.
+  - This keeps full run usage, current context-window occupancy, cached request context, and non-cache-read request context visually distinct.
+- Tests and validation:
+  - `npm test -- src/app/mindroom/messages/aiRun.test.ts src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+  - `npm run typecheck`
+  - `npm run build`
+  - `npm run lint` completed with the repo warning-only baseline (`17` warnings, `0` errors).
+  - `npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/__tests__/Message.test.ts src/app/mindroom/messages/aiRun.test.ts src/app/mindroom/messages/aiRun.ts src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/aiRunDisplay.ts`
+  - `git diff --check`
+  - `npm test` passed (`244` files, `1827` tests).
+
 ### CINNY-097 Recording Waveform Implementation Report (2026-04-27)
 
 - Summary:

--- a/src/app/mindroom/messages/MindroomMessageControls.tsx
+++ b/src/app/mindroom/messages/MindroomMessageControls.tsx
@@ -26,14 +26,13 @@ import { MindroomAiRunInfo, getMindroomAiRunInfo } from './aiRun';
 import {
   formatMindroomAiRunNumber,
   formatMindroomAiRunTimeToFirstToken,
+  getMindroomAiRunContextCacheLabel,
   getMindroomAiRunContextLabel,
   getMindroomAiRunModelLabel,
+  getMindroomAiRunUsageCacheLabel,
   getMindroomAiRunUsageLabel,
 } from './aiRunDisplay';
-import {
-  MindroomLongTextSource,
-  getMindroomLongTextSource,
-} from './longText';
+import { MindroomLongTextSource, getMindroomLongTextSource } from './longText';
 import { getMindroomLongTextDownloadName } from './longTextDownload';
 import {
   downloadMindroomLongTextSidecarBlob,
@@ -41,10 +40,7 @@ import {
 } from './MindroomLongTextText';
 import * as css from './MindroomMessageControls.css';
 
-export function useMindroomMessageControls(
-  content: Record<string, unknown>,
-  menuOpen: boolean
-) {
+export function useMindroomMessageControls(content: Record<string, unknown>, menuOpen: boolean) {
   const longTextSource = useMemo(() => getMindroomLongTextSource(content), [content]);
   const resolvedLongTextContent = useMindroomLongTextResolvedContent(longTextSource, menuOpen);
   const longTextLoading = longTextSource !== undefined && resolvedLongTextContent === undefined;
@@ -80,7 +76,9 @@ function MindroomAiRunInfoDialog({
 }) {
   const modelLabel = getMindroomAiRunModelLabel(info);
   const usageLabel = getMindroomAiRunUsageLabel(info);
+  const usageCacheLabel = getMindroomAiRunUsageCacheLabel(info);
   const contextLabel = getMindroomAiRunContextLabel(info);
+  const contextCacheLabel = getMindroomAiRunContextCacheLabel(info);
   const toolsLabel = formatMindroomAiRunNumber(info.toolCount);
   const ttftLabel = formatMindroomAiRunTimeToFirstToken(info.timeToFirstToken);
 
@@ -120,7 +118,9 @@ function MindroomAiRunInfoDialog({
               <MindroomAiRunDetail label="Status" value={info.status} />
               <MindroomAiRunDetail label="Model" value={modelLabel} />
               <MindroomAiRunDetail label="Tokens" value={usageLabel} />
+              <MindroomAiRunDetail label="Run Cache" value={usageCacheLabel} />
               <MindroomAiRunDetail label="Request Context" value={contextLabel} />
+              <MindroomAiRunDetail label="Request Cache" value={contextCacheLabel} />
               <MindroomAiRunDetail label="Tools" value={toolsLabel} />
               <MindroomAiRunDetail label="TTFT" value={ttftLabel} />
               <MindroomAiRunDetail label="Run" value={info.runId} />
@@ -133,13 +133,7 @@ function MindroomAiRunInfoDialog({
   );
 }
 
-export function MindroomAiRunInfoButton({
-  open,
-  onOpen,
-}: {
-  open: boolean;
-  onOpen: () => void;
-}) {
+export function MindroomAiRunInfoButton({ open, onOpen }: { open: boolean; onOpen: () => void }) {
   return (
     <button
       type="button"

--- a/src/app/mindroom/messages/__tests__/Message.test.ts
+++ b/src/app/mindroom/messages/__tests__/Message.test.ts
@@ -327,7 +327,8 @@ vi.mock('../../../state/settings', () => ({
   },
 }));
 
-const getMessageComponent = async () => (await import('../../../features/room/message/Message')).Message;
+const getMessageComponent = async () =>
+  (await import('../../../features/room/message/Message')).Message;
 
 beforeEach(() => {
   lastMessageBaseNode = undefined;
@@ -472,11 +473,16 @@ const mindroomAiRunContent = {
       input_tokens: 40,
       output_tokens: 2,
       total_tokens: 42,
+      cache_read_tokens: 20,
+      cache_write_tokens: 5,
       time_to_first_token: 0.042,
     },
     context: {
-      input_tokens: 40,
+      input_tokens: 65,
       window_tokens: 100,
+      cache_read_input_tokens: 20,
+      cache_write_input_tokens: 5,
+      uncached_input_tokens: 45,
     },
     tools: {
       count: 3,
@@ -485,20 +491,16 @@ const mindroomAiRunContent = {
 } as const;
 
 describe('Message token usage menu item', () => {
-  it(
-    'does not render Token usage in the context menu for messages without ai_run metadata',
-    async () => {
-      const { renderer } = await renderMessage({
-        msgtype: 'm.text',
-        body: 'hello',
-      });
+  it('does not render Token usage in the context menu for messages without ai_run metadata', async () => {
+    const { renderer } = await renderMessage({
+      msgtype: 'm.text',
+      body: 'hello',
+    });
 
-      await openContextMenu(renderer);
+    await openContextMenu(renderer);
 
-      expect(hasSpanText(renderer, 'Token usage')).toBe(false);
-    },
-    10000
-  );
+    expect(hasSpanText(renderer, 'Token usage')).toBe(false);
+  }, 10000);
 
   it('opens the AI run dialog from the context menu and configures explicit return focus', async () => {
     const { renderer, messageBaseNode } = await renderMessage(mindroomAiRunContent);
@@ -522,6 +524,7 @@ describe('Message token usage menu item', () => {
     expect(hasSpanText(renderer, 'AI Run Metadata')).toBe(true);
     expect(hasSpanText(renderer, 'Status: completed')).toBe(true);
     expect(hasSpanText(renderer, 'Tokens: in 40 • out 2 • total 42')).toBe(true);
+    expect(hasSpanText(renderer, 'Run Cache: read 20 • write 5')).toBe(true);
     const setReturnFocus = getDialogFocusTrapOptions(renderer).setReturnFocus as () =>
       | HostNodeMock
       | false;
@@ -542,7 +545,8 @@ describe('Message token usage menu item', () => {
 
     expect(hasSpanText(renderer, 'AI Run Metadata')).toBe(true);
     expect(hasSpanText(renderer, 'Model: fast (openai / gpt-5-mini)')).toBe(true);
-    expect(hasSpanText(renderer, 'Request Context: 40 / 100 (40.0%)')).toBe(true);
+    expect(hasSpanText(renderer, 'Request Context: 65 / 100 (65.0%)')).toBe(true);
+    expect(hasSpanText(renderer, 'Request Cache: read 20 • write 5 • not read 45')).toBe(true);
     expect(hasSpanText(renderer, 'Tools: 3')).toBe(true);
     expect(hasSpanText(renderer, 'TTFT: 42 ms')).toBe(true);
     expect(hasSpanText(renderer, 'Run: run-123')).toBe(true);
@@ -572,9 +576,9 @@ describe('Message copy text overflow integration', () => {
 
     longTextMocks.getMindroomLongTextSource.mockReturnValue(longTextSource);
     longTextMocks.useMindroomLongTextResolvedContent.mockImplementation((source, enabled) => {
-      const [resolvedContent, setResolvedContent] = React.useState<Record<string, unknown> | undefined>(
-        () => undefined
-      );
+      const [resolvedContent, setResolvedContent] = React.useState<
+        Record<string, unknown> | undefined
+      >(() => undefined);
 
       React.useEffect(() => {
         if (!source || !enabled) {

--- a/src/app/mindroom/messages/aiRun.test.ts
+++ b/src/app/mindroom/messages/aiRun.test.ts
@@ -22,9 +22,17 @@ describe('getMindroomAiRunInfo', () => {
           input_tokens: 100,
           output_tokens: 25,
           total_tokens: 125,
+          cache_read_tokens: 20,
+          cache_write_tokens: 5,
           time_to_first_token: 0.42,
         },
-        context: { input_tokens: 100, window_tokens: 4000 },
+        context: {
+          input_tokens: 125,
+          window_tokens: 4000,
+          cache_read_input_tokens: 20,
+          cache_write_input_tokens: 5,
+          uncached_input_tokens: 105,
+        },
         tools: { count: 2 },
       },
     });
@@ -39,9 +47,14 @@ describe('getMindroomAiRunInfo', () => {
       inputTokens: 100,
       outputTokens: 25,
       totalTokens: 125,
+      cacheReadTokens: 20,
+      cacheWriteTokens: 5,
       timeToFirstToken: 0.42,
-      contextInputTokens: 100,
+      contextInputTokens: 125,
       contextWindowTokens: 4000,
+      contextCacheReadInputTokens: 20,
+      contextCacheWriteInputTokens: 5,
+      contextUncachedInputTokens: 105,
       toolCount: 2,
     });
   });
@@ -80,25 +93,21 @@ describe('isMindroomAiRunStreaming', () => {
   it('returns false for terminal statuses', () => {
     const terminalStatuses = ['completed', 'cached', 'error', 'cancelled'];
     for (const status of terminalStatuses) {
-      expect(
-        isMindroomAiRunStreaming({ 'io.mindroom.ai_run': { version: 1, status } })
-      ).toBe(false);
+      expect(isMindroomAiRunStreaming({ 'io.mindroom.ai_run': { version: 1, status } })).toBe(
+        false
+      );
     }
   });
 
   it('returns true for non-terminal statuses', () => {
     const activeStatuses = ['streaming', 'running', 'active', 'thinking'];
     for (const status of activeStatuses) {
-      expect(
-        isMindroomAiRunStreaming({ 'io.mindroom.ai_run': { version: 1, status } })
-      ).toBe(true);
+      expect(isMindroomAiRunStreaming({ 'io.mindroom.ai_run': { version: 1, status } })).toBe(true);
     }
   });
 
   it('returns true when metadata exists but status is absent', () => {
-    expect(
-      isMindroomAiRunStreaming({ 'io.mindroom.ai_run': { version: 1 } })
-    ).toBe(true);
+    expect(isMindroomAiRunStreaming({ 'io.mindroom.ai_run': { version: 1 } })).toBe(true);
   });
 
   it('reads metadata from m.new_content wrapper', () => {
@@ -124,28 +133,28 @@ describe('isMindroomAiRunStreaming', () => {
   it('returns true when io.mindroom.stream_status is active (no ai_run metadata)', () => {
     const activeStatuses = ['streaming', 'running', 'active'];
     for (const status of activeStatuses) {
-      expect(
-        isMindroomAiRunStreaming({ 'io.mindroom.stream_status': status })
-      ).toBe(true);
+      expect(isMindroomAiRunStreaming({ 'io.mindroom.stream_status': status })).toBe(true);
     }
   });
 
   it('returns false when io.mindroom.stream_status is terminal (no ai_run metadata)', () => {
-    const terminalStatuses = ['completed', 'complete', 'done', 'error', 'failed', 'stopped', 'cancelled'];
+    const terminalStatuses = [
+      'completed',
+      'complete',
+      'done',
+      'error',
+      'failed',
+      'stopped',
+      'cancelled',
+    ];
     for (const status of terminalStatuses) {
-      expect(
-        isMindroomAiRunStreaming({ 'io.mindroom.stream_status': status })
-      ).toBe(false);
+      expect(isMindroomAiRunStreaming({ 'io.mindroom.stream_status': status })).toBe(false);
     }
   });
 
   it('returns false when io.mindroom.stream_status is unrecognized (no ai_run metadata)', () => {
-    expect(
-      isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'pending' })
-    ).toBe(false);
-    expect(
-      isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'unknown' })
-    ).toBe(false);
+    expect(isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'pending' })).toBe(false);
+    expect(isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'unknown' })).toBe(false);
   });
 
   it('reads stream_status from m.new_content wrapper', () => {
@@ -169,12 +178,8 @@ describe('isMindroomAiRunStreaming', () => {
   });
 
   it('is case-insensitive for stream_status', () => {
-    expect(
-      isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'STREAMING' })
-    ).toBe(true);
-    expect(
-      isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'Completed' })
-    ).toBe(false);
+    expect(isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'STREAMING' })).toBe(true);
+    expect(isMindroomAiRunStreaming({ 'io.mindroom.stream_status': 'Completed' })).toBe(false);
   });
 
   it('prefers ai_run metadata over stream_status when both present', () => {

--- a/src/app/mindroom/messages/aiRun.ts
+++ b/src/app/mindroom/messages/aiRun.ts
@@ -10,12 +10,17 @@ type MindroomAiRunUsage = {
   input_tokens?: unknown;
   output_tokens?: unknown;
   total_tokens?: unknown;
+  cache_read_tokens?: unknown;
+  cache_write_tokens?: unknown;
   time_to_first_token?: unknown;
 };
 
 type MindroomAiRunContext = {
   input_tokens?: unknown;
   window_tokens?: unknown;
+  cache_read_input_tokens?: unknown;
+  cache_write_input_tokens?: unknown;
+  uncached_input_tokens?: unknown;
 };
 
 type MindroomAiRunTools = {
@@ -43,9 +48,14 @@ export type MindroomAiRunInfo = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   timeToFirstToken?: number;
   contextInputTokens?: number;
   contextWindowTokens?: number;
+  contextCacheReadInputTokens?: number;
+  contextCacheWriteInputTokens?: number;
+  contextUncachedInputTokens?: number;
   toolCount?: number;
 };
 
@@ -105,9 +115,14 @@ export const getMindroomAiRunInfo = (
     inputTokens: asFiniteNumber(usage?.input_tokens),
     outputTokens: asFiniteNumber(usage?.output_tokens),
     totalTokens: asFiniteNumber(usage?.total_tokens),
+    cacheReadTokens: asFiniteNumber(usage?.cache_read_tokens),
+    cacheWriteTokens: asFiniteNumber(usage?.cache_write_tokens),
     timeToFirstToken: asFiniteNumber(usage?.time_to_first_token),
     contextInputTokens: asFiniteNumber(context?.input_tokens),
     contextWindowTokens: asFiniteNumber(context?.window_tokens),
+    contextCacheReadInputTokens: asFiniteNumber(context?.cache_read_input_tokens),
+    contextCacheWriteInputTokens: asFiniteNumber(context?.cache_write_input_tokens),
+    contextUncachedInputTokens: asFiniteNumber(context?.uncached_input_tokens),
     toolCount: asFiniteNumber(tools?.count),
   };
 
@@ -118,12 +133,7 @@ export const getMindroomAiRunInfo = (
 export const hasMindroomAiRunMetadata = (content: Record<string, unknown>): boolean =>
   !!getMindroomAiRunMetadata(content);
 
-const TERMINAL_AI_RUN_STATUSES = new Set([
-  'completed',
-  'cached',
-  'error',
-  'cancelled',
-]);
+const TERMINAL_AI_RUN_STATUSES = new Set(['completed', 'cached', 'error', 'cancelled']);
 
 const STREAM_STATUS_KEY = 'io.mindroom.stream_status';
 const ACTIVE_STREAM_STATUSES = new Set(['active', 'running', 'streaming']);

--- a/src/app/mindroom/messages/aiRunDisplay.test.ts
+++ b/src/app/mindroom/messages/aiRunDisplay.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   formatMindroomAiRunNumber,
   formatMindroomAiRunTimeToFirstToken,
+  getMindroomAiRunContextCacheLabel,
   getMindroomAiRunContextLabel,
+  getMindroomAiRunUsageCacheLabel,
   getMindroomAiRunModelLabel,
   getMindroomAiRunUsageLabel,
 } from './aiRunDisplay';
@@ -45,6 +47,21 @@ describe('getMindroomAiRunUsageLabel', () => {
   });
 });
 
+describe('getMindroomAiRunUsageCacheLabel', () => {
+  it('formats cumulative run cache counters separately from token totals', () => {
+    expect(
+      getMindroomAiRunUsageCacheLabel({
+        cacheReadTokens: 20000,
+        cacheWriteTokens: 500,
+      })
+    ).toBe('read 20,000 • write 500');
+  });
+
+  it('returns undefined when no cumulative cache counters are present', () => {
+    expect(getMindroomAiRunUsageCacheLabel({})).toBeUndefined();
+  });
+});
+
 describe('getMindroomAiRunContextLabel', () => {
   it('formats context usage with a percentage', () => {
     expect(
@@ -63,6 +80,22 @@ describe('getMindroomAiRunContextLabel', () => {
         contextWindowTokens: 0,
       })
     ).toBeUndefined();
+  });
+});
+
+describe('getMindroomAiRunContextCacheLabel', () => {
+  it('formats latest-request cache and non-cache-read context counters', () => {
+    expect(
+      getMindroomAiRunContextCacheLabel({
+        contextCacheReadInputTokens: 9000,
+        contextCacheWriteInputTokens: 10,
+        contextUncachedInputTokens: 130,
+      })
+    ).toBe('read 9,000 • write 10 • not read 130');
+  });
+
+  it('returns undefined when no latest-request cache counters are present', () => {
+    expect(getMindroomAiRunContextCacheLabel({})).toBeUndefined();
   });
 });
 

--- a/src/app/mindroom/messages/aiRunDisplay.ts
+++ b/src/app/mindroom/messages/aiRunDisplay.ts
@@ -19,11 +19,28 @@ export const getMindroomAiRunModelLabel = (info: MindroomAiRunInfo): string | un
 
 export const getMindroomAiRunUsageLabel = (info: MindroomAiRunInfo): string | undefined => {
   const parts = [
-    info.inputTokens !== undefined ? `in ${formatMindroomAiRunNumber(info.inputTokens)}` : undefined,
+    info.inputTokens !== undefined
+      ? `in ${formatMindroomAiRunNumber(info.inputTokens)}`
+      : undefined,
     info.outputTokens !== undefined
       ? `out ${formatMindroomAiRunNumber(info.outputTokens)}`
       : undefined,
-    info.totalTokens !== undefined ? `total ${formatMindroomAiRunNumber(info.totalTokens)}` : undefined,
+    info.totalTokens !== undefined
+      ? `total ${formatMindroomAiRunNumber(info.totalTokens)}`
+      : undefined,
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join(' • ') : undefined;
+};
+
+export const getMindroomAiRunUsageCacheLabel = (info: MindroomAiRunInfo): string | undefined => {
+  const parts = [
+    info.cacheReadTokens !== undefined
+      ? `read ${formatMindroomAiRunNumber(info.cacheReadTokens)}`
+      : undefined,
+    info.cacheWriteTokens !== undefined
+      ? `write ${formatMindroomAiRunNumber(info.cacheWriteTokens)}`
+      : undefined,
   ].filter(Boolean);
 
   return parts.length > 0 ? parts.join(' • ') : undefined;
@@ -37,5 +54,23 @@ export const getMindroomAiRunContextLabel = (info: MindroomAiRunInfo): string | 
   }
 
   const percentage = ((inputTokens / windowTokens) * 100).toFixed(1);
-  return `${formatMindroomAiRunNumber(inputTokens)} / ${formatMindroomAiRunNumber(windowTokens)} (${percentage}%)`;
+  return `${formatMindroomAiRunNumber(inputTokens)} / ${formatMindroomAiRunNumber(
+    windowTokens
+  )} (${percentage}%)`;
+};
+
+export const getMindroomAiRunContextCacheLabel = (info: MindroomAiRunInfo): string | undefined => {
+  const parts = [
+    info.contextCacheReadInputTokens !== undefined
+      ? `read ${formatMindroomAiRunNumber(info.contextCacheReadInputTokens)}`
+      : undefined,
+    info.contextCacheWriteInputTokens !== undefined
+      ? `write ${formatMindroomAiRunNumber(info.contextCacheWriteInputTokens)}`
+      : undefined,
+    info.contextUncachedInputTokens !== undefined
+      ? `not read ${formatMindroomAiRunNumber(info.contextUncachedInputTokens)}`
+      : undefined,
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join(' • ') : undefined;
 };


### PR DESCRIPTION
## Summary
- Parse cumulative AI-run cache read/write token counters from `usage` metadata.
- Parse latest-request cache read/write and non-cache-read context counters from `context` metadata.
- Show `Run Cache` and `Request Cache` as separate rows in the token usage dialog.
- Update focused parser, formatter, and rendered dialog tests plus the fork runbook.

## Validation
- npm test -- src/app/mindroom/messages/aiRun.test.ts src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/__tests__/Message.test.ts
- npm test -- src/app/theme/themeBootstrap.test.ts
- npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts
- npm test
- npm run typecheck
- npm run lint
- npm run build
- npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/__tests__/Message.test.ts src/app/mindroom/messages/aiRun.test.ts src/app/mindroom/messages/aiRun.ts src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/aiRunDisplay.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced AI run metadata display with cache token metrics: the dialog now shows cumulative cache read/write token counters for the full run ("Run Cache") and latest-request cache token breakdowns ("Request Cache" and "Request Context"), providing improved visibility into cache performance and efficiency, visually distinct from standard token usage counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->