### PR TITLE
ci: harden Xcode Cloud scripts

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -12,11 +12,21 @@
   - Root cause: the repository intentionally ignores `ios/App/Pods`, `ios/App/App/public`, and the workspace depends on `node_modules` for Capacitor pods, so a clean Xcode Cloud machine needs explicit setup scripts before `xcodebuild`.
   - Added Xcode Cloud scripts next to `ios/App/App.xcworkspace` to install Node/CocoaPods when missing, run `npm ci`, build the Vite web app, run `npx cap sync ios`, and then run the App Store preflight.
   - Xcode Cloud builds now rewrite the transient Xcode project version from `package.json` and `CI_BUILD_NUMBER` before building, while the checked-in project is aligned to `4.11.1` build `3` for local archives.
-  - Review follow-up: `ci_post_clone.sh` now fails with a clear message if a missing tool cannot be installed because Homebrew is unavailable.
+  - Review follow-up: `ci_post_clone.sh` now fails with a clear message if a missing tool cannot be installed because Homebrew is unavailable, with shared Homebrew initialization kept in `ci_common.sh`.
   - Review follow-up: `ci_pre_xcodebuild.sh` initializes the Homebrew shell environment in its own process, verifies all required commands are available, reads the package version with `node -p`, and passes version values through environment variables instead of Node argv.
-  - Review follow-up: the transient project-file rewrite now asserts the expected number of version-setting occurrences before replacing them, so future target/configuration changes fail clearly instead of silently rewriting unexpected entries.
+  - Review follow-up: the transient project-file rewrite now asserts the expected App Debug and Release build-setting occurrence count before replacing version settings, so future target/configuration changes fail clearly instead of silently rewriting unexpected entries.
+- Risks:
+  - Homebrew may be absent or installed outside standard paths on a future Xcode Cloud image, causing the scripts to fail before dependency installation.
+  - Xcode project structure changes can increase the version-setting occurrence count and intentionally stop the build until the rewrite guard is updated.
+  - Fresh CI machines can still expose npm, CocoaPods, or Xcode Cloud network flakiness during install and sync steps.
+- Next steps:
+  - Owner: release engineer monitors the next automated Xcode Cloud and GitHub CI runs for the merged branch.
+  - Owner: iOS maintainer uses the same script validation and `xcodebuild` commands as the rollback check before changing CI scripts again.
+  - Owner: release engineer rolls back the follow-up commit if Xcode Cloud fails before dependency installation or rewrites unexpected project settings.
+  - Owner: iOS maintainer updates this runbook whenever Xcode targets, build configurations, or CI ownership changes.
 - Files changed:
   - `FORK_CHANGES.md`
+  - `ios/App/ci_scripts/ci_common.sh`
   - `ios/App/App.xcodeproj/project.pbxproj`
   - `ios/App/ci_scripts/ci_post_clone.sh`
   - `ios/App/ci_scripts/ci_pre_xcodebuild.sh`
@@ -27,7 +37,7 @@
   - Green check: `xcodebuild -workspace ios/App/App.xcworkspace -scheme App -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build` passed after the scripts prepared the Capacitor workspace.
   - Green check: built app `Info.plist` reported `CFBundleShortVersionString` `4.11.1` and `CFBundleVersion` `3`.
   - Review check: `node -e "console.log(JSON.stringify(process.argv))" marketing build` confirmed this Node runtime passes the first argument at `process.argv[1]`, but the script now uses environment variables to avoid Node CLI argv ambiguity.
