### PR TITLE
fix(ios-auth): use native web auth for SSO

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,57 @@
 
 ## Runbook
 
+### CINNY-092 - Welcome setup prompt for unpaired Local MindRoom (2026-05-15)
+
+- Status:
+  - Complete.
+- Summary:
+  - Added a delayed setup prompt to the welcome page for users with no active
+    Local MindRoom connection after the first-seen grace period reaches one day.
+  - The prompt uses the hosted getting-started flow: initialize config, add
+    provider credentials or Codex auth, generate a Local MindRoom pair code,
+    connect with `uvx mindroom connect`, and run `uvx mindroom run`.
+  - The config init step lists the supported `--provider` presets directly in
+    the welcome instructions.
+  - The pair-code step now includes a direct Local MindRoom settings button
+    instead of telling users to open Settings manually.
+  - WelcomePage queries the existing Local MindRoom connections endpoint and
+    hides the prompt for active linked installations, revoked-only states before
+    the one-day threshold, and provisioning failures.
+  - The one-day timer starts only after the welcome page observes zero active
+    connections, and it resets when an active connection exists.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/mindroom/local-mindroom/mindroom.ts`
+  - `src/app/mindroom/local-mindroom/mindroom.test.ts`
+  - `src/app/pages/client/WelcomePage.tsx`
+  - `src/app/pages/client/WelcomePage.test.ts`
+- Tests and validation:
+  - Red check:
+    `npm test -- src/app/mindroom/local-mindroom/mindroom.test.ts src/app/pages/client/WelcomePage.test.ts`
+    failed while the welcome setup prompt gate and storage key helper did not
+    exist.
+  - Green check:
+    `npm test -- src/app/mindroom/local-mindroom/mindroom.test.ts src/app/pages/client/WelcomePage.test.ts`
+    passed (`15` tests).
+  - Green check: `npm run typecheck`.
+  - Green check:
+    `npx prettier --check src/app/pages/client/WelcomePage.tsx src/app/pages/client/WelcomePage.test.ts src/app/mindroom/local-mindroom/mindroom.ts src/app/mindroom/local-mindroom/mindroom.test.ts`.
+  - Green check: `git diff --check`.
+  - Green check: `npm run lint` (16 warnings, 0 errors - pre-existing
+    baseline).
+  - Green check: `npm run build` passed with existing Vite
+    runtime-config/sourcemap/chunk-size warnings.
+  - Green check: `npm test` passed (`292` files, `2157` tests) with existing
+    `--localstorage-file` and React Router future-flag warnings.
+  - Local dev-server check: `npm start -- --host 127.0.0.1 --port 5174` served
+    `HTTP/1.1 200 OK` via `curl -I`; browser screenshot capture was skipped
+    because the available DevTools browser profile was already locked by another
+    session.
+  - Independent review: second self-review of the final diff found no issues;
+    subagent review was not used because this session was not explicitly
+    authorized to spawn agents.
+
 ### CINNY-091 - Members drawer invite entry point (2026-05-14)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,56 @@
 
 ## Runbook
 
+### CINNY-093 - Native iOS web-auth session for Apple SSO (2026-05-15)
+
+- Status:
+  - In progress.
+- Summary:
+  - Investigating App Review rejection for build `4.11.1 (27)`: Sign in with
+    Apple through the default `mindroom.chat` server did not complete for the
+    reviewer.
+  - Verified `mindroom.chat` advertises Apple SSO and redirects to
+    `appleid.apple.com`, and downloaded the App Review screenshot showing the
+    reviewer remained inside the Apple web auth page.
+  - Added a native Capacitor bridge that uses `ASWebAuthenticationSession` for
+    iOS SSO and returns the `mindroom://auth/...` callback URL directly to the
+    SPA route handler, with the existing SafariViewController path left as a
+    fallback if the native plugin is unavailable.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `ios/App/App/Base.lproj/Main.storyboard`
+  - `ios/App/App/MindRoomAuthPlugin.swift`
+  - `ios/App/App/MindRoomBridgeViewController.swift`
+  - `ios/App/App.xcodeproj/project.pbxproj`
+  - `src/app/pages/auth/SSOLogin.test.ts`
+  - `src/app/mindroom/native/nativeSso.ts`
+  - `src/app/mindroom/native/nativeSso.test.ts`
+  - `src/index.tsx`
+- Tests and validation:
+  - Red check: `npm test -- src/app/mindroom/native/nativeSso.test.ts` failed
+    while the native auth plugin path and reusable callback router did not
+    exist.
+  - Green check: `npm test -- src/app/mindroom/native/nativeSso.test.ts`.
+  - Green check:
+    `npm test -- src/app/pages/auth/SSOLogin.test.ts src/app/mindroom/native/nativeSso.test.ts`.
+  - Green check: `npm run typecheck`.
+  - Green check: `npm run build` passed with existing Vite
+    runtime-config/sourcemap/chunk-size warnings.
+  - Green check: `npx cap sync ios`.
+  - Green check: `npm run appstore:preflight`.
+  - Green check: `npm run lint` (16 warnings, 0 errors - pre-existing
+    baseline).
+  - Green check: `npm test` passed (`292` files, `2161` tests) with existing
+    `--localstorage-file` and React Router future-flag warnings.
+  - Green check: `git diff --check`.
+  - Syntax check:
+    `xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift ios/App/App/MindRoomBridgeViewController.swift`.
+  - Local iOS compile check:
+    `xcodebuild -workspace ios/App/App.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
+    could not run because the local Xcode/CoreSimulator install is out of sync
+    and reports no eligible iOS destinations. Xcode Cloud validation is needed
+    after pushing.
+
 ### CINNY-092 - Welcome setup prompt for unpaired Local MindRoom (2026-05-15)
 
 - Status:

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 		A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */; };
+		C0DEC0DE0000000000000002 /* MindRoomAuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000001 /* MindRoomAuthPlugin.swift */; };
+		C0DEC0DE0000000000000004 /* MindRoomBridgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000003 /* MindRoomBridgeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +31,8 @@
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.release.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.release.xcconfig"; sourceTree = "<group>"; };
+		C0DEC0DE0000000000000001 /* MindRoomAuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindRoomAuthPlugin.swift; sourceTree = "<group>"; };
+		C0DEC0DE0000000000000003 /* MindRoomBridgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindRoomBridgeViewController.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -75,6 +79,8 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				C0DEC0DE0000000000000003 /* MindRoomBridgeViewController.swift */,
+				C0DEC0DE0000000000000001 /* MindRoomAuthPlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -210,6 +216,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				C0DEC0DE0000000000000004 /* MindRoomBridgeViewController.swift in Sources */,
+				C0DEC0DE0000000000000002 /* MindRoomAuthPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -8,10 +8,10 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
     </dependencies>
     <scenes>
-        <!--Bridge View Controller-->
+        <!--MindRoom Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="MindRoomBridgeViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/ios/App/App/MindRoomAuthPlugin.swift
+++ b/ios/App/App/MindRoomAuthPlugin.swift
@@ -1,0 +1,81 @@
+import AuthenticationServices
+import Capacitor
+import UIKit
+
+@objc(MindRoomAuthPlugin)
+public class MindRoomAuthPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticationPresentationContextProviding {
+    public let identifier = "MindRoomAuthPlugin"
+    public let jsName = "MindRoomAuth"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "authenticate", returnType: CAPPluginReturnPromise)
+    ]
+
+    private var authSession: ASWebAuthenticationSession?
+
+    @objc func authenticate(_ call: CAPPluginCall) {
+        guard authSession == nil else {
+            call.reject("An authentication session is already in progress", "AUTH_IN_PROGRESS")
+            return
+        }
+
+        guard let urlString = call.getString("url"),
+              let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme) else {
+            call.reject("Must provide an HTTP(S) authentication URL", "INVALID_URL")
+            return
+        }
+
+        let callbackScheme = call.getString("callbackScheme")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: callbackScheme
+            ) { [weak self] callbackUrl, error in
+                DispatchQueue.main.async {
+                    defer {
+                        self?.authSession = nil
+                    }
+
+                    if let callbackUrl = callbackUrl {
+                        call.resolve(["url": callbackUrl.absoluteString])
+                        return
+                    }
+
+                    if let authError = error as? ASWebAuthenticationSessionError,
+                       authError.code == .canceledLogin {
+                        call.reject("Authentication cancelled", "AUTH_CANCELLED", authError)
+                        return
+                    }
+
+                    call.reject(error?.localizedDescription ?? "Authentication failed", "AUTH_FAILED", error)
+                }
+            }
+
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            self.authSession = session
+
+            if !session.start() {
+                self.authSession = nil
+                call.reject("Unable to start authentication session", "AUTH_START_FAILED")
+            }
+        }
+    }
+
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if let window = bridge?.viewController?.view.window {
+            return window
+        }
+
+        let window = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+
+        return window ?? ASPresentationAnchor()
+    }
+}

--- a/ios/App/App/MindRoomBridgeViewController.swift
+++ b/ios/App/App/MindRoomBridgeViewController.swift
@@ -1,0 +1,9 @@
+import Capacitor
+
+@objc(MindRoomBridgeViewController)
+class MindRoomBridgeViewController: CAPBridgeViewController {
+    override func capacitorDidLoad() {
+        super.capacitorDidLoad()
+        bridge?.registerPluginInstance(MindRoomAuthPlugin())
+    }
+}

--- a/src/app/mindroom/local-mindroom/mindroom.test.ts
+++ b/src/app/mindroom/local-mindroom/mindroom.test.ts
@@ -5,8 +5,10 @@ import {
   getMindroomDocsUrl,
   getMindroomPairingCommand,
   getPairingSecondsRemaining,
+  getWelcomeSetupFirstSeenStorageKey,
   isConnectionRevoked,
   resolveMindroomProvisioningRequest,
+  shouldShowWelcomeSetupPrompt,
 } from './mindroom';
 
 describe('local mindroom helpers', () => {
@@ -78,5 +80,44 @@ describe('local mindroom helpers', () => {
   it('treats active connections as not revoked', () => {
     expect(getConnectionRevokedAt({ id: 'conn-1' })).toBeUndefined();
     expect(isConnectionRevoked({ id: 'conn-1' })).toBe(false);
+  });
+
+  it('scopes welcome setup prompt first-seen storage by user id', () => {
+    expect(getWelcomeSetupFirstSeenStorageKey('@alice:mindroom.chat')).toBe(
+      'mindroom_welcome_setup_first_seen_at::@alice:mindroom.chat'
+    );
+  });
+
+  it('shows welcome setup prompt only after one day without active connections', () => {
+    const firstSeenAtMs = Date.parse('2026-05-13T12:00:00.000Z');
+
+    expect(
+      shouldShowWelcomeSetupPrompt({
+        activeConnectionCount: 0,
+        firstSeenAtMs,
+        nowMs: Date.parse('2026-05-14T12:00:00.000Z'),
+      })
+    ).toBe(true);
+    expect(
+      shouldShowWelcomeSetupPrompt({
+        activeConnectionCount: 0,
+        firstSeenAtMs,
+        nowMs: Date.parse('2026-05-14T11:59:59.000Z'),
+      })
+    ).toBe(false);
+    expect(
+      shouldShowWelcomeSetupPrompt({
+        activeConnectionCount: 1,
+        firstSeenAtMs,
+        nowMs: Date.parse('2026-05-15T12:00:00.000Z'),
+      })
+    ).toBe(false);
+    expect(
+      shouldShowWelcomeSetupPrompt({
+        activeConnectionCount: 0,
+        firstSeenAtMs: undefined,
+        nowMs: Date.parse('2026-05-15T12:00:00.000Z'),
+      })
+    ).toBe(false);
   });
 });

--- a/src/app/mindroom/local-mindroom/mindroom.ts
+++ b/src/app/mindroom/local-mindroom/mindroom.ts
@@ -1,6 +1,7 @@
 import { LocalMindroomConnection } from './api';
 
 export const DEFAULT_MINDROOM_DOCS_URL = 'https://docs.mindroom.chat/';
+const WELCOME_SETUP_PROMPT_DELAY_MS = 24 * 60 * 60 * 1000;
 
 export const getMindroomDocsUrl = (url?: string): string =>
   url?.trim() || DEFAULT_MINDROOM_DOCS_URL;
@@ -40,9 +41,7 @@ export const resolveMindroomProvisioningRequest = ({
   if (!provisioningBaseUrl) return {};
 
   const isCrossOriginOverride =
-    overrideOrigin !== undefined &&
-    sessionOrigin !== undefined &&
-    overrideOrigin !== sessionOrigin;
+    overrideOrigin !== undefined && sessionOrigin !== undefined && overrideOrigin !== sessionOrigin;
 
   if (isCrossOriginOverride) {
     return {
@@ -60,6 +59,24 @@ export const resolveMindroomProvisioningRequest = ({
 
 export const getMindroomPairingCommand = (pairCode: string): string =>
   `uvx mindroom connect --pair-code ${pairCode}`;
+
+export const getWelcomeSetupFirstSeenStorageKey = (userId: string): string =>
+  `mindroom_welcome_setup_first_seen_at::${userId}`;
+
+export type WelcomeSetupPromptState = {
+  activeConnectionCount: number;
+  firstSeenAtMs: number | undefined;
+  nowMs?: number;
+};
+
+export const shouldShowWelcomeSetupPrompt = ({
+  activeConnectionCount,
+  firstSeenAtMs,
+  nowMs = Date.now(),
+}: WelcomeSetupPromptState): boolean =>
+  activeConnectionCount === 0 &&
+  firstSeenAtMs !== undefined &&
+  nowMs - firstSeenAtMs >= WELCOME_SETUP_PROMPT_DELAY_MS;
 
 export const getPairingSecondsRemaining = (
   expiresAt: string,
@@ -82,10 +99,7 @@ export const getConnectionId = (connection: LocalMindroomConnection): string | u
   return undefined;
 };
 
-export const getConnectionName = (
-  connection: LocalMindroomConnection,
-  index: number
-): string => {
+export const getConnectionName = (connection: LocalMindroomConnection, index: number): string => {
   if (typeof connection.client_name === 'string' && connection.client_name.trim()) {
     return connection.client_name;
   }
@@ -97,7 +111,8 @@ export const getConnectionName = (
 };
 
 export const getConnectionCreatedAt = (connection: LocalMindroomConnection): string | undefined => {
-  if (typeof connection.created_at === 'string' && connection.created_at) return connection.created_at;
+  if (typeof connection.created_at === 'string' && connection.created_at)
+    return connection.created_at;
 
   const alt = connection.createdAt;
   if (typeof alt === 'string' && alt) return alt;
@@ -105,7 +120,9 @@ export const getConnectionCreatedAt = (connection: LocalMindroomConnection): str
   return undefined;
 };
 
-export const getConnectionLastSeenAt = (connection: LocalMindroomConnection): string | undefined => {
+export const getConnectionLastSeenAt = (
+  connection: LocalMindroomConnection
+): string | undefined => {
   if (typeof connection.last_seen_at === 'string' && connection.last_seen_at) {
     return connection.last_seen_at;
   }
@@ -116,9 +133,7 @@ export const getConnectionLastSeenAt = (connection: LocalMindroomConnection): st
   return undefined;
 };
 
-export const getConnectionRevokedAt = (
-  connection: LocalMindroomConnection
-): string | undefined => {
+export const getConnectionRevokedAt = (connection: LocalMindroomConnection): string | undefined => {
   const direct = connection.revoked_at;
   if (typeof direct === 'string' && direct) return direct;
 

--- a/src/app/mindroom/native/nativeSso.test.ts
+++ b/src/app/mindroom/native/nativeSso.test.ts
@@ -1,23 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Browser } from '@capacitor/browser';
-import { Capacitor } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
 import {
   buildNativeSsoRedirectUrl,
   getAppPathFromNativeSsoUrl,
   isIOSStandaloneWebApp,
   isNativeIOS,
   openNativeSsoBrowser,
+  routeNativeSsoCallback,
 } from './nativeSso';
+
+const authenticate = vi.fn();
 
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
+    isPluginAvailable: vi.fn(),
     isNativePlatform: vi.fn(),
     getPlatform: vi.fn(),
   },
+  registerPlugin: vi.fn(() => ({
+    authenticate,
+  })),
 }));
 
 vi.mock('@capacitor/browser', () => ({
   Browser: {
+    close: vi.fn(),
     open: vi.fn(),
   },
 }));
@@ -43,8 +51,11 @@ describe('nativeSso', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    authenticate.mockReset();
+    vi.mocked(Capacitor.isPluginAvailable).mockReset();
     vi.mocked(Capacitor.isNativePlatform).mockReset();
     vi.mocked(Capacitor.getPlatform).mockReset();
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(false);
     vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
     vi.mocked(Capacitor.getPlatform).mockReturnValue('web');
     Object.defineProperty(globalThis, 'window', {
@@ -74,9 +85,9 @@ describe('nativeSso', () => {
   });
 
   it('extracts app path from hostless native callback url', () => {
-    expect(
-      getAppPathFromNativeSsoUrl('mindroom:/auth/login/mindroom.chat?loginToken=abc123')
-    ).toBe('/login/mindroom.chat?loginToken=abc123');
+    expect(getAppPathFromNativeSsoUrl('mindroom:/auth/login/mindroom.chat?loginToken=abc123')).toBe(
+      '/login/mindroom.chat?loginToken=abc123'
+    );
   });
 
   it('extracts app path from triple-slash hostless native callback url', () => {
@@ -86,9 +97,9 @@ describe('nativeSso', () => {
   });
 
   it('extracts app path from compact hostless native callback url', () => {
-    expect(
-      getAppPathFromNativeSsoUrl('mindroom:auth/login/mindroom.chat?loginToken=abc123')
-    ).toBe('/login/mindroom.chat?loginToken=abc123');
+    expect(getAppPathFromNativeSsoUrl('mindroom:auth/login/mindroom.chat?loginToken=abc123')).toBe(
+      '/login/mindroom.chat?loginToken=abc123'
+    );
   });
 
   it('normalizes extra slashes in native callback path', () => {
@@ -159,5 +170,71 @@ describe('nativeSso', () => {
       url: 'https://mindroom.chat/_matrix/client/v3/login/sso/redirect',
       presentationStyle: 'fullscreen',
     });
+  });
+
+  it('uses the native iOS web authentication session when available', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.getPlatform).mockReturnValue('ios');
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    authenticate.mockResolvedValue({
+      url: 'mindroom://auth/login/mindroom.chat?loginToken=abc123',
+    });
+    const replaceState = vi.fn();
+    const dispatchEvent = vi.fn();
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        dispatchEvent,
+        history: { replaceState },
+        location: { replace: vi.fn() },
+      },
+    });
+
+    await openNativeSsoBrowser('https://mindroom.chat/_matrix/client/v3/login/sso/redirect');
+
+    expect(registerPlugin).toHaveBeenCalledWith('MindRoomAuth');
+    expect(authenticate).toHaveBeenCalledWith({
+      callbackScheme: 'mindroom',
+      url: 'https://mindroom.chat/_matrix/client/v3/login/sso/redirect',
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/login/mindroom.chat?loginToken=abc123');
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'popstate' }));
+    expect(Browser.open).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the Capacitor browser when the native auth plugin is unavailable', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.getPlatform).mockReturnValue('ios');
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(false);
+    vi.mocked(Browser.open).mockResolvedValue();
+
+    await openNativeSsoBrowser('https://mindroom.chat/_matrix/client/v3/login/sso/redirect');
+
+    expect(authenticate).not.toHaveBeenCalled();
+    expect(Browser.open).toHaveBeenCalledWith({
+      url: 'https://mindroom.chat/_matrix/client/v3/login/sso/redirect',
+      presentationStyle: 'fullscreen',
+    });
+  });
+
+  it('routes native SSO callbacks through the SPA router', () => {
+    const replaceState = vi.fn();
+    const dispatchEvent = vi.fn();
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        dispatchEvent,
+        history: { replaceState },
+        location: { replace: vi.fn() },
+      },
+    });
+
+    expect(routeNativeSsoCallback('mindroom://auth/login/mindroom.chat?loginToken=abc123')).toBe(
+      true
+    );
+
+    expect(Browser.close).toHaveBeenCalled();
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/login/mindroom.chat?loginToken=abc123');
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'popstate' }));
   });
 });

--- a/src/app/mindroom/native/nativeSso.ts
+++ b/src/app/mindroom/native/nativeSso.ts
@@ -1,11 +1,27 @@
 import { Browser } from '@capacitor/browser';
-import { Capacitor } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
 
 const NATIVE_SSO_SCHEME = 'mindroom';
 const NATIVE_SSO_HOST = 'auth';
 type StandaloneNavigator = Navigator & { standalone?: boolean };
+type MindRoomAuthPlugin = {
+  authenticate(options: { url: string; callbackScheme: string }): Promise<{ url?: string }>;
+};
+
+let mindRoomAuthPlugin: MindRoomAuthPlugin | undefined;
 
 const normalizePath = (path: string): string => path.replace(/\/{2,}/g, '/');
+
+const getMindRoomAuthPlugin = (): MindRoomAuthPlugin => {
+  if (!mindRoomAuthPlugin) {
+    mindRoomAuthPlugin = registerPlugin<MindRoomAuthPlugin>('MindRoomAuth');
+  }
+
+  return mindRoomAuthPlugin;
+};
+
+const createPopStateNavigationEvent = (): Event =>
+  typeof PopStateEvent === 'function' ? new PopStateEvent('popstate') : new Event('popstate');
 
 export const buildNativeSsoRedirectUrl = (webRedirectUrl: string): string => {
   const parsed = new URL(webRedirectUrl);
@@ -46,7 +62,36 @@ export const isIOSStandaloneWebApp = (): boolean => {
   return standaloneDisplayMode || (window.navigator as StandaloneNavigator).standalone === true;
 };
 
+export const routeNativeSsoCallback = (incomingUrl: string): boolean => {
+  const appPath = getAppPathFromNativeSsoUrl(incomingUrl);
+  if (!appPath || typeof window === 'undefined') return false;
+
+  Promise.resolve(Browser.close()).catch(() => undefined);
+
+  try {
+    window.history.replaceState(null, '', appPath);
+    window.dispatchEvent(createPopStateNavigationEvent());
+  } catch {
+    window.location.replace(appPath);
+  }
+
+  return true;
+};
+
 export const openNativeSsoBrowser = async (url: string): Promise<void> => {
+  if (isNativeIOS() && Capacitor.isPluginAvailable('MindRoomAuth')) {
+    const result = await getMindRoomAuthPlugin().authenticate({
+      callbackScheme: NATIVE_SSO_SCHEME,
+      url,
+    });
+
+    if (result.url) {
+      routeNativeSsoCallback(result.url);
+    }
+
+    return;
+  }
+
   await Browser.open({ url, presentationStyle: 'fullscreen' });
 };
 

--- a/src/app/pages/auth/SSOLogin.test.ts
+++ b/src/app/pages/auth/SSOLogin.test.ts
@@ -12,47 +12,30 @@ vi.mock('folds', async () => {
   const reactModule = await import('react');
 
   return {
-    Avatar: ({
-      children,
-      ...props
-    }: {
-      children: React.ReactNode;
-      [key: string]: unknown;
-    }) => reactModule.createElement('div', props, children),
+    Avatar: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      reactModule.createElement('div', props, children),
     AvatarImage: () => reactModule.createElement('img'),
-    Box: ({
-      children,
-      ...props
-    }: {
-      children: React.ReactNode;
-      [key: string]: unknown;
-    }) => reactModule.createElement('div', props, children),
-    Button: ({
-      children,
-      ...props
-    }: {
-      children: React.ReactNode;
-      [key: string]: unknown;
-    }) => reactModule.createElement('button', props, children),
-    Text: ({
-      children,
-      ...props
-    }: {
-      children: React.ReactNode;
-      [key: string]: unknown;
-    }) => reactModule.createElement('span', props, children),
+    Box: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      reactModule.createElement('div', props, children),
+    Button: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      reactModule.createElement('button', props, children),
+    Text: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+      reactModule.createElement('span', props, children),
   };
 });
 
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
+    isPluginAvailable: vi.fn(),
     isNativePlatform: vi.fn(),
     getPlatform: vi.fn(),
   },
+  registerPlugin: vi.fn(),
 }));
 
 vi.mock('@capacitor/browser', () => ({
   Browser: {
+    close: vi.fn(),
     open: vi.fn(),
   },
 }));
@@ -66,9 +49,11 @@ vi.mock('../../hooks/useAutoDiscoveryInfo', () => ({
 }));
 
 const findButtonByText = (renderer: ReturnType<typeof create>, text: string) =>
-  renderer.root.findAllByType('button').find((node) =>
-    node.findAllByType('span').some((textNode) => textNode.children.join('') === text)
-  );
+  renderer.root
+    .findAllByType('button')
+    .find((node) =>
+      node.findAllByType('span').some((textNode) => textNode.children.join('') === text)
+    );
 
 describe('SSOLogin', () => {
   const originalWindow = globalThis.window;
@@ -89,6 +74,7 @@ describe('SSOLogin', () => {
     vi.mocked(createMatrixClient).mockReturnValue({
       getSsoLoginUrl: vi.fn(() => 'https://mindroom.chat/_matrix/client/v3/login/sso/redirect'),
     } as never);
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(false);
   });
 
   afterEach(() => {

--- a/src/app/pages/client/WelcomePage.test.ts
+++ b/src/app/pages/client/WelcomePage.test.ts
@@ -1,20 +1,21 @@
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { create } from 'react-test-renderer';
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, create } from 'react-test-renderer';
 import { WelcomePage } from './WelcomePage';
 import { useClientConfig } from '../../hooks/useClientConfig';
+import { useMatrixClient } from '../../hooks/useMatrixClient';
+import { getLocalMindroomConnections } from '../../mindroom/local-mindroom/api';
+import { getWelcomeSetupFirstSeenStorageKey } from '../../mindroom/local-mindroom/mindroom';
+import { LOCAL_MINDROOM_SETTINGS_PAGE } from '../../mindroom/local-mindroom/settingsPage';
+import { settingsModalAtom } from '../../state/settingsModal';
 
 vi.mock('folds', async () => {
   const reactModule = await import('react');
 
   return {
-    Box: ({
-      children,
-      ...props
-    }: {
-      children?: React.ReactNode;
-      [key: string]: unknown;
-    }) => reactModule.createElement('div', props, children),
+    Box: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) =>
+      reactModule.createElement('div', props, children),
     Button: ({
       before,
       children,
@@ -35,13 +36,8 @@ vi.mock('folds', async () => {
       Code: () => null,
       Info: () => null,
     },
-    Text: ({
-      children,
-      ...props
-    }: {
-      children?: React.ReactNode;
-      [key: string]: unknown;
-    }) => reactModule.createElement('span', props, children),
+    Text: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) =>
+      reactModule.createElement('span', props, children),
     toRem: (value: number) => `${value / 16}rem`,
   };
 });
@@ -67,7 +63,78 @@ vi.mock('../../hooks/useClientConfig', () => ({
   useClientConfig: vi.fn(),
 }));
 
+vi.mock('../../hooks/useMatrixClient', () => ({
+  useMatrixClient: vi.fn(),
+}));
+
+vi.mock('../../mindroom/local-mindroom/api', () => ({
+  getLocalMindroomConnections: vi.fn(),
+}));
+
 const useClientConfigMock = vi.mocked(useClientConfig);
+const useMatrixClientMock = vi.mocked(useMatrixClient);
+const getLocalMindroomConnectionsMock = vi.mocked(getLocalMindroomConnections);
+const originalLocalStorage = globalThis.localStorage;
+
+const createStorageMock = (): Storage => {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+};
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: createStorageMock(),
+  });
+  mockClient();
+  getLocalMindroomConnectionsMock.mockResolvedValue({ connections: [{ id: 'conn-1' }] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  localStorage.clear();
+  useClientConfigMock.mockReset();
+  useMatrixClientMock.mockReset();
+  getLocalMindroomConnectionsMock.mockReset();
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: originalLocalStorage,
+  });
+});
+
+const mockClient = () => {
+  useMatrixClientMock.mockReturnValue({
+    getAccessToken: () => 'matrix-token',
+    getHomeserverUrl: () => 'https://mindroom.chat',
+    getSafeUserId: () => '@alice:mindroom.chat',
+  } as ReturnType<typeof useMatrixClient>);
+};
+
+const mockWelcomeConfig = () => {
+  useClientConfigMock.mockReturnValue({
+    sidebar: {
+      mindRoomUrl: 'https://docs.mindroom.chat/',
+    },
+    welcome: {
+      docsUrl: 'https://docs.example.test',
+      docsLabel: 'Docs',
+      sourceUrl: 'https://source.example.test',
+      sourceLabel: 'Source',
+    },
+  });
+};
 
 describe('WelcomePage', () => {
   it('renders docs button when docsUrl is set and icons are safe', () => {
@@ -112,5 +179,99 @@ describe('WelcomePage', () => {
 
     const emptyDocsLinks = renderer.root.findAll((node) => node.props?.href === '');
     expect(emptyDocsLinks.length).toBe(0);
+  });
+
+  it('renders setup instructions after one day without a paired Local MindRoom device', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
+    mockClient();
+    mockWelcomeConfig();
+    localStorage.setItem(
+      getWelcomeSetupFirstSeenStorageKey('@alice:mindroom.chat'),
+      Date.parse('2026-05-14T11:59:59.000Z').toString()
+    );
+    getLocalMindroomConnectionsMock.mockResolvedValue({ connections: [] });
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(React.createElement(WelcomePage));
+    });
+
+    const text = renderer!.root.findAllByType('span').map((node) => node.children.join(' '));
+    expect(text).toContain('Set up Local MindRoom');
+    expect(text).toContain(
+      '1. Run uvx mindroom config init --provider <anthropic|codex|llama.cpp|ollama|openai|openrouter|vertexai_claude>'
+    );
+    expect(text).toContain('2. Add model credentials in ~/.mindroom/.env, or run codex login');
+    expect(text).toContain('3. Click here to open Local MindRoom and generate a pair code');
+    expect(text).toContain('4. Run uvx mindroom connect --pair-code ABCD-EFGH');
+    expect(text).toContain('5. Start it with uvx mindroom run');
+  });
+
+  it('opens Local MindRoom settings from the setup instructions', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
+    mockClient();
+    mockWelcomeConfig();
+    localStorage.setItem(
+      getWelcomeSetupFirstSeenStorageKey('@alice:mindroom.chat'),
+      Date.parse('2026-05-14T11:59:59.000Z').toString()
+    );
+    getLocalMindroomConnectionsMock.mockResolvedValue({ connections: [] });
+    const store = createStore();
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(React.createElement(Provider, { store }, React.createElement(WelcomePage)));
+    });
+
+    const setupButton = renderer!.root.find(
+      (node) => node.props['aria-label'] === 'Open Local MindRoom settings'
+    );
+
+    await act(async () => {
+      setupButton.props.onClick();
+    });
+
+    expect(store.get(settingsModalAtom)).toEqual({
+      initialPage: LOCAL_MINDROOM_SETTINGS_PAGE,
+    });
+  });
+
+  it('does not render setup instructions before the one-day grace period or with a paired device', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
+    mockClient();
+    mockWelcomeConfig();
+    const storageKey = getWelcomeSetupFirstSeenStorageKey('@alice:mindroom.chat');
+    localStorage.setItem(storageKey, Date.parse('2026-05-14T12:00:01.000Z').toString());
+    getLocalMindroomConnectionsMock.mockResolvedValue({ connections: [] });
+
+    let renderer: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(React.createElement(WelcomePage));
+    });
+
+    let setupHeadings = renderer!.root.findAll(
+      (node) => node.children.join(' ') === 'Set up Local MindRoom'
+    );
+    expect(setupHeadings.length).toBe(0);
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+
+    localStorage.setItem(storageKey, Date.parse('2026-05-14T11:59:59.000Z').toString());
+    getLocalMindroomConnectionsMock.mockResolvedValue({ connections: [{ id: 'conn-1' }] });
+
+    await act(async () => {
+      renderer = create(React.createElement(WelcomePage));
+    });
+
+    setupHeadings = renderer!.root.findAll(
+      (node) => node.children.join(' ') === 'Set up Local MindRoom'
+    );
+    expect(setupHeadings.length).toBe(0);
+    expect(localStorage.getItem(storageKey)).toBeNull();
   });
 });

--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -1,18 +1,189 @@
 import React from 'react';
 import { Box, Button, Icon, Icons, Text, config, toRem } from 'folds';
+import { useSetAtom } from 'jotai';
 import { Page, PageHero, PageHeroSection } from '../../components/page';
 import { useClientConfig } from '../../hooks/useClientConfig';
+import { useMatrixClient } from '../../hooks/useMatrixClient';
 import {
   getMindroomWelcomePageContent,
   MINDROOM_CLIENT_BRANDING,
 } from '../../mindroom/branding/clientBranding';
+import { getLocalMindroomConnections } from '../../mindroom/local-mindroom/api';
+import {
+  getWelcomeSetupFirstSeenStorageKey,
+  isConnectionRevoked,
+  resolveMindroomProvisioningRequest,
+  shouldShowWelcomeSetupPrompt,
+} from '../../mindroom/local-mindroom/mindroom';
+import { LOCAL_MINDROOM_SETTINGS_PAGE } from '../../mindroom/local-mindroom/settingsPage';
+import { settingsModalAtom } from '../../state/settingsModal';
 
 const safeIcon = (icon?: (filled?: boolean) => JSX.Element) => icon ?? Icons.Info;
 
+const WELCOME_SETUP_INITIAL_STEPS = [
+  '1. Run uvx mindroom config init --provider <anthropic|codex|llama.cpp|ollama|openai|openrouter|vertexai_claude>',
+  '2. Add model credentials in ~/.mindroom/.env, or run codex login',
+];
+
+const WELCOME_SETUP_FINAL_STEPS = [
+  '4. Run uvx mindroom connect --pair-code ABCD-EFGH',
+  '5. Start it with uvx mindroom run',
+];
+
+const getWelcomeSetupStorage = (): Storage | undefined => {
+  try {
+    if (typeof globalThis.localStorage === 'undefined') return undefined;
+    return globalThis.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+const readFirstSeenAtMs = (storageKey: string): number | undefined => {
+  const storage = getWelcomeSetupStorage();
+  if (typeof storage?.getItem !== 'function') return undefined;
+
+  let stored: string | null;
+  try {
+    stored = storage.getItem(storageKey);
+  } catch {
+    return undefined;
+  }
+  if (!stored) return undefined;
+
+  const firstSeenAtMs = Number(stored);
+  return Number.isFinite(firstSeenAtMs) ? firstSeenAtMs : undefined;
+};
+
+const getOrCreateFirstSeenAtMs = (storageKey: string, nowMs: number): number | undefined => {
+  const firstSeenAtMs = readFirstSeenAtMs(storageKey);
+  if (firstSeenAtMs !== undefined) return firstSeenAtMs;
+  const storage = getWelcomeSetupStorage();
+  if (typeof storage?.setItem !== 'function') return undefined;
+
+  try {
+    storage.setItem(storageKey, nowMs.toString());
+  } catch {
+    return undefined;
+  }
+  return nowMs;
+};
+
+const clearFirstSeenAtMs = (storageKey: string) => {
+  const storage = getWelcomeSetupStorage();
+  if (typeof storage?.removeItem !== 'function') return;
+
+  try {
+    storage.removeItem(storageKey);
+  } catch {
+    // Fail closed if localStorage is unavailable or blocked.
+  }
+};
+
+type WelcomeSetupInstructionsProps = {
+  onOpenLocalMindroomSettings: () => void;
+};
+
+function WelcomeSetupInstructions({ onOpenLocalMindroomSettings }: WelcomeSetupInstructionsProps) {
+  return (
+    <Box
+      direction="Column"
+      gap="200"
+      style={{
+        border: '1px solid rgba(125, 125, 125, 0.28)',
+        borderRadius: '8px',
+        padding: '12px',
+        textAlign: 'left',
+      }}
+    >
+      <Text as="span" size="L400">
+        Set up Local MindRoom
+      </Text>
+      {WELCOME_SETUP_INITIAL_STEPS.map((step) => (
+        <Text key={step} as="span" size="T200" priority="300" style={{ overflowWrap: 'anywhere' }}>
+          {step}
+        </Text>
+      ))}
+      <Button
+        aria-label="Open Local MindRoom settings"
+        fill="Soft"
+        onClick={onOpenLocalMindroomSettings}
+        before={<Icon size="200" src={safeIcon(Icons.Link)} />}
+        style={{ justifyContent: 'flex-start' }}
+      >
+        <Text as="span" size="B300" style={{ overflowWrap: 'anywhere', whiteSpace: 'normal' }}>
+          3. Click here to open Local MindRoom and generate a pair code
+        </Text>
+      </Button>
+      {WELCOME_SETUP_FINAL_STEPS.map((step) => (
+        <Text key={step} as="span" size="T200" priority="300" style={{ overflowWrap: 'anywhere' }}>
+          {step}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
 export function WelcomePage() {
-  const { welcome } = useClientConfig();
+  const mx = useMatrixClient();
+  const setSettingsModal = useSetAtom(settingsModalAtom);
+  const { sidebar, welcome } = useClientConfig();
+  const userId = mx.getSafeUserId();
+  const sessionHomeserverUrl = mx.getHomeserverUrl();
+  const sessionAccessToken = mx.getAccessToken() ?? undefined;
+  const provisioningRequest = React.useMemo(
+    () =>
+      resolveMindroomProvisioningRequest({
+        sessionHomeserverUrl,
+        provisioningOverrideUrl: sidebar?.mindRoomProvisioningUrl,
+        accessToken: sessionAccessToken,
+      }),
+    [sessionAccessToken, sessionHomeserverUrl, sidebar?.mindRoomProvisioningUrl]
+  );
+  const [showSetupInstructions, setShowSetupInstructions] = React.useState(false);
   const { docsLabel, docsUrl, poweredBy, sourceLabel, sourceUrl, subtitle, title } =
     getMindroomWelcomePageContent(welcome);
+  const openLocalMindroomSettings = React.useCallback(() => {
+    setSettingsModal({ initialPage: LOCAL_MINDROOM_SETTINGS_PAGE });
+  }, [setSettingsModal]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const nowMs = Date.now();
+    const storageKey = getWelcomeSetupFirstSeenStorageKey(userId);
+
+    getLocalMindroomConnections(
+      provisioningRequest.accessToken,
+      provisioningRequest.provisioningBaseUrl
+    )
+      .then((result) => {
+        if (cancelled) return;
+        const activeConnectionCount = result.connections.filter(
+          (connection) => !isConnectionRevoked(connection)
+        ).length;
+        if (activeConnectionCount > 0) {
+          clearFirstSeenAtMs(storageKey);
+          setShowSetupInstructions(false);
+          return;
+        }
+
+        const firstSeenAtMs = getOrCreateFirstSeenAtMs(storageKey, nowMs);
+        setShowSetupInstructions(
+          shouldShowWelcomeSetupPrompt({
+            activeConnectionCount,
+            firstSeenAtMs,
+            nowMs,
+          })
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setShowSetupInstructions(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [provisioningRequest.accessToken, provisioningRequest.provisioningBaseUrl, userId]);
 
   return (
     <Page>
@@ -63,6 +234,11 @@ export function WelcomePage() {
                       {docsLabel}
                     </Text>
                   </Button>
+                )}
+                {showSetupInstructions && (
+                  <WelcomeSetupInstructions
+                    onOpenLocalMindroomSettings={openLocalMindroomSettings}
+                  />
                 )}
                 {poweredBy.length > 0 && (
                   <Text size="T300" align="Center">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { enableMapSet } from 'immer';
 import { App as CapacitorApp } from '@capacitor/app';
-import { Browser } from '@capacitor/browser';
 import '@fontsource/inter/variable.css';
 import 'folds/dist/style.css';
 import 'katex/dist/katex.min.css';
@@ -13,7 +12,7 @@ enableMapSet();
 import './index.css';
 
 import { appUrl, ensureBasePathTrailingSlash, getAppBasePath } from './app/utils/basePath';
-import { getAppPathFromNativeSsoUrl, isNativeIOS } from './app/mindroom/native/nativeSso';
+import { isNativeIOS, routeNativeSsoCallback } from './app/mindroom/native/nativeSso';
 import { isServiceWorkerEnabled } from './app/utils/runtimeConfig';
 import { pushSessionToSW, waitForServiceWorkerControl } from './sw-session';
 import { getActiveSession, subscribeToSessionStore } from './app/state/sessions';
@@ -26,18 +25,7 @@ import './app/i18n';
 applyThemeToDom(resolveInitialTheme());
 
 const handleNativeSSOCallback = (url: string) => {
-  const appPath = getAppPathFromNativeSsoUrl(url);
-  if (!appPath) return;
-  // Dismiss the in-app SSO browser once the OAuth callback returns control.
-  Browser.close().catch(() => undefined);
-  try {
-    // Handle SSO callback as an SPA route transition (no full WebView reload),
-    // preventing iOS from treating path params like `mindroom.chat` as file paths.
-    window.history.replaceState(null, '', appPath);
-    window.dispatchEvent(new PopStateEvent('popstate'));
-  } catch {
-    window.location.replace(appPath);
-  }
+  routeNativeSsoCallback(url);
 };
 
 if (isNativeIOS()) {


### PR DESCRIPTION
## Summary
- add the delayed Local MindRoom setup prompt from the original PR
- switch native iOS SSO to ASWebAuthenticationSession so Apple/OIDC callbacks return directly to the SPA
- keep the existing Capacitor Browser path as fallback when the native bridge is unavailable
- add focused coverage for the native auth plugin path and callback router

## Validation
- npm test -- src/app/mindroom/native/nativeSso.test.ts
- npm test -- src/app/pages/auth/SSOLogin.test.ts src/app/mindroom/native/nativeSso.test.ts
- npm run typecheck
- npm run build
- npx cap sync ios
- npm run appstore:preflight
- npm run lint (16 warnings, 0 errors; existing baseline)
- npm test
- git diff --check
- xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift ios/App/App/MindRoomBridgeViewController.swift

Local xcodebuild could not run because this Mac's Xcode/CoreSimulator install reports no eligible iOS destinations; Xcode Cloud should validate the native archive.