### PR TITLE
fix(auth): scope hosted tenant auth policy

### DIFF
--- a/src/app/mindroom/auth/authPolicy.test.ts
+++ b/src/app/mindroom/auth/authPolicy.test.ts
@@ -3,6 +3,7 @@ import {
   isMindroomHomeserver,
   normalizeHomeserverName,
   shouldDisablePasswordLogin,
+  shouldRequireAppleProvider,
   shouldUseSsoOnlyRegistration,
 } from './authPolicy';
 
@@ -18,11 +19,27 @@ describe('MindRoom auth policy', () => {
 
   it('forces the hosted homeserver onto SSO-only auth', () => {
     expect(shouldDisablePasswordLogin('mindroom.chat', undefined)).toBe(true);
-    expect(shouldDisablePasswordLogin('https://123.matrix.mindroom.chat', undefined)).toBe(true);
+    expect(shouldDisablePasswordLogin('https://123.matrix.mindroom.chat', undefined)).toBe(false);
+    expect(
+      shouldDisablePasswordLogin('https://123.matrix.mindroom.chat', {
+        disablePasswordLogin: true,
+      })
+    ).toBe(true);
     expect(shouldDisablePasswordLogin('matrix.org', { disablePasswordLogin: true })).toBe(true);
     expect(shouldDisablePasswordLogin('matrix.org', undefined)).toBe(false);
     expect(shouldUseSsoOnlyRegistration('https://mindroom.chat')).toBe(true);
-    expect(shouldUseSsoOnlyRegistration('https://123.matrix.mindroom.chat')).toBe(true);
+    expect(shouldUseSsoOnlyRegistration('https://123.matrix.mindroom.chat')).toBe(false);
     expect(shouldUseSsoOnlyRegistration('https://matrix.org')).toBe(false);
+  });
+
+  it('requires Apple only for the primary MindRoom homeserver', () => {
+    expect(shouldRequireAppleProvider('mindroom.chat', { requireAppleProvider: true })).toBe(true);
+    expect(
+      shouldRequireAppleProvider('https://123.matrix.mindroom.chat', {
+        requireAppleProvider: true,
+      })
+    ).toBe(false);
+    expect(shouldRequireAppleProvider('matrix.org', { requireAppleProvider: true })).toBe(false);
+    expect(shouldRequireAppleProvider('mindroom.chat', undefined)).toBe(false);
   });
 });

--- a/src/app/mindroom/auth/authPolicy.ts
+++ b/src/app/mindroom/auth/authPolicy.ts
@@ -6,18 +6,26 @@ export const MINDROOM_TENANT_HOMESERVER_SUFFIX = '.matrix.mindroom.chat';
 export const normalizeHomeserverName = (server: string): string =>
   server.replace(/^https?:\/\//i, '').replace(/\/+$/, '').toLowerCase();
 
+export const isPrimaryMindroomHomeserver = (server: string): boolean =>
+  normalizeHomeserverName(server) === MINDROOM_HOMESERVER;
+
+export const isMindroomTenantHomeserver = (server: string): boolean =>
+  normalizeHomeserverName(server).endsWith(MINDROOM_TENANT_HOMESERVER_SUFFIX);
+
 export const isMindroomHomeserver = (server: string): boolean => {
   const normalizedServer = normalizeHomeserverName(server);
-  return (
-    normalizedServer === MINDROOM_HOMESERVER ||
-    normalizedServer.endsWith(MINDROOM_TENANT_HOMESERVER_SUFFIX)
-  );
+  return normalizedServer === MINDROOM_HOMESERVER || isMindroomTenantHomeserver(normalizedServer);
 };
 
 export const shouldDisablePasswordLogin = (
   server: string,
   authConfig: ClientConfig['auth'] | undefined
-): boolean => authConfig?.disablePasswordLogin === true || isMindroomHomeserver(server);
+): boolean => authConfig?.disablePasswordLogin === true || isPrimaryMindroomHomeserver(server);
 
 export const shouldUseSsoOnlyRegistration = (server: string): boolean =>
-  isMindroomHomeserver(server);
+  isPrimaryMindroomHomeserver(server);
+
+export const shouldRequireAppleProvider = (
+  server: string,
+  authConfig: ClientConfig['auth'] | undefined
+): boolean => authConfig?.requireAppleProvider === true && isPrimaryMindroomHomeserver(server);

