### PR TITLE
feat(message-extras): allow safe SVG in HTML extras

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,52 @@
 
 ## Runbook
 
+### Safe SVG in message extras HTML (2026-05-11)
+
+- Status:
+  - Complete.
+- Summary:
+  - Investigated both requested sides. `/srv/mindroom` and `/var/www/cinny` are
+    not mounted in this environment; the available MindRoom server checkout is
+    `/Users/basnijholt/dev/mindroom`, and this Cinny worktree is
+    `/Users/basnijholt/.codex/worktrees/bb45/mindroom-cinny`.
+  - MindRoom server search found no `message_extras` writer/sanitizer in
+    `/Users/basnijholt/dev/mindroom`; its only relevant HTML sanitizer is the
+    general Matrix `formatted_body` sanitizer in
+    `src/mindroom/matrix/message_builder.py`, so the server side did not need a
+    message-extras-specific change in the available checkout.
+  - Cinny message extras HTML sanitization lives in
+    `src/app/mindroom/messages/messageExtrasHtml.ts`; it previously listed
+    `svg` as a non-text tag, so all inline SVG content was discarded before
+    render.
+  - Added a labeled SVG allowlist for geometry/text primitives and direct
+    presentation attributes while keeping SVG script vectors out: script,
+    foreignObject, use, image, animation tags, `href`/`xlink:href`, `style`,
+    and all event handlers remain stripped.
+  - Added sanitizer and render tests covering sparkline/status/diagram SVG plus
+    adversarial SVG payloads.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/mindroom/messages/messageExtrasHtml.ts`
+  - `src/app/mindroom/messages/messageExtrasHtml.test.ts`
+  - `src/app/mindroom/messages/MessageExtrasView.test.ts`
+- Tests and validation:
+  - Red check: `npm test -- src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`
+    failed while `svg` remained stripped.
+  - Green check: `npm test -- src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`.
+  - Green check: `npm run typecheck`.
+  - Green check: `npm run lint` completed with the existing warning-only
+    baseline (`16` warnings, `0` errors).
+  - Green check: `npm test` passed (`276` files, `2057` tests).
+  - Green check: `npm run build` passed with existing Vite
+    runtime-config/sourcemap/chunk-size warnings.
+  - Green check:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/messageExtrasHtml.ts src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`.
+  - Green check: `git diff --check`.
+  - Live browser evidence was not captured in this chat-thread worktree; the
+    sanitizer/render unit tests verify the production render path used by
+    message extras.
+
 ### CINNY-128 - Remove transient planning and completion docs (2026-05-29)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -26,6 +26,32 @@
     and all event handlers remain stripped.
   - Added sanitizer and render tests covering sparkline/status/diagram SVG plus
     adversarial SVG payloads.
+- Review follow-up:
+  - SVG paint and marker attributes now reject external `url(...)`,
+    `javascript:` URL references, and `data:` URL references while preserving
+    internal fragment marker references such as `url(#arrow)`.
+  - Restored sanitize-html's default case-insensitive HTML parsing so uppercase
+    HTML attributes like `HREF` are normalized safely, then explicitly restores
+    only the SVG camelCase attributes needed for `viewBox` and marker geometry.
+  - SVG class allowlisting now accepts only simple identifier-like class tokens
+    instead of any class string.
+- Risks:
+  - `title` and `desc` are allowed as inert text labels because sanitize-html
+    does not enforce SVG-only parent context; they may also survive outside SVG,
+    but without scripting or external-resource attributes.
+  - SVG paint values still allow plain colors, `none`, `currentColor`, and
+    internal fragment `url(#...)` references; future support for richer CSS-like
+    paint syntax should add value-level tests before broadening this list.
+  - MindRoom server-side message-extras sanitization could not be changed in
+    this worktree because the mounted server checkout did not contain the
+    described writer path.
+- Next steps:
+  - Owner: PR reviewer verifies the production deployment path for Cinny uses
+    this sanitizer before rendering message extras.
+  - Owner: MindRoom server maintainer applies the same SVG allowlist server-side
+    if the message-extras sanitizer exists in a private or different checkout.
+  - Owner: product/agent workflow owner captures live lab evidence after this PR
+    is deployed to the lab Cinny build.
 - Files changed:
   - `FORK_CHANGES.md`
   - `src/app/mindroom/messages/messageExtrasHtml.ts`
