### PR TITLE
Show AI run context window bar

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -84,6 +84,23 @@
   - `git diff --check`
   - `npm test` passed (`244` files, `1827` tests).
 
+### AI run context-window usage bar (2026-05-03)
+
+- Summary:
+  - The AI run metadata dialog now includes a visual `Request context window` bar after the `Request Context` row.
+  - The full bar represents `context.window_tokens`.
+  - Bar segments represent latest-request cache-read context, latest-request new or non-cache-read context, and remaining reserve.
+  - Segment hover titles expose the exact token counts and window percentages; the new-input segment also includes `context.cache_write_input_tokens` when reported.
+  - The existing text rows remain available for scanability, while the detailed cache/new/reserve breakdown is attached to the visual bar.
+- Tests and validation:
+  - `npm test -- src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+  - `npm run typecheck`
+  - `npm test` passed (`244` files, `1829` tests).
+  - `npm run lint` completed with the repo warning-only baseline (`17` warnings, `0` errors).
+  - `npm run build`
+  - `npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/MindroomMessageControls.css.ts src/app/mindroom/messages/__tests__/Message.test.ts src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/aiRunDisplay.ts`
+  - `git diff --check`
+
 ### CINNY-097 Recording Waveform Implementation Report (2026-04-27)
 
 - Summary:

--- a/src/app/mindroom/messages/MindroomMessageControls.css.ts
+++ b/src/app/mindroom/messages/MindroomMessageControls.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { DefaultReset, toRem } from 'folds';
+import { DefaultReset, color, config, toRem } from 'folds';
 
 export const AiRunInfoButton = style([
   DefaultReset,
@@ -30,4 +30,38 @@ export const AiRunInfoButton = style([
 
 export const MenuItemText = style({
   flexGrow: 1,
+});
+
+export const AiRunContextBar = style({
+  display: 'flex',
+  width: '100%',
+  height: toRem(10),
+  margin: `${config.space.S100} 0`,
+  borderRadius: toRem(999),
+  overflow: 'hidden',
+  backgroundColor: color.SurfaceVariant.Container,
+  border: `${config.borderWidth.B300} solid ${color.SurfaceVariant.ContainerLine}`,
+});
+
+export const AiRunContextBarSegment = style({
+  height: '100%',
+  cursor: 'help',
+  selectors: {
+    '&:focus-visible': {
+      outline: `${toRem(2)} solid ${color.Primary.Main}`,
+      outlineOffset: toRem(-2),
+    },
+  },
+});
+
+export const AiRunContextBarSegmentCacheRead = style({
+  backgroundColor: color.Success.Main,
+});
+
+export const AiRunContextBarSegmentNewInput = style({
+  backgroundColor: color.Primary.Main,
+});
+
+export const AiRunContextBarSegmentReserve = style({
+  backgroundColor: color.SurfaceVariant.ContainerLine,
 });

--- a/src/app/mindroom/messages/MindroomMessageControls.tsx
+++ b/src/app/mindroom/messages/MindroomMessageControls.tsx
@@ -24,8 +24,10 @@ import { stopPropagation } from '../../utils/keyboard';
 import { assignElementRef } from '../../utils/react';
 import { MindroomAiRunInfo, getMindroomAiRunInfo } from './aiRun';
 import {
+  MindroomAiRunContextBarSegment,
   formatMindroomAiRunNumber,
   formatMindroomAiRunTimeToFirstToken,
+  getMindroomAiRunContextBarSegments,
   getMindroomAiRunContextCacheLabel,
   getMindroomAiRunContextLabel,
   getMindroomAiRunModelLabel,
@@ -60,6 +62,37 @@ function MindroomAiRunDetail({ label, value }: { label: string; value?: string }
     <Text size="T200">
       {label}: {value}
     </Text>
+  );
+}
+
+const getMindroomAiRunContextBarSegmentClassName = (
+  key: MindroomAiRunContextBarSegment['key']
+): string => {
+  if (key === 'cacheRead') {
+    return `${css.AiRunContextBarSegment} ${css.AiRunContextBarSegmentCacheRead}`;
+  }
+  if (key === 'newInput') {
+    return `${css.AiRunContextBarSegment} ${css.AiRunContextBarSegmentNewInput}`;
+  }
+  return `${css.AiRunContextBarSegment} ${css.AiRunContextBarSegmentReserve}`;
+};
+
+function MindroomAiRunContextBar({ info }: { info: MindroomAiRunInfo }) {
+  const segments = getMindroomAiRunContextBarSegments(info);
+  if (!segments) return null;
+
+  return (
+    <div className={css.AiRunContextBar} aria-label="Request context window">
+      {segments.map((segment) => (
+        <div
+          key={segment.key}
+          className={getMindroomAiRunContextBarSegmentClassName(segment.key)}
+          style={{ width: `${segment.percentage}%` }}
+          title={segment.title}
+          aria-label={`${segment.label}: ${formatMindroomAiRunNumber(segment.tokens)} tokens`}
+        />
+      ))}
+    </div>
   );
 }
 
@@ -120,6 +153,7 @@ function MindroomAiRunInfoDialog({
               <MindroomAiRunDetail label="Tokens" value={usageLabel} />
               <MindroomAiRunDetail label="Run Cache" value={usageCacheLabel} />
               <MindroomAiRunDetail label="Request Context" value={contextLabel} />
+              <MindroomAiRunContextBar info={info} />
               <MindroomAiRunDetail label="Request Cache" value={contextCacheLabel} />
               <MindroomAiRunDetail label="Tools" value={toolsLabel} />
               <MindroomAiRunDetail label="TTFT" value={ttftLabel} />

--- a/src/app/mindroom/messages/__tests__/Message.test.ts
+++ b/src/app/mindroom/messages/__tests__/Message.test.ts
@@ -34,6 +34,11 @@ vi.mock('../../../features/room/message/styles.css', () => ({
 
 vi.mock('../MindroomMessageControls.css', () => ({
   AiRunInfoButton: 'AiRunInfoButton',
+  AiRunContextBar: 'AiRunContextBar',
+  AiRunContextBarSegment: 'AiRunContextBarSegment',
+  AiRunContextBarSegmentCacheRead: 'AiRunContextBarSegmentCacheRead',
+  AiRunContextBarSegmentNewInput: 'AiRunContextBarSegmentNewInput',
+  AiRunContextBarSegmentReserve: 'AiRunContextBarSegmentReserve',
   MenuItemText: 'MenuItemText',
 }));
 
@@ -433,6 +438,9 @@ const getDialogFocusTrapOptions = (renderer: ReactTestRenderer): Record<string, 
   return dialogFocusTrap.props.focusTrapOptions;
 };
 
+const hasNodeTitle = (renderer: ReactTestRenderer, title: string): boolean =>
+  renderer.root.findAll((node) => node.props.title === title).length > 0;
+
 const openContextMenu = async (renderer: ReactTestRenderer) => {
   const menuButton = getButtonByIcon(renderer, 'VerticalDots');
 
@@ -547,6 +555,11 @@ describe('Message token usage menu item', () => {
     expect(hasSpanText(renderer, 'Model: fast (openai / gpt-5-mini)')).toBe(true);
     expect(hasSpanText(renderer, 'Request Context: 65 / 100 (65.0%)')).toBe(true);
     expect(hasSpanText(renderer, 'Request Cache: read 20 • write 5 • not read 45')).toBe(true);
+    expect(hasNodeTitle(renderer, 'Cache read: 20 tokens (20.0% of window)')).toBe(true);
+    expect(
+      hasNodeTitle(renderer, 'New input: 45 tokens (45.0% of window); cache write: 5 tokens')
+    ).toBe(true);
+    expect(hasNodeTitle(renderer, 'Reserve: 35 tokens (35.0% of window)')).toBe(true);
     expect(hasSpanText(renderer, 'Tools: 3')).toBe(true);
     expect(hasSpanText(renderer, 'TTFT: 42 ms')).toBe(true);
     expect(hasSpanText(renderer, 'Run: run-123')).toBe(true);

--- a/src/app/mindroom/messages/aiRunDisplay.test.ts
+++ b/src/app/mindroom/messages/aiRunDisplay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   formatMindroomAiRunNumber,
   formatMindroomAiRunTimeToFirstToken,
+  getMindroomAiRunContextBarSegments,
   getMindroomAiRunContextCacheLabel,
   getMindroomAiRunContextLabel,
   getMindroomAiRunUsageCacheLabel,
@@ -96,6 +97,54 @@ describe('getMindroomAiRunContextCacheLabel', () => {
 
   it('returns undefined when no latest-request cache counters are present', () => {
     expect(getMindroomAiRunContextCacheLabel({})).toBeUndefined();
+  });
+});
+
+describe('getMindroomAiRunContextBarSegments', () => {
+  it('maps latest-request cache, new input, and reserve to context-window bar segments', () => {
+    expect(
+      getMindroomAiRunContextBarSegments({
+        contextInputTokens: 65,
+        contextWindowTokens: 100,
+        contextCacheReadInputTokens: 20,
+        contextCacheWriteInputTokens: 5,
+        contextUncachedInputTokens: 45,
+      })
+    ).toEqual([
+      {
+        key: 'cacheRead',
+        label: 'Cache read',
+        tokens: 20,
+        percentage: 20,
+        title: 'Cache read: 20 tokens (20.0% of window)',
+      },
+      {
+        key: 'newInput',
+        label: 'New input',
+        tokens: 45,
+        percentage: 45,
+        title: 'New input: 45 tokens (45.0% of window); cache write: 5 tokens',
+      },
+      {
+        key: 'reserve',
+        label: 'Reserve',
+        tokens: 35,
+        percentage: 35,
+        title: 'Reserve: 35 tokens (35.0% of window)',
+      },
+    ]);
+  });
+
+  it('returns undefined when required context-window values are missing or inconsistent', () => {
+    expect(getMindroomAiRunContextBarSegments({ contextInputTokens: 65 })).toBeUndefined();
+    expect(
+      getMindroomAiRunContextBarSegments({
+        contextInputTokens: 120,
+        contextWindowTokens: 100,
+        contextCacheReadInputTokens: 20,
+        contextUncachedInputTokens: 100,
+      })
+    ).toBeUndefined();
   });
 });
 

--- a/src/app/mindroom/messages/aiRunDisplay.ts
+++ b/src/app/mindroom/messages/aiRunDisplay.ts
@@ -1,5 +1,13 @@
 import { MindroomAiRunInfo } from './aiRun';
 
+export type MindroomAiRunContextBarSegment = {
+  key: 'cacheRead' | 'newInput' | 'reserve';
+  label: string;
+  tokens: number;
+  percentage: number;
+  title: string;
+};
+
 export const formatMindroomAiRunNumber = (value: number | undefined): string | undefined =>
   typeof value === 'number' ? Math.round(value).toLocaleString() : undefined;
 
@@ -73,4 +81,79 @@ export const getMindroomAiRunContextCacheLabel = (info: MindroomAiRunInfo): stri
   ].filter(Boolean);
 
   return parts.length > 0 ? parts.join(' • ') : undefined;
+};
+
+const isValidContextBarTokenCount = (value: number | undefined): value is number =>
+  typeof value === 'number' && value >= 0;
+
+const formatMindroomAiRunContextBarPercentage = (value: number, windowTokens: number): string =>
+  ((value / windowTokens) * 100).toFixed(1);
+
+const getMindroomAiRunContextBarTitle = (
+  label: string,
+  tokens: number,
+  windowTokens: number,
+  suffix?: string
+): string => {
+  const tokenLabel = tokens === 1 ? 'token' : 'tokens';
+  const percentage = formatMindroomAiRunContextBarPercentage(tokens, windowTokens);
+  return `${label}: ${formatMindroomAiRunNumber(tokens)} ${tokenLabel} (${percentage}% of window)${
+    suffix ? `; ${suffix}` : ''
+  }`;
+};
+
+export const getMindroomAiRunContextBarSegments = (
+  info: MindroomAiRunInfo
+): MindroomAiRunContextBarSegment[] | undefined => {
+  const inputTokens = info.contextInputTokens;
+  const windowTokens = info.contextWindowTokens;
+  const cacheReadTokens = info.contextCacheReadInputTokens;
+  const uncachedTokens = info.contextUncachedInputTokens;
+
+  if (
+    !isValidContextBarTokenCount(inputTokens) ||
+    !isValidContextBarTokenCount(windowTokens) ||
+    windowTokens <= 0 ||
+    !isValidContextBarTokenCount(cacheReadTokens) ||
+    !isValidContextBarTokenCount(uncachedTokens) ||
+    inputTokens > windowTokens ||
+    cacheReadTokens + uncachedTokens !== inputTokens
+  ) {
+    return undefined;
+  }
+
+  const reserveTokens = windowTokens - inputTokens;
+  const cacheWriteSuffix =
+    info.contextCacheWriteInputTokens !== undefined
+      ? `cache write: ${formatMindroomAiRunNumber(info.contextCacheWriteInputTokens)} tokens`
+      : undefined;
+
+  return [
+    {
+      key: 'cacheRead',
+      label: 'Cache read',
+      tokens: cacheReadTokens,
+      percentage: (cacheReadTokens / windowTokens) * 100,
+      title: getMindroomAiRunContextBarTitle('Cache read', cacheReadTokens, windowTokens),
+    },
+    {
+      key: 'newInput',
+      label: 'New input',
+      tokens: uncachedTokens,
+      percentage: (uncachedTokens / windowTokens) * 100,
+      title: getMindroomAiRunContextBarTitle(
+        'New input',
+        uncachedTokens,
+        windowTokens,
+        cacheWriteSuffix
+      ),
+    },
+    {
+      key: 'reserve',
+      label: 'Reserve',
+      tokens: reserveTokens,
+      percentage: (reserveTokens / windowTokens) * 100,
+      title: getMindroomAiRunContextBarTitle('Reserve', reserveTokens, windowTokens),
+    },
+  ];
 };


### PR DESCRIPTION
## Summary
- Add a request context-window bar to the AI run metadata dialog.
- Derive cache-read, new/not-cache-read input, and reserve segments from the latest request context metadata.
- Put exact token counts and percentages on segment hover titles, with cache-write included on the new-input segment.
- Keep existing text rows for scanability while the bar carries the detailed visual breakdown.

## Validation
- npm test -- src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/__tests__/Message.test.ts
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/MindroomMessageControls.css.ts src/app/mindroom/messages/__tests__/Message.test.ts src/app/mindroom/messages/aiRunDisplay.test.ts src/app/mindroom/messages/aiRunDisplay.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a visual "Request context window" bar to the AI run metadata dialog displaying context token breakdown across cache-read, new-input, and reserve segments with hover tooltips showing exact token counts and percentages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->