### PR TITLE
Fix classic large-room loading jump

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,35 @@
 
 ## Runbook
 
+### Classic large-room loading scroll stability (2026-05-11)
+
+- Status:
+  - Complete.
+- Summary:
+  - Reproduced the classic large-room jump in a real browser before changing source code.
+  - Browser reproduction seeded a 2600-message room, opened it in Classic view, and delayed room `/messages` pagination; while idle, the timeline scroll root jumped from `scrollTop=0` to roughly `25502` and the first visible message changed from `message 2593` to `message 2578`.
+  - Added a full Docker Matrix e2e regression that seeds a 700-message room, opens Classic view, slows only room back-pagination, and samples the timeline scroll root while the user is idle.
+  - Root cause: Classic view still ran the high-target room eager-preload loop on open. The virtualized transcript grew in backward-pagination batches under the visible viewport, causing the scroll root and first visible message to jump during loading.
+  - Classic view now skips room eager preload and behaves like a normal transcript: it renders the latest window and loads older history only through the existing user-driven pagination path.
+  - Independent second self-review completed against the final diff; scope stayed limited to Classic-view passive preload, the e2e regression, and runbook updates.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `e2e/live/cinny077-classic-large-room-scroll.spec.ts`
+  - `src/app/mindroom/threads/MindroomRoomTimeline.tsx`
+  - `src/app/mindroom/threads/preloadController.ts`
+- Tests and validation:
+  - Red browser reproduction: seeded a 2600-message room and observed idle scroll movement from `message 2593` to `message 2578` while delayed `/messages` back-pagination ran.
+  - Red check: `E2E_ENABLE_DEPLOYED_FIXTURE=0 npm run test:e2e:docker-matrix -- e2e/live/cinny077-classic-large-room-scroll.spec.ts` failed because the first visible message changed across samples.
+  - Green check: `E2E_ENABLE_DEPLOYED_FIXTURE=0 npm run test:e2e:docker-matrix -- e2e/live/cinny077-classic-large-room-scroll.spec.ts`.
+  - Green check: `npm test -- src/app/mindroom/threads/roomPreloadTarget.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts`.
+  - Green check: `npm run typecheck`.
+  - Green check: `npx prettier --check FORK_CHANGES.md e2e/live/cinny077-classic-large-room-scroll.spec.ts src/app/mindroom/threads/MindroomRoomTimeline.tsx src/app/mindroom/threads/preloadController.ts`.
+  - Green check: `git diff --check`.
+  - Green check: `npm run lint` completed with the existing warning-only baseline (`16` warnings, `0` errors).
+  - Green check: `npm test` passed (`276` files, `2054` tests).
+  - Green check: `npm run build` passed with existing Vite runtime-config/sourcemap/chunk-size warnings.
+  - Green final e2e check: `E2E_ENABLE_DEPLOYED_FIXTURE=0 npm run test:e2e:docker-matrix -- e2e/live/cinny077-classic-large-room-scroll.spec.ts`.
+
 ### Xcode Cloud TestFlight build setup (2026-05-11)
 
 - Status:

--- a/e2e/live/cinny077-classic-large-room-scroll.spec.ts
+++ b/e2e/live/cinny077-classic-large-room-scroll.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, type Page } from '@playwright/test';
+import { getHomeserver, getPrimaryCredentials } from '../env';
+import { loginWithPassword } from '../helpers/auth';
+import {
+  createDefaultThreadFilterState,
+  createPrivateRoom,
+  loginToMatrix,
+  matrixFetch,
+  seedRoomOverviewState,
+} from '../helpers/matrix';
+
+const hasCredentials = !!process.env.E2E_USERNAME;
+const MESSAGE_COUNT = 700;
+
+type ScrollSample = {
+  scrollTop: number;
+  scrollHeight: number;
+  mountedMessageCount: number;
+  firstVisibleMessage: string;
+};
+
+const sendLargeRoomMessages = async (
+  homeserver: string,
+  accessToken: string,
+  roomId: string,
+  stamp: number
+) => {
+  let nextIndex = 1;
+
+  await Promise.all(
+    Array.from({ length: 20 }, async () => {
+      while (nextIndex <= MESSAGE_COUNT) {
+        const index = nextIndex;
+        nextIndex += 1;
+
+        await matrixFetch(
+          homeserver,
+          `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/cinny-077-${stamp}-${index}`,
+          {
+            method: 'PUT',
+            accessToken,
+            body: JSON.stringify({
+              msgtype: 'm.text',
+              body: `CINNY-077 classic large room ${stamp} message ${String(index).padStart(
+                4,
+                '0'
+              )}`,
+            }),
+          }
+        );
+      }
+    })
+  );
+};
+
+const sampleClassicRoomScroll = async (page: Page): Promise<ScrollSample[]> =>
+  page.evaluate(async () => {
+    const findTimelineScrollRoot = (): HTMLElement => {
+      const candidates = Array.from(document.querySelectorAll<HTMLElement>('body *')).filter(
+        (element) => {
+          const { overflowY } = window.getComputedStyle(element);
+          return (
+            (overflowY === 'auto' || overflowY === 'scroll') &&
+            !!element.querySelector('[data-message-id]')
+          );
+        }
+      );
+
+      const timelineRoot = candidates.sort((a, b) => b.scrollHeight - a.scrollHeight)[0];
+      if (!timelineRoot) {
+        throw new Error('Unable to find room timeline scroll root.');
+      }
+      return timelineRoot;
+    };
+
+    const firstVisibleMessage = (root: HTMLElement): string => {
+      const rootRect = root.getBoundingClientRect();
+      const visibleItem = Array.from(root.querySelectorAll<HTMLElement>('[data-message-id]')).find(
+        (item) => {
+          const rect = item.getBoundingClientRect();
+          return rect.bottom > rootRect.top + 8 && rect.top < rootRect.bottom - 8;
+        }
+      );
+
+      return visibleItem?.textContent?.match(/message \d{4}/)?.[0] ?? '';
+    };
+
+    const scrollRoot = findTimelineScrollRoot();
+    const samples: ScrollSample[] = [];
+
+    for (let index = 0; index < 60; index += 1) {
+      samples.push({
+        scrollTop: Math.round(scrollRoot.scrollTop),
+        scrollHeight: Math.round(scrollRoot.scrollHeight),
+        mountedMessageCount: document.querySelectorAll('[data-message-id]').length,
+        firstVisibleMessage: firstVisibleMessage(scrollRoot),
+      });
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200);
+      });
+    }
+
+    return samples;
+  });
+
+test.describe('CINNY-077: classic large room loading scroll stability', () => {
+  test.skip(!hasCredentials, 'E2E_USERNAME / E2E_PASSWORD not set');
+
+  test('opening a large classic room does not jump while backfill is loading', async ({ page }) => {
+    test.slow();
+
+    const homeserver = getHomeserver();
+    const { username, password } = getPrimaryCredentials();
+    const { accessToken, userId } = await loginToMatrix(homeserver, username, password);
+    const stamp = Date.now();
+    const roomId = await createPrivateRoom(homeserver, accessToken, {
+      name: `CINNY-077 Classic Large ${stamp}`,
+      topic: 'Regression fixture for classic large-room loading scroll stability.',
+    });
+
+    await sendLargeRoomMessages(homeserver, accessToken, roomId, stamp);
+
+    await loginWithPassword(page, { homeserver, username, password });
+    await seedRoomOverviewState({
+      page,
+      roomId,
+      userId,
+      viewMode: 'classic',
+      filterState: createDefaultThreadFilterState(),
+    });
+
+    let backPaginationRequests = 0;
+    await page.route(/\/rooms\/.*\/messages(?:\?|$)/, async (route) => {
+      backPaginationRequests += 1;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 250);
+      });
+      await route.continue();
+    });
+
+    await page.goto(`/home/${encodeURIComponent(roomId)}`);
+    await expect(
+      page.getByText(`message ${String(MESSAGE_COUNT).padStart(4, '0')}`).first()
+    ).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const samples = await sampleClassicRoomScroll(page);
+    const visibleSamples = samples.filter((sample) => sample.firstVisibleMessage.length > 0);
+    expect(visibleSamples.length).toBeGreaterThan(0);
+
+    const firstVisibleMessages = new Set(
+      visibleSamples.map((sample) => sample.firstVisibleMessage)
+    );
+    const scrollTopDelta =
+      Math.max(...visibleSamples.map((sample) => sample.scrollTop)) -
+      Math.min(...visibleSamples.map((sample) => sample.scrollTop));
+
+    expect(firstVisibleMessages).toEqual(new Set([visibleSamples[0].firstVisibleMessage]));
+    expect(scrollTopDelta).toBeLessThanOrEqual(2);
+    expect(backPaginationRequests).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/app/mindroom/threads/MindroomRoomTimeline.tsx
+++ b/src/app/mindroom/threads/MindroomRoomTimeline.tsx
@@ -298,6 +298,7 @@ export function RoomTimeline({
     viewMode,
   });
   const showThreadRepliesInRoom = effectiveViewMode === 'classic';
+  const roomEagerPreloadEnabled = !threadId && !eventId && effectiveViewMode !== 'classic';
   const showThreadBadgesInRoom = effectiveViewMode !== 'classic';
   const [hideMembershipEvents] = useSetting(settingsAtom, 'hideMembershipEvents');
   const [hideNickAvatarEvents] = useSetting(settingsAtom, 'hideNickAvatarEvents');
@@ -380,7 +381,7 @@ export function RoomTimeline({
   const [focusItem, setFocusItem] = useState<RoomTimelineFocusItem | undefined>();
   const [threadLoadError, setThreadLoadError] = useState(false);
   const [roomHasMoreCachedBack, setRoomHasMoreCachedBack] = useState(false);
-  const [eagerPreloading, setEagerPreloading] = useState(!threadId && !eventId);
+  const [eagerPreloading, setEagerPreloading] = useState(roomEagerPreloadEnabled);
   const [roomInitialCacheHydratedKey, setRoomInitialCacheHydratedKey] = useState<
     string | undefined
   >();
@@ -472,9 +473,9 @@ export function RoomTimeline({
   // useLayoutEffect so the reset fires before paint, preventing a single-frame skeleton flash
   useLayoutEffect(() => {
     if (!eventId && !threadId) {
-      setEagerPreloading(true);
+      setEagerPreloading(roomEagerPreloadEnabled);
     }
-  }, [eventId, threadId]);
+  }, [eventId, roomEagerPreloadEnabled, threadId]);
   useLayoutEffect(() => {
     if (prevShowThreadRepliesInRoomRef.current === showThreadRepliesInRoom) return;
     prevShowThreadRepliesInRoomRef.current = showThreadRepliesInRoom;
@@ -814,6 +815,7 @@ export function RoomTimeline({
 
   useRoomEagerPreload({
     alive,
+    enabled: roomEagerPreloadEnabled,
     eventId,
     eagerPreloadDoneForRoomRef,
     mx,
@@ -999,7 +1001,10 @@ export function RoomTimeline({
     }
 
     const virtualIndex = anchor.item - activeTimelineRange.start;
-    const offset = Math.max(virtualIndex * estimateRoomTimelineItemSize() - anchor.viewportOffset, 0);
+    const offset = Math.max(
+      virtualIndex * estimateRoomTimelineItemSize() - anchor.viewportOffset,
+      0
+    );
     roomTimelineVirtualizer.scrollToOffset(offset, { behavior: 'auto' });
     roomVirtualPrependAnchorRef.current = undefined;
 

--- a/src/app/mindroom/threads/preloadController.ts
+++ b/src/app/mindroom/threads/preloadController.ts
@@ -2,10 +2,7 @@ import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } 
 import { Direction, type MatrixClient, type Room } from 'matrix-js-sdk';
 import to from 'await-to-js';
 import { decryptAllTimelineEvent } from '../../utils/room';
-import {
-  getRoomPreloadCounts,
-  getRenderableEvents,
-} from './roomTimelineEvents';
+import { getRoomPreloadCounts, getRenderableEvents } from './roomTimelineEvents';
 import { logTimelineDebug } from './timelineDebug';
 import {
   getLinkedTimelines,
@@ -19,6 +16,7 @@ import {
 
 type RoomEagerPreloadOptions = {
   alive: () => boolean;
+  enabled: boolean;
   eventId?: string;
   eagerPreloadDoneForRoomRef: MutableRefObject<string | null>;
   mx: MatrixClient;
@@ -37,6 +35,7 @@ type RoomEagerPreloadOptions = {
 
 export const useRoomEagerPreload = ({
   alive,
+  enabled,
   eventId,
   eagerPreloadDoneForRoomRef,
   mx,
@@ -53,6 +52,10 @@ export const useRoomEagerPreload = ({
   useSurfacePreloadTarget,
 }: RoomEagerPreloadOptions): void => {
   useEffect(() => {
+    if (!enabled) {
+      setEagerPreloading(false);
+      return undefined;
+    }
     if (threadId || eventId) return undefined;
     if (eagerPreloadDoneForRoomRef.current === room.roomId) {
       // Cache hydration still needs to reset timeline.range before the loading flag clears.
@@ -292,6 +295,7 @@ export const useRoomEagerPreload = ({
     };
   }, [
     alive,
+    enabled,
     eventId,
     eagerPreloadDoneForRoomRef,
     mx,


### PR DESCRIPTION
## Summary

- Reproduced the Classic view large-room loading jump in a real browser before changing code.
- Added a Docker Matrix e2e regression that opens a 700-message Classic room, slows room back-pagination, and samples idle scroll stability.
- Disabled passive room eager preload for Classic view so it renders the latest transcript window and loads older history through the existing user-driven pagination path.

## Validation

- Red browser reproduction: 2600-message Classic room jumped from `message 2593` to `message 2578` while delayed `/messages` back-pagination ran.
- Red check: `E2E_ENABLE_DEPLOYED_FIXTURE=0 npm run test:e2e:docker-matrix -- e2e/live/cinny077-classic-large-room-scroll.spec.ts` failed before the fix.
- Green check: `E2E_ENABLE_DEPLOYED_FIXTURE=0 npm run test:e2e:docker-matrix -- e2e/live/cinny077-classic-large-room-scroll.spec.ts`.
- Green check: `npm test -- src/app/mindroom/threads/roomPreloadTarget.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts`.
- Green check: `npm run typecheck`.
- Green check: `npm run lint` with existing warning-only baseline (`16` warnings, `0` errors).
- Green check: `npm test` passed (`276` files, `2054` tests).
- Green check: `npm run build` passed with existing Vite runtime-config/sourcemap/chunk-size warnings.

Note: I did not run the full Docker Matrix e2e suite after this change; only the focused new e2e regression.

## Summary by Sourcery

Improve scroll stability when opening large rooms in Classic view by disabling passive eager preload and adding regression coverage.

New Features:
- Add a Playwright Docker Matrix e2e test to verify scroll stability when loading a large Classic room.

Bug Fixes:
- Prevent scroll position and first visible message from jumping while back-pagination loads in large Classic rooms by disabling room eager preload in Classic view.

Enhancements:
- Gate room eager preload behavior behind an explicit flag so it only runs in supported view modes.

Documentation:
- Document the Classic large-room loading scroll stability investigation, root cause, fix, and validation steps in the fork runbook.

Tests:
- Introduce an automated regression test that seeds a large Matrix room, slows back-pagination, and asserts stable scroll position and visible message while the user is idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scroll instability when opening large rooms in classic view mode while content loads.

* **Tests**
  * Added end-to-end test coverage for scroll behavior in large classic rooms during backfill operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/14)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->