@@ -47,6 +73,19 @@
   - Live browser evidence was not captured in this chat-thread worktree; the
     sanitizer/render unit tests verify the production render path used by
     message extras.
+  - Review red check: focused sanitizer tests failed before follow-up fixes for
+    uppercase `HREF`, marker geometry attributes, and external SVG `url(...)`
+    references.
+  - Review green check: `npm test -- src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`.
+  - Review green check:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/messageExtrasHtml.ts src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`.
+  - Review green check: `npm run typecheck`.
+  - Review green check: `npm run lint` completed with the existing warning-only
+    baseline (`16` warnings, `0` errors).
+  - Review green check: `npm test` passed (`276` files, `2057` tests).
+  - Review green check: `npm run build` passed with existing Vite
+    runtime-config/sourcemap/chunk-size warnings.
+  - Review green check: `git diff --check`.
 
 ### CINNY-128 - Remove transient planning and completion docs (2026-05-29)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -5,7 +5,7 @@
 ### Safe SVG in message extras HTML (2026-05-11)
 
 - Status:
-  - Complete.
+  - Complete; rebased onto `origin/dev` at `be494836` on 2026-05-29.
 - Summary:
   - Investigated both requested sides. `/srv/mindroom` and `/var/www/cinny` are
     not mounted in this environment; the available MindRoom server checkout is
@@ -37,6 +37,12 @@
     instead of any class string.
   - `preserveAspectRatio` is now preserved with explicit camelCase restoration
     so safe charts and diagrams can control viewport scaling.
+- Rebase follow-up:
+  - Replayed the three PR #15 safe-SVG commits onto the latest `origin/dev`
+    after the v4.12.2 MindRoom history rewrite.
+  - Resolved `FORK_CHANGES.md` conflicts by preserving the newer v4.12.2
+    runbook entries and carrying forward the safe-SVG implementation, review,
+    and validation notes.
 - Risks:
   - `title` and `desc` are allowed as inert text labels because sanitize-html
     does not enforce SVG-only parent context; they may also survive outside SVG,
@@ -95,6 +101,16 @@
   - Final review green check: `npm run lint` completed with the existing
     warning-only baseline (`16` warnings, `0` errors).
   - Final review green check: `git diff --check`.
+  - Rebase green check: `npm ci`.
+  - Rebase green check:
+    `npm test -- src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`
+    (2 files, 22 tests).
+  - Rebase green check: `npm run typecheck`.
+  - Rebase green check: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Rebase green check: `npm run build` (existing Vite runtime-config,
+    sourcemap, and chunk-size warnings only).
+  - Rebase green check: `npm test` (299 files, 2233 tests).
 
 ### CINNY-128 - Remove transient planning and completion docs (2026-05-29)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -35,6 +35,8 @@
     only the SVG camelCase attributes needed for `viewBox` and marker geometry.
   - SVG class allowlisting now accepts only simple identifier-like class tokens
     instead of any class string.
+  - `preserveAspectRatio` is now preserved with explicit camelCase restoration
+    so safe charts and diagrams can control viewport scaling.
 - Risks:
   - `title` and `desc` are allowed as inert text labels because sanitize-html
     does not enforce SVG-only parent context; they may also survive outside SVG,
@@ -86,6 +88,13 @@
   - Review green check: `npm run build` passed with existing Vite
     runtime-config/sourcemap/chunk-size warnings.
   - Review green check: `git diff --check`.
+  - Final review green check: `npm test -- src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`.
+  - Final review green check:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/messageExtrasHtml.ts src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`.
+  - Final review green check: `npm run typecheck`.
+  - Final review green check: `npm run lint` completed with the existing
+    warning-only baseline (`16` warnings, `0` errors).
+  - Final review green check: `git diff --check`.
 
 ### CINNY-128 - Remove transient planning and completion docs (2026-05-29)
 

--- a/src/app/mindroom/messages/MessageExtrasView.test.ts
+++ b/src/app/mindroom/messages/MessageExtrasView.test.ts
@@ -306,6 +306,34 @@ describe('MindroomMessageExtras', () => {
     renderer.unmount();
   });
 