-  - Review green check: `bash -n ios/App/ci_scripts/ci_post_clone.sh ios/App/ci_scripts/ci_pre_xcodebuild.sh`.
+  - Review green check: `bash -n ios/App/ci_scripts/ci_common.sh ios/App/ci_scripts/ci_post_clone.sh ios/App/ci_scripts/ci_pre_xcodebuild.sh`.
   - Review green check: `CI_BUILD_NUMBER=3 ios/App/ci_scripts/ci_pre_xcodebuild.sh` passed, including the CI version rewrite path.
   - Review green check: `xcodebuild -workspace ios/App/App.xcworkspace -scheme App -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build`.
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -12,6 +12,9 @@
   - Root cause: the repository intentionally ignores `ios/App/Pods`, `ios/App/App/public`, and the workspace depends on `node_modules` for Capacitor pods, so a clean Xcode Cloud machine needs explicit setup scripts before `xcodebuild`.
   - Added Xcode Cloud scripts next to `ios/App/App.xcworkspace` to install Node/CocoaPods when missing, run `npm ci`, build the Vite web app, run `npx cap sync ios`, and then run the App Store preflight.
   - Xcode Cloud builds now rewrite the transient Xcode project version from `package.json` and `CI_BUILD_NUMBER` before building, while the checked-in project is aligned to `4.11.1` build `3` for local archives.
+  - Review follow-up: `ci_post_clone.sh` now fails with a clear message if a missing tool cannot be installed because Homebrew is unavailable.
+  - Review follow-up: `ci_pre_xcodebuild.sh` initializes the Homebrew shell environment in its own process, verifies all required commands are available, reads the package version with `node -p`, and passes version values through environment variables instead of Node argv.
+  - Review follow-up: the transient project-file rewrite now asserts the expected number of version-setting occurrences before replacing them, so future target/configuration changes fail clearly instead of silently rewriting unexpected entries.
 - Files changed:
   - `FORK_CHANGES.md`
   - `ios/App/App.xcodeproj/project.pbxproj`
@@ -23,6 +26,10 @@
   - Green check: `ios/App/ci_scripts/ci_pre_xcodebuild.sh` passed, including `npm run build`, `npx cap sync ios`, CocoaPods install, and `npm run appstore:preflight`.
   - Green check: `xcodebuild -workspace ios/App/App.xcworkspace -scheme App -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build` passed after the scripts prepared the Capacitor workspace.
   - Green check: built app `Info.plist` reported `CFBundleShortVersionString` `4.11.1` and `CFBundleVersion` `3`.
+  - Review check: `node -e "console.log(JSON.stringify(process.argv))" marketing build` confirmed this Node runtime passes the first argument at `process.argv[1]`, but the script now uses environment variables to avoid Node CLI argv ambiguity.
+  - Review green check: `bash -n ios/App/ci_scripts/ci_post_clone.sh ios/App/ci_scripts/ci_pre_xcodebuild.sh`.
+  - Review green check: `CI_BUILD_NUMBER=3 ios/App/ci_scripts/ci_pre_xcodebuild.sh` passed, including the CI version rewrite path.
+  - Review green check: `xcodebuild -workspace ios/App/App.xcworkspace -scheme App -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build`.
 
 ### Canonical compact audio player with More menu (2026-05-11)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -13,8 +13,9 @@
   - Added Xcode Cloud scripts next to `ios/App/App.xcworkspace` to install Node/CocoaPods when missing, run `npm ci`, build the Vite web app, run `npx cap sync ios`, and then run the App Store preflight.
   - Xcode Cloud builds now rewrite the transient Xcode project version from `package.json` and `CI_BUILD_NUMBER` before building, while the checked-in project is aligned to `4.11.1` build `3` for local archives.
   - Review follow-up: `ci_post_clone.sh` now fails with a clear message if a missing tool cannot be installed because Homebrew is unavailable, with shared Homebrew initialization kept in `ci_common.sh`.