--- a/src/app/mindroom/auth/authUi.ts
+++ b/src/app/mindroom/auth/authUi.ts
@@ -13,6 +13,7 @@ import {
 import {
   isMindroomHomeserver,
   shouldDisablePasswordLogin,
+  shouldRequireAppleProvider,
   shouldUseSsoOnlyRegistration,
 } from './authPolicy';
 
@@ -32,5 +33,6 @@ export {
   isNativeIOS,
   openNativeSsoBrowser,
   shouldDisablePasswordLogin,
+  shouldRequireAppleProvider,
   shouldUseSsoOnlyRegistration,
 };

--- a/src/app/pages/auth/login/Login.tsx
+++ b/src/app/pages/auth/login/Login.tsx
@@ -19,6 +19,7 @@ import {
   getMindroomAuthSsoRedirectUrl,
   isMindroomHomeserver,
   shouldDisablePasswordLogin,
+  shouldRequireAppleProvider,
 } from '../../../mindroom/auth/authUi';
 
 const getLoginTokenSearchParam = () => {
@@ -67,7 +68,7 @@ export function Login() {
   const disablePasswordLogin = shouldDisablePasswordLogin(server, auth);
   const showPasswordLogin = parsedFlows.password !== undefined && !disablePasswordLogin;
   const registrationAllowed = auth?.allowRegistration !== false;
-  const requireAppleProvider = auth?.requireAppleProvider === true;
+  const requireAppleProvider = shouldRequireAppleProvider(server, auth);
   const appleProviderAvailable = hasAppleIdentityProvider(parsedFlows.sso?.identity_providers);
 
   return (

--- a/src/app/pages/auth/register/Register.tsx
+++ b/src/app/pages/auth/register/Register.tsx
@@ -17,6 +17,7 @@ import { hasAppleIdentityProvider } from '../ssoProviders';
 import { isAddAccountSearch, withAddAccountSearch } from '../addAccount';
 import {
   getMindroomAuthSsoRedirectUrl,
+  shouldRequireAppleProvider,
   shouldUseSsoOnlyRegistration,
 } from '../../../mindroom/auth/authUi';
 
@@ -39,7 +40,7 @@ export function Register() {
   const addAccount = isAddAccountSearch(searchParams);
   const { sso } = useParsedLoginFlows(loginFlows.flows);
   const registrationAllowed = auth?.allowRegistration !== false;
-  const requireAppleProvider = auth?.requireAppleProvider === true;
+  const requireAppleProvider = shouldRequireAppleProvider(server, auth);
   const appleProviderAvailable = hasAppleIdentityProvider(sso?.identity_providers);
   const ssoOnlyRegistration = shouldUseSsoOnlyRegistration(server);
   const showPasswordRegistration =


### PR DESCRIPTION
## Summary
- keep hosted tenant homeservers recognized for deep-link routing
- stop applying the primary mindroom.chat Apple-only/password-disabled policy to tenant homeservers
- add auth policy regression coverage

## Validation
- npm run test -- src/app/mindroom/auth/authPolicy.test.ts
- npm run test -- src/app/pages/auth/ssoProviders.test.ts src/app/pages/auth/SSOLogin.test.ts src/app/mindroom/auth/authPolicy.test.ts
- npm run lint
- npm run typecheck
- npm run build

## Summary by Sourcery

Scope MindRoom authentication policies so that the stricter primary homeserver rules do not automatically apply to tenant homeservers.

New Features:
- Introduce explicit helpers to distinguish the primary MindRoom homeserver from MindRoom tenant homeservers.
- Add a policy hook to require Apple as an SSO provider only on the primary MindRoom homeserver.

Bug Fixes:
- Ensure tenant homeservers are no longer forced into SSO-only auth and password-disabled login unless configured explicitly.
- Restrict the Apple-only SSO requirement to the primary MindRoom homeserver instead of applying it to tenant homeservers.

Enhancements:
- Update login and registration flows to rely on centralized auth policy helpers for password and Apple-provider requirements.

Tests:
- Extend auth policy tests to cover the new primary vs tenant homeserver behavior and Apple-only requirement logic.