+  it('renders sanitized text/html SVG sections as React SVG elements', () => {
+    const renderer = create(
+      React.createElement(MindroomMessageExtras, {
+        extras: createExtras(
+          [
+            section({
+              contentType: 'text/html',
+              content:
+                '<svg viewBox="0 0 200 40"><polyline fill="none" stroke="#7d5fff" points="0,30 50,10 100,20 150,5 200,15"/></svg>',
+            }),
+          ],
+          2
+        ),
+        htmlReactParserOptions: {},
+      })
+    );
+
+    const svg = renderer.root.findByType('svg');
+    const polyline = renderer.root.findByType('polyline');
+
+    expect(svg.props.viewBox).toBe('0 0 200 40');
+    expect(polyline.props.fill).toBe('none');
+    expect(polyline.props.stroke).toBe('#7d5fff');
+    expect(polyline.props.points).toBe('0,30 50,10 100,20 150,5 200,15');
+
+    renderer.unmount();
+  });
+
   it('removes sender-owned disclosure controls from text/html sections', () => {
     const renderer = create(
       React.createElement(MindroomMessageExtras, {

--- a/src/app/mindroom/messages/messageExtrasHtml.test.ts
+++ b/src/app/mindroom/messages/messageExtrasHtml.test.ts
@@ -36,7 +36,7 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
 
   it('keeps safe inline SVG primitives for charts, badges, and diagrams', () => {
     const sanitized = sanitizeMindroomMessageExtraHtml(`
-      <svg viewBox="0 0 200 40" class="sparkline">
+      <svg viewBox="0 0 200 40" preserveAspectRatio="none" class="sparkline">
         <title>Sparkline</title>
         <desc>Recent status trend</desc>
         <polyline fill="none" stroke="#7d5fff" points="0,30 50,10 100,20 150,5 200,15"></polyline>
@@ -58,7 +58,9 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
       </svg>
     `);
 
-    expect(sanitized).toContain('<svg viewBox="0 0 200 40" class="sparkline">');
+    expect(sanitized).toContain(
+      '<svg viewBox="0 0 200 40" preserveAspectRatio="none" class="sparkline">'
+    );
     expect(sanitized).toContain(
       '<polyline fill="none" stroke="#7d5fff" points="0,30 50,10 100,20 150,5 200,15"></polyline>'
     );

--- a/src/app/mindroom/messages/messageExtrasHtml.test.ts
+++ b/src/app/mindroom/messages/messageExtrasHtml.test.ts
@@ -30,6 +30,87 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
     );
   });
 
+  it('keeps safe inline SVG primitives for charts, badges, and diagrams', () => {
+    const sanitized = sanitizeMindroomMessageExtraHtml(`
+      <svg viewBox="0 0 200 40" class="sparkline">
+        <title>Sparkline</title>
+        <desc>Recent status trend</desc>
+        <polyline fill="none" stroke="#7d5fff" points="0,30 50,10 100,20 150,5 200,15"></polyline>
+      </svg>
+      <svg width="80" height="20">
+        <rect width="80" height="20" rx="3" fill="#28a745"></rect>
+        <text x="40" y="14" text-anchor="middle" fill="white" font-size="11">passing</text>
+      </svg>
+      <svg viewBox="0 0 120 60">
+        <defs><marker id="arrow" markerWidth="6" markerHeight="6"><path d="M0,0 L6,3 L0,6 z" fill="currentColor"></path></marker></defs>
+        <g transform="translate(4 4)" opacity="0.9">
+          <rect x="0" y="0" width="42" height="20" ry="2" stroke="black" fill="none"></rect>
+          <line x1="44" y1="10" x2="78" y2="10" marker-end="url(#arrow)" stroke="black"></line>
+          <circle cx="98" cy="10" r="8" fill="#7d5fff"></circle>
+          <ellipse cx="20" cy="44" rx="16" ry="8" fill="none" stroke="black"></ellipse>
+          <polygon points="80,36 106,44 80,52" fill="#28a745"></polygon>
+          <text x="21" y="14"><tspan font-weight="700">API</tspan></text>
+        </g>
+      </svg>
+    `);
+
+    expect(sanitized).toContain('<svg viewBox="0 0 200 40" class="sparkline">');
+    expect(sanitized).toContain(
+      '<polyline fill="none" stroke="#7d5fff" points="0,30 50,10 100,20 150,5 200,15"></polyline>'
+    );
+    expect(sanitized).toContain('<rect width="80" height="20" rx="3" fill="#28a745"></rect>');
+    expect(sanitized).toContain(
+      '<text x="40" y="14" text-anchor="middle" fill="white" font-size="11">passing</text>'
+    );
+    expect(sanitized).toContain('<defs><marker id="arrow">');
+    expect(sanitized).toContain(
+      '<line x1="44" y1="10" x2="78" y2="10" marker-end="url(#arrow)" stroke="black"></line>'
+    );
+    expect(sanitized).toContain('<tspan font-weight="700">API</tspan>');
+  });
+
+  it('strips SVG script vectors while keeping safe SVG siblings', () => {
+    const sanitized = sanitizeMindroomMessageExtraHtml(`
+      <svg onload="alert(1)" style="background:url(javascript:alert(1))" href="javascript:alert(1)" xlink:href="https://evil.example/x.svg#bad">
+        <script>alert(1)</script>
+        <circle cx="50" cy="50" r="40" onclick="alert(1)" fill="red"></circle>
+        <foreignObject><body><script>alert(1)</script></body></foreignObject>
+        <use href="https://evil.com/x.svg#bad"></use>
+        <image href="https://tracker.example/pixel.png"></image>
+        <animate attributeName="href" values="javascript:alert(1)"></animate>
+        <animateTransform attributeName="transform" type="rotate" from="0" to="360"></animateTransform>
+        <animateMotion path="M0,0 L10,10"></animateMotion>
+        <set attributeName="href" to="javascript:alert(1)"></set>
+        <a href="javascript:alert(1)"><text>click</text></a>
+      </svg>
+    `);
+
+    expect(sanitized).toContain('<svg>');
+    expect(sanitized).toContain('<circle cx="50" cy="50" r="40" fill="red"></circle>');
+    expect(sanitized).toContain('<text>click</text>');
+    for (const forbidden of [
+      'onload',
+      'onclick',
+      'style=',
+      'href=',
+      'xlink:href',
+      '<script',
+      'alert(1)',
+      '<foreignObject',
+      '<body',
+      '<use',
+      '<image',
+      '<animate',
+      '<animateTransform',
+      '<animateMotion',
+      '<set',
+      'tracker.example',
+      'evil.com',
+    ]) {
+      expect(sanitized).not.toContain(forbidden);
+    }
+  });
+
   it('removes executable, embed, form, media, metadata, reply, and image surfaces', () => {
     const sanitized = sanitizeMindroomMessageExtraHtml(`
       <script>window.__mindroomExtrasXss = true</script>
@@ -38,7 +119,6 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
       <object data="https://example.test"></object>
       <embed src="https://example.test">
       <form><input value="x"><button>submit</button><select><option>one</option></select><textarea>text</textarea></form>
-      <svg><circle></circle></svg>
       <math><mi>x</mi></math>
       <canvas>draw</canvas>
       <audio src="x"></audio><video src="x"><source src="x"><track src="x"></video>
@@ -60,7 +140,6 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
       'select',
       'textarea',
       'option',
-      'svg',
       'math',
       'canvas',
       'audio',

--- a/src/app/mindroom/messages/messageExtrasHtml.test.ts
+++ b/src/app/mindroom/messages/messageExtrasHtml.test.ts
@@ -12,6 +12,7 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
       <table><caption>Rows</caption><thead><tr><th>Name</th></tr></thead><tbody><tr><td>ok</td></tr></tbody></table>
       <pre class="language-js"><code>const value = 1;</code></pre>
       <a href="https://example.test/path?q=1" target="_self" rel="opener">link</a>
+      <a HREF="https://example.test/caps">caps</a>
       <a href="mailto:user@example.test">mail</a>
     `);
 
@@ -24,6 +25,9 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
     expect(sanitized).toContain('<pre class="language-js">');
     expect(sanitized).toContain(
       '<a href="https://example.test/path?q=1" target="_blank" rel="noreferrer noopener">link</a>'
+    );
+    expect(sanitized).toContain(
+      '<a href="https://example.test/caps" target="_blank" rel="noreferrer noopener">caps</a>'
     );
     expect(sanitized).toContain(
       '<a href="mailto:user@example.test" target="_blank" rel="noreferrer noopener">mail</a>'
@@ -42,7 +46,7 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
         <text x="40" y="14" text-anchor="middle" fill="white" font-size="11">passing</text>
       </svg>
       <svg viewBox="0 0 120 60">
-        <defs><marker id="arrow" markerWidth="6" markerHeight="6"><path d="M0,0 L6,3 L0,6 z" fill="currentColor"></path></marker></defs>
+        <defs><marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L6,3 L0,6 z" fill="currentColor"></path></marker></defs>
         <g transform="translate(4 4)" opacity="0.9">
           <rect x="0" y="0" width="42" height="20" ry="2" stroke="black" fill="none"></rect>
           <line x1="44" y1="10" x2="78" y2="10" marker-end="url(#arrow)" stroke="black"></line>
@@ -62,7 +66,9 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
     expect(sanitized).toContain(
       '<text x="40" y="14" text-anchor="middle" fill="white" font-size="11">passing</text>'
     );
-    expect(sanitized).toContain('<defs><marker id="arrow">');
+    expect(sanitized).toContain(
+      '<defs><marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="strokeWidth">'
+    );
     expect(sanitized).toContain(
       '<line x1="44" y1="10" x2="78" y2="10" marker-end="url(#arrow)" stroke="black"></line>'
     );
@@ -71,9 +77,9 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
 
   it('strips SVG script vectors while keeping safe SVG siblings', () => {
     const sanitized = sanitizeMindroomMessageExtraHtml(`
-      <svg onload="alert(1)" style="background:url(javascript:alert(1))" href="javascript:alert(1)" xlink:href="https://evil.example/x.svg#bad">
+      <svg class="safe bad@class -bad" onload="alert(1)" style="background:url(javascript:alert(1))" href="javascript:alert(1)" xlink:href="https://evil.example/x.svg#bad">
         <script>alert(1)</script>
-        <circle cx="50" cy="50" r="40" onclick="alert(1)" fill="red"></circle>
+        <circle cx="50" cy="50" r="40" onclick="alert(1)" fill="red" stroke="url(https://tracker.example/stroke.svg#paint)"></circle>
         <foreignObject><body><script>alert(1)</script></body></foreignObject>
         <use href="https://evil.com/x.svg#bad"></use>
         <image href="https://tracker.example/pixel.png"></image>
@@ -82,12 +88,15 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
         <animateMotion path="M0,0 L10,10"></animateMotion>
         <set attributeName="href" to="javascript:alert(1)"></set>
         <a href="javascript:alert(1)"><text>click</text></a>
+        <path d="M0,0 L1,1" fill="url(https://tracker.example/fill.svg#paint)" marker-start="url(javascript:alert(1))" marker-mid="url(data:image/svg+xml;base64,PHN2Zy8+)" marker-end="url(#safe)"></path>
       </svg>
     `);
 
-    expect(sanitized).toContain('<svg>');
+    expect(sanitized).toContain('<svg class="safe">');
     expect(sanitized).toContain('<circle cx="50" cy="50" r="40" fill="red"></circle>');
+    expect(sanitized).toContain('<path d="M0,0 L1,1" marker-end="url(#safe)"></path>');
     expect(sanitized).toContain('<text>click</text>');
+    const normalized = sanitized.toLowerCase();
     for (const forbidden of [
       'onload',
       'onclick',
@@ -96,7 +105,7 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
       'xlink:href',
       '<script',
       'alert(1)',
-      '<foreignObject',
+      '<foreignobject',
       '<body',
       '<use',
       '<image',
@@ -106,8 +115,13 @@ describe('sanitizeMindroomMessageExtraHtml', () => {
       '<set',
       'tracker.example',
       'evil.com',
+      'url(https:',
+      'url(javascript:',
+      'url(data:',
+      'bad@class',
+      '-bad',
     ]) {
-      expect(sanitized).not.toContain(forbidden);
+      expect(normalized).not.toContain(forbidden.toLowerCase());
     }
   });
 

--- a/src/app/mindroom/messages/messageExtrasHtml.ts
+++ b/src/app/mindroom/messages/messageExtrasHtml.ts
@@ -66,6 +66,7 @@ const svgMixedCaseAttributeNames: Record<string, string> = {
   markerheight: 'markerHeight',
   markerunits: 'markerUnits',
   markerwidth: 'markerWidth',
+  preserveaspectratio: 'preserveAspectRatio',
   refx: 'refX',
   refy: 'refY',
   viewbox: 'viewBox',
@@ -112,6 +113,7 @@ const svgAttributes = [
   'refY',
   'orient',
   'markerUnits',
+  'preserveAspectRatio',
   'id',
   'class',
 ];

--- a/src/app/mindroom/messages/messageExtrasHtml.ts
+++ b/src/app/mindroom/messages/messageExtrasHtml.ts
@@ -42,6 +42,92 @@ const allowedTags = [
   'a',
 ];
 
+const svgTags = [
+  'svg',
+  'g',
+  'defs',
+  'marker',
+  'path',
+  'rect',
+  'circle',
+  'ellipse',
+  'line',
+  'polyline',
+  'polygon',
+  'text',
+  'tspan',
+  'title',
+  'desc',
+];
+
+const svgAttributes = [
+  'viewBox',
+  'width',
+  'height',
+  'x',
+  'y',
+  'x1',
+  'y1',
+  'x2',
+  'y2',
+  'cx',
+  'cy',
+  'r',
+  'rx',
+  'ry',
+  'd',
+  'points',
+  'fill',
+  'stroke',
+  'stroke-width',
+  'stroke-linecap',
+  'stroke-linejoin',
+  'stroke-dasharray',
+  'opacity',
+  'fill-opacity',
+  'stroke-opacity',
+  'transform',
+  'text-anchor',
+  'dominant-baseline',
+  'font-size',
+  'font-family',
+  'font-weight',
+  'marker-end',
+  'marker-start',
+  'marker-mid',
+  'id',
+  'class',
+];
+
+const allowedSvgAttributes = Object.fromEntries(
+  svgTags.map((tag) => [tag, svgAttributes])
+) as Record<string, string[]>;
+
+const allowedSvgClasses = Object.fromEntries(svgTags.map((tag) => [tag, [/.+/]])) as Record<
+  string,
+  RegExp[]
+>;
+
+const svgTransformTags = Object.fromEntries(svgTags.map((tag) => [tag, transformSvgTag])) as Record<
+  string,
+  Transformer
+>;
+
+const forbiddenSvgTags = [
+  'foreignObject',
+  'foreignobject',
+  'use',
+  'image',
+  'animate',
+  'animateTransform',
+  'animatetransform',
+  'animateMotion',
+  'animatemotion',
+  'set',
+];
+
+const forbiddenSvgAttributes = new Set(['href', 'xlink:href', 'style']);
+
 const nonTextTags = [
   'script',
   'style',
@@ -54,7 +140,6 @@ const nonTextTags = [
   'select',
   'textarea',
   'option',
-  'svg',
   'math',
   'canvas',
   'audio',
@@ -75,6 +160,7 @@ const nonTextTags = [
   'plan',
   'analysis',
   'research',
+  ...forbiddenSvgTags,
 ];
 
 const hasRawWhitespace = (value: string): boolean => /\s/.test(value);
@@ -112,14 +198,31 @@ const transformAnchorTag: Transformer = (tagName, attribs) => {
   };
 };
 
+function transformSvgTag(tagName: string, attribs: Attributes) {
+  const sanitizedAttributes = Object.fromEntries(
+    Object.entries(attribs).filter(([attrName]) => {
+      const normalizedAttrName = attrName.toLowerCase();
+      return (
+        !normalizedAttrName.startsWith('on') && !forbiddenSvgAttributes.has(normalizedAttrName)
+      );
+    })
+  );
+
+  return {
+    tagName,
+    attribs: sanitizedAttributes as Attributes,
+  };
+}
+
 export const sanitizeMindroomMessageExtraHtml = (html: string): string =>
   sanitizeHtml(html, {
-    allowedTags,
+    allowedTags: [...allowedTags, ...svgTags],
     allowedAttributes: {
       a: ['href', 'target', 'rel'],
       ol: ['start', 'type'],
       code: ['class'],
       pre: ['class'],
+      ...allowedSvgAttributes,
     },
     disallowedTagsMode: 'discard',
     allowedSchemes: ['http', 'https', 'mailto'],
@@ -131,10 +234,15 @@ export const sanitizeMindroomMessageExtraHtml = (html: string): string =>
     allowedClasses: {
       code: ['language-*'],
       pre: ['language-*'],
+      ...allowedSvgClasses,
     },
     transformTags: {
       a: transformAnchorTag,
+      ...svgTransformTags,
     },
     nonTextTags,
     nestingLimit: MAX_TAG_NESTING,
+    parser: {
+      lowerCaseAttributeNames: false,
+    },
   });

--- a/src/app/mindroom/messages/messageExtrasHtml.ts
+++ b/src/app/mindroom/messages/messageExtrasHtml.ts
@@ -42,6 +42,8 @@ const allowedTags = [
   'a',
 ];
 
+// sanitize-html does not track SVG parent context. title/desc are kept as inert
+// text labels for accessible inline SVG, and remain inert if they appear outside SVG.
 const svgTags = [
   'svg',
   'g',
@@ -59,6 +61,15 @@ const svgTags = [
   'title',
   'desc',
 ];
+
+const svgMixedCaseAttributeNames: Record<string, string> = {
+  markerheight: 'markerHeight',
+  markerunits: 'markerUnits',
+  markerwidth: 'markerWidth',
+  refx: 'refX',
+  refy: 'refY',
+  viewbox: 'viewBox',
+};
 
 const svgAttributes = [
   'viewBox',
@@ -95,6 +106,12 @@ const svgAttributes = [
   'marker-end',
   'marker-start',
   'marker-mid',
+  'markerWidth',
+  'markerHeight',
+  'refX',
+  'refY',
+  'orient',
+  'markerUnits',
   'id',
   'class',
 ];
@@ -103,10 +120,11 @@ const allowedSvgAttributes = Object.fromEntries(
   svgTags.map((tag) => [tag, svgAttributes])
 ) as Record<string, string[]>;
 
-const allowedSvgClasses = Object.fromEntries(svgTags.map((tag) => [tag, [/.+/]])) as Record<
-  string,
-  RegExp[]
->;
+const SAFE_SVG_CLASS_PATTERN = /^[A-Za-z_][\w:-]*$/;
+
+const allowedSvgClasses = Object.fromEntries(
+  svgTags.map((tag) => [tag, [SAFE_SVG_CLASS_PATTERN]])
+) as Record<string, RegExp[]>;
 
 const svgTransformTags = Object.fromEntries(svgTags.map((tag) => [tag, transformSvgTag])) as Record<
   string,
@@ -127,6 +145,8 @@ const forbiddenSvgTags = [
 ];
 
 const forbiddenSvgAttributes = new Set(['href', 'xlink:href', 'style']);
+
+const SVG_URL_REFERENCE_PATTERN = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
 
 const nonTextTags = [
   'script',
@@ -199,20 +219,38 @@ const transformAnchorTag: Transformer = (tagName, attribs) => {
 };
 
 function transformSvgTag(tagName: string, attribs: Attributes) {
-  const sanitizedAttributes = Object.fromEntries(
-    Object.entries(attribs).filter(([attrName]) => {
-      const normalizedAttrName = attrName.toLowerCase();
-      return (
-        !normalizedAttrName.startsWith('on') && !forbiddenSvgAttributes.has(normalizedAttrName)
-      );
-    })
-  );
+  const sanitizedAttributes: Attributes = {};
+
+  for (const [attrName, attrValue] of Object.entries(attribs)) {
+    const normalizedAttrName = attrName.toLowerCase();
+    if (normalizedAttrName.startsWith('on') || forbiddenSvgAttributes.has(normalizedAttrName)) {
+      continue;
+    }
+    if (hasUnsafeSvgUrlReference(attrValue)) {
+      continue;
+    }
+    const safeAttrName = svgMixedCaseAttributeNames[normalizedAttrName] ?? attrName;
+    sanitizedAttributes[safeAttrName] = attrValue;
+  }
 
   return {
     tagName,
-    attribs: sanitizedAttributes as Attributes,
+    attribs: sanitizedAttributes,
   };
 }
+
+const hasUnsafeSvgUrlReference = (value: string): boolean => {
+  SVG_URL_REFERENCE_PATTERN.lastIndex = 0;
+  for (
+    let match = SVG_URL_REFERENCE_PATTERN.exec(value);
+    match !== null;
+    match = SVG_URL_REFERENCE_PATTERN.exec(value)
+  ) {
+    const target = (match[1] ?? match[2] ?? match[3] ?? '').trim();
+    if (!target.startsWith('#')) return true;
+  }
+  return false;
+};
 
 export const sanitizeMindroomMessageExtraHtml = (html: string): string =>
   sanitizeHtml(html, {
@@ -242,7 +280,4 @@ export const sanitizeMindroomMessageExtraHtml = (html: string): string =>
     },
     nonTextTags,
     nestingLimit: MAX_TAG_NESTING,
-    parser: {
-      lowerCaseAttributeNames: false,
-    },
   });


### PR DESCRIPTION
## Summary
- Allow safe inline SVG primitives in MindRoom `message_extras` HTML sections so charts, badges, sparklines, and diagrams render without media uploads.
- Keep SVG XSS vectors stripped with explicit handling for script-bearing tags, `foreignObject`, `use`, SVG `image`, animation tags, `href`/`xlink:href`, `style`, and `on*` event handlers.
- Add sanitizer and render coverage for positive SVG examples and adversarial payloads.

## Server/client verification
- Checked the requested server path equivalents available in this environment: `/srv/mindroom` and `/var/www/cinny` were not mounted.
- In `/Users/basnijholt/dev/mindroom`, no `message_extras` writer/sanitizer was present; the only relevant HTML sanitizer found was the general Matrix `formatted_body` sanitizer in `src/mindroom/matrix/message_builder.py`.
- Cinny extras rendering sanitizes through `src/app/mindroom/messages/messageExtrasHtml.ts`, which is the code changed here.

## Test Plan
- [x] `npm test -- src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint` (existing warning-only baseline: 16 warnings, 0 errors)
- [x] `npm test` (276 files, 2057 tests)
- [x] `npm run build` (existing Vite/runtime-config/sourcemap/chunk-size warnings)
- [x] `prettier --check FORK_CHANGES.md src/app/mindroom/messages/messageExtrasHtml.ts src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/messages/MessageExtrasView.test.ts`
- [x] `git diff --check`

## Notes
- Live browser screenshot evidence was not captured in this chat-thread worktree; the added render test covers the production message extras render path directly.

## Summary by Sourcery

Allow inline SVG primitives in Mindroom message extras HTML while maintaining strict sanitization against SVG-based XSS vectors.

New Features:
- Enable rendering of safe inline SVG geometry and text primitives in message extras HTML so charts, badges, and diagrams can be embedded without uploads.

Bug Fixes:
- Prevent SVG-based XSS vectors in message extras by disallowing dangerous SVG tags, attributes, and event handlers while still permitting safe SVG content.

Enhancements:
- Extend the HTML sanitizer configuration for message extras to treat SVG as allowed content with a constrained attribute and class allowlist.
- Verify that sanitized SVG content is correctly rendered as React SVG elements in the message extras view.

Documentation:
- Document the SVG sanitization and rendering behavior for message extras in the fork runbook.

Tests:
- Add sanitizer tests covering safe SVG examples and adversarial SVG payloads for message extras HTML.
- Add a render test ensuring sanitized SVG sections are parsed and rendered as React SVG elements in the message extras view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safely render a limited set of inline SVG in message-extras HTML: preserve safe geometry/text primitives and selected attributes, strip scripting/embedding vectors and external/unsafe URL references while allowing internal fragment references.

* **Tests**
  * Added tests for SVG sanitization, uppercase HREF normalization to safe links, preservation of allowed elements/attributes, and removal of scripts, event handlers, unsafe URLs and malformed class tokens.

* **Documentation**
  * Added a dated runbook entry documenting the SVG sanitization policy, validation steps, risks, and follow-ups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->