-  - Review follow-up: `ci_pre_xcodebuild.sh` initializes the Homebrew shell environment in its own process, verifies all required commands are available, reads the package version with `node -p`, and passes version values through environment variables instead of Node argv.
-  - Review follow-up: the transient project-file rewrite now asserts the expected App Debug and Release build-setting occurrence count before replacing version settings, so future target/configuration changes fail clearly instead of silently rewriting unexpected entries.
+  - Review follow-up: `ci_post_clone.sh` verifies `npm` after confirming `node` exists, without trying to install a second Node formula for nonstandard Node installs.
+  - Review follow-up: `ci_pre_xcodebuild.sh` initializes the Homebrew shell environment in its own process, verifies all required commands are available, reads and validates the package version with `node -p`, and passes version values through environment variables instead of Node argv.
+  - Review follow-up: the transient project-file rewrite now asserts the expected App Debug and Release build-setting occurrence count before replacing version settings and uses function replacers so version strings are written literally.
 - Risks:
   - Homebrew may be absent or installed outside standard paths on a future Xcode Cloud image, causing the scripts to fail before dependency installation.
   - Xcode project structure changes can increase the version-setting occurrence count and intentionally stop the build until the rewrite guard is updated.

--- a/ios/App/ci_scripts/ci_common.sh
+++ b/ios/App/ci_scripts/ci_common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+init_homebrew() {
+  if command -v brew >/dev/null 2>&1; then
+    return
+  fi
+
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+}

--- a/ios/App/ci_scripts/ci_post_clone.sh
+++ b/ios/App/ci_scripts/ci_post_clone.sh
@@ -27,7 +27,11 @@ init_homebrew
 cd "$REPO_ROOT"
 
 install_if_missing node node
-install_if_missing npm node
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Error: npm is not available after confirming node is installed." >&2
+  echo "Install a Node distribution that includes npm before running this script." >&2
+  exit 1
+fi
 install_if_missing pod cocoapods
 
 node --version

--- a/ios/App/ci_scripts/ci_post_clone.sh
+++ b/ios/App/ci_scripts/ci_post_clone.sh
@@ -3,18 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
-
-init_homebrew() {
-  if command -v brew >/dev/null 2>&1; then
-    return
-  fi
-
-  if [[ -x /opt/homebrew/bin/brew ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-  elif [[ -x /usr/local/bin/brew ]]; then
-    eval "$(/usr/local/bin/brew shellenv)"
-  fi
-}
+source "$SCRIPT_DIR/ci_common.sh"
 
 install_if_missing() {
   local command_name="$1"

--- a/ios/App/ci_scripts/ci_post_clone.sh
+++ b/ios/App/ci_scripts/ci_post_clone.sh
@@ -4,23 +4,42 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
-if ! command -v brew >/dev/null 2>&1; then
+init_homebrew() {
+  if command -v brew >/dev/null 2>&1; then
+    return
+  fi
+
   if [[ -x /opt/homebrew/bin/brew ]]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
   elif [[ -x /usr/local/bin/brew ]]; then
     eval "$(/usr/local/bin/brew shellenv)"
   fi
-fi
+}
+
+install_if_missing() {
+  local command_name="$1"
+  local formula="$2"
+
+  if command -v "$command_name" >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Error: $command_name is not available and Homebrew was not found." >&2
+    echo "Install $command_name before running this script, or make Homebrew available in PATH." >&2
+    exit 1
+  fi
+
+  brew install "$formula"
+}
+
+init_homebrew
 
 cd "$REPO_ROOT"
 
-if ! command -v node >/dev/null 2>&1; then
-  brew install node
-fi
-
-if ! command -v pod >/dev/null 2>&1; then
-  brew install cocoapods
-fi
+install_if_missing node node
+install_if_missing npm node
+install_if_missing pod cocoapods
 
 node --version
 npm --version

--- a/ios/App/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/App/ci_scripts/ci_pre_xcodebuild.sh
@@ -3,14 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/ci_common.sh"
 
-if ! command -v brew >/dev/null 2>&1; then
-  if [[ -x /opt/homebrew/bin/brew ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-  elif [[ -x /usr/local/bin/brew ]]; then
-    eval "$(/usr/local/bin/brew shellenv)"
-  fi
-fi
+init_homebrew
 
 cd "$REPO_ROOT"
 
@@ -31,6 +26,8 @@ if [[ -n "${CI_BUILD_NUMBER:-}" ]]; then
     const marketingVersion = process.env.MARKETING_VERSION;
     const buildNumber = process.env.CURRENT_PROJECT_VERSION;
     const original = fs.readFileSync(projectPath, 'utf8');
+    // The App target has Debug and Release build settings.
+    const appBuildConfigurationCount = 2;
 
     const replaceExpectedOccurrences = (text, pattern, replacement, expectedCount) => {
       const matches = text.match(pattern) ?? [];
@@ -46,13 +43,13 @@ if [[ -n "${CI_BUILD_NUMBER:-}" ]]; then
       original,
       /MARKETING_VERSION = [^;]+;/g,
       'MARKETING_VERSION = ' + marketingVersion + ';',
-      2
+      appBuildConfigurationCount
     );
     updated = replaceExpectedOccurrences(
       updated,
       /CURRENT_PROJECT_VERSION = [^;]+;/g,
       'CURRENT_PROJECT_VERSION = ' + buildNumber + ';',
-      2
+      appBuildConfigurationCount
     );
 
     fs.writeFileSync(projectPath, updated);

--- a/ios/App/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/App/ci_scripts/ci_pre_xcodebuild.sh
@@ -18,6 +18,10 @@ for command_name in node npm npx pod; do
 done
 
 PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+if [[ -z "$PACKAGE_VERSION" || "$PACKAGE_VERSION" == "undefined" ]]; then
+  echo "Error: Could not determine version from package.json." >&2
+  exit 1
+fi
 
 if [[ -n "${CI_BUILD_NUMBER:-}" ]]; then
   MARKETING_VERSION="$PACKAGE_VERSION" CURRENT_PROJECT_VERSION="$CI_BUILD_NUMBER" node <<'NODE'
@@ -29,26 +33,26 @@ if [[ -n "${CI_BUILD_NUMBER:-}" ]]; then
     // The App target has Debug and Release build settings.
     const appBuildConfigurationCount = 2;
 
-    const replaceExpectedOccurrences = (text, pattern, replacement, expectedCount) => {
+    const replaceExpectedOccurrences = (text, pattern, replacer, expectedCount) => {
       const matches = text.match(pattern) ?? [];
       if (matches.length !== expectedCount) {
         throw new Error(
           `Expected ${expectedCount} occurrences of ${pattern}, found ${matches.length}.`
         );
       }
-      return text.replace(pattern, replacement);
+      return text.replace(pattern, replacer);
     };
 
     let updated = replaceExpectedOccurrences(
       original,
       /MARKETING_VERSION = [^;]+;/g,
-      'MARKETING_VERSION = ' + marketingVersion + ';',
+      () => 'MARKETING_VERSION = ' + marketingVersion + ';',
       appBuildConfigurationCount
     );
     updated = replaceExpectedOccurrences(
       updated,
       /CURRENT_PROJECT_VERSION = [^;]+;/g,
-      'CURRENT_PROJECT_VERSION = ' + buildNumber + ';',
+      () => 'CURRENT_PROJECT_VERSION = ' + buildNumber + ';',
       appBuildConfigurationCount
     );
 

--- a/ios/App/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/App/ci_scripts/ci_pre_xcodebuild.sh
@@ -4,22 +4,59 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
+if ! command -v brew >/dev/null 2>&1; then
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
+
 cd "$REPO_ROOT"
 
-PACKAGE_VERSION="$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version)")"
+for command_name in node npm npx pod; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Error: $command_name is not available before xcodebuild." >&2
+    echo "ci_post_clone.sh should install dependencies and initialize CocoaPods before this script runs." >&2
+    exit 1
+  fi
+done
+
+PACKAGE_VERSION="$(node -p "require('./package.json').version")"
 
 if [[ -n "${CI_BUILD_NUMBER:-}" ]]; then
-  node -e "
+  MARKETING_VERSION="$PACKAGE_VERSION" CURRENT_PROJECT_VERSION="$CI_BUILD_NUMBER" node <<'NODE'
     const fs = require('fs');
     const projectPath = 'ios/App/App.xcodeproj/project.pbxproj';
-    const marketingVersion = process.argv[1];
-    const buildNumber = process.argv[2];
+    const marketingVersion = process.env.MARKETING_VERSION;
+    const buildNumber = process.env.CURRENT_PROJECT_VERSION;
     const original = fs.readFileSync(projectPath, 'utf8');
-    const updated = original
-      .replace(/MARKETING_VERSION = [^;]+;/g, 'MARKETING_VERSION = ' + marketingVersion + ';')
-      .replace(/CURRENT_PROJECT_VERSION = [^;]+;/g, 'CURRENT_PROJECT_VERSION = ' + buildNumber + ';');
+
+    const replaceExpectedOccurrences = (text, pattern, replacement, expectedCount) => {
+      const matches = text.match(pattern) ?? [];
+      if (matches.length !== expectedCount) {
+        throw new Error(
+          `Expected ${expectedCount} occurrences of ${pattern}, found ${matches.length}.`
+        );
+      }
+      return text.replace(pattern, replacement);
+    };
+
+    let updated = replaceExpectedOccurrences(
+      original,
+      /MARKETING_VERSION = [^;]+;/g,
+      'MARKETING_VERSION = ' + marketingVersion + ';',
+      2
+    );
+    updated = replaceExpectedOccurrences(
+      updated,
+      /CURRENT_PROJECT_VERSION = [^;]+;/g,
+      'CURRENT_PROJECT_VERSION = ' + buildNumber + ';',
+      2
+    );
+
     fs.writeFileSync(projectPath, updated);
-  " "$PACKAGE_VERSION" "$CI_BUILD_NUMBER"
+NODE
 fi
 
 npm run build


### PR DESCRIPTION
## Summary
- initialize Homebrew/PATH in both Xcode Cloud scripts and fail clearly if a missing tool cannot be installed
- verify required commands before pre-xcodebuild work starts
- use env vars for transient Xcode version rewriting and assert expected version-setting occurrences before replacing

## Validation
- bash -n ios/App/ci_scripts/ci_post_clone.sh ios/App/ci_scripts/ci_pre_xcodebuild.sh
- ios/App/ci_scripts/ci_post_clone.sh
- CI_BUILD_NUMBER=8 ios/App/ci_scripts/ci_pre_xcodebuild.sh
- xcodebuild -workspace ios/App/App.xcworkspace -scheme App -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build
- git diff --check
- npx prettier --check FORK_CHANGES.md

## Summary by Sourcery

Harden Xcode Cloud CI scripts for iOS builds by making tool/bootstrap failures explicit and tightening project version rewrite safety.

Enhancements:
- Ensure both Xcode Cloud scripts initialize the Homebrew environment and explicitly fail when required tools cannot be installed or are missing before xcodebuild.
- Read the app version from package.json via a simpler Node expression and pass versioning data through environment variables instead of CLI arguments when rewriting Xcode project settings.
- Validate the expected number of MARKETING_VERSION and CURRENT_PROJECT_VERSION occurrences in the Xcode project file before performing in-place replacements to avoid unintended edits.

Documentation:
- Document the CI script follow‑ups in FORK_CHANGES.md, including new failure behaviours, versioning safeguards, and validation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS CI robustness: clearer Homebrew failure messaging, safer Node version extraction, pre-flight tool checks, and guarded version rewrites that verify expected occurrence counts.

* **Documentation**
  * Expanded build-setup runbook with reviewer follow-ups, risks, next steps, and added validation steps.

* **Chores**
  * Consolidated CI initialization into shared helpers, added conditional tool installation, script linting/sanity runs, and a final build verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/13)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->