### PR TITLE
feat: add native Apple sign-in exchange

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,47 @@
 
 ## Runbook
 
+### CINNY-094 - Native Sign in with Apple exchange (2026-05-17)
+
+- Status:
+  - Implemented locally; pending Tuwunel release/deploy and App Store build.
+- Summary:
+  - Replaced the native iOS Apple provider path with
+    `ASAuthorizationAppleIDProvider` so Sign in with Apple uses the device
+    account sheet instead of the Apple web login page.
+  - The native plugin now returns the Apple identity token, authorization code,
+    user identifier, and raw nonce to the web layer.
+  - The web layer posts the native Apple credential to
+    `/_matrix/client/unstable/org.mindroom.login/apple` and routes the returned
+    Matrix `loginToken` through the existing token-login path.
+  - Enabled the iOS Sign in with Apple entitlement in `App.entitlements`.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `ios/App/App/App.entitlements`
+  - `ios/App/App/MindRoomAuthPlugin.swift`
+  - `src/app/mindroom/auth/authUi.ts`
+  - `src/app/mindroom/native/nativeSso.ts`
+  - `src/app/mindroom/native/nativeSso.test.ts`
+  - `src/app/pages/auth/SSOLogin.tsx`
+  - `src/app/pages/auth/SSOLogin.test.ts`
+- Tests and validation:
+  - Red check:
+    `npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts`
+    failed while `signInWithNativeApple` and the Apple-provider intercept did
+    not exist.
+  - Green check:
+    `npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts`.
+  - Green check: `npm run typecheck`.
+  - Green check: `xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift`.
+  - Green check: `npm run build` passed with existing Vite
+    runtime-config/sourcemap/chunk-size warnings.
+  - Green check: `npx cap sync ios`.
+  - Green check: `npm run appstore:preflight`.
+  - Local iOS compile check:
+    `xcodebuild -workspace ios/App/App.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
+    could not run because this Mac's CoreSimulator is older than the installed
+    Xcode support files and no eligible iOS 26.5 destination is installed.
+
 ### CINNY-093 - Native iOS web-auth session for Apple SSO (2026-05-15)
 
 - Status:

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>$(APS_ENVIRONMENT)</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/ios/App/App/MindRoomAuthPlugin.swift
+++ b/ios/App/App/MindRoomAuthPlugin.swift
@@ -1,16 +1,21 @@
 import AuthenticationServices
 import Capacitor
+import CryptoKit
+import Security
 import UIKit
 
 @objc(MindRoomAuthPlugin)
-public class MindRoomAuthPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticationPresentationContextProviding {
+public class MindRoomAuthPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticationPresentationContextProviding, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     public let identifier = "MindRoomAuthPlugin"
     public let jsName = "MindRoomAuth"
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "authenticate", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "authenticate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "signInWithApple", returnType: CAPPluginReturnPromise)
     ]
 
     private var authSession: ASWebAuthenticationSession?
+    private var appleSignInCall: CAPPluginCall?
+    private var appleSignInNonce: String?
 
     @objc func authenticate(_ call: CAPPluginCall) {
         guard authSession == nil else {
@@ -66,7 +71,39 @@ public class MindRoomAuthPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticatio
         }
     }
 
+    @objc func signInWithApple(_ call: CAPPluginCall) {
+        guard appleSignInCall == nil else {
+            call.reject("A Sign in with Apple request is already in progress", "APPLE_AUTH_IN_PROGRESS")
+            return
+        }
+
+        let nonce = randomNonceString()
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+
+        appleSignInCall = call
+        appleSignInNonce = nonce
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+    }
+
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        presentationAnchor()
+    }
+
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        presentationAnchor()
+    }
+
+    private func presentationAnchor() -> ASPresentationAnchor {
         if let window = bridge?.viewController?.view.window {
             return window
         }
@@ -77,5 +114,102 @@ public class MindRoomAuthPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticatio
             .first { $0.isKeyWindow }
 
         return window ?? ASPresentationAnchor()
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let call = appleSignInCall else { return }
+
+        defer {
+            appleSignInCall = nil
+            appleSignInNonce = nil
+        }
+
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            call.reject("Unexpected Sign in with Apple credential", "APPLE_AUTH_INVALID_CREDENTIAL")
+            return
+        }
+
+        guard let identityTokenData = credential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+            call.reject("Sign in with Apple did not return an identity token", "APPLE_AUTH_MISSING_ID_TOKEN")
+            return
+        }
+
+        var result: [String: Any] = [
+            "identityToken": identityToken,
+            "user": credential.user
+        ]
+
+        if let authorizationCodeData = credential.authorizationCode,
+           let authorizationCode = String(data: authorizationCodeData, encoding: .utf8) {
+            result["authorizationCode"] = authorizationCode
+        }
+
+        if let nonce = appleSignInNonce {
+            result["nonce"] = nonce
+        }
+
+        if let email = credential.email {
+            result["email"] = email
+        }
+
+        if let givenName = credential.fullName?.givenName {
+            result["givenName"] = givenName
+        }
+
+        if let familyName = credential.fullName?.familyName {
+            result["familyName"] = familyName
+        }
+
+        call.resolve(result)
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        guard let call = appleSignInCall else { return }
+
+        defer {
+            appleSignInCall = nil
+            appleSignInNonce = nil
+        }
+
+        if let authError = error as? ASAuthorizationError,
+           authError.code == .canceled {
+            call.reject("Sign in with Apple cancelled", "APPLE_AUTH_CANCELLED", authError)
+            return
+        }
+
+        call.reject(error.localizedDescription, "APPLE_AUTH_FAILED", error)
+    }
+
+    private func randomNonceString(length: Int = 32) -> String {
+        let charset = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            var randomBytes = [UInt8](repeating: 0, count: 16)
+            let status = randomBytes.withUnsafeMutableBytes { buffer in
+                SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, buffer.baseAddress!)
+            }
+
+            if status != errSecSuccess {
+                return UUID().uuidString.replacingOccurrences(of: "-", with: "")
+            }
+
+            for randomByte in randomBytes where remainingLength > 0 {
+                if Int(randomByte) < charset.count {
+                    result.append(charset[Int(randomByte)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+
+    private func sha256(_ value: String) -> String {
+        let inputData = Data(value.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/src/app/mindroom/auth/authUi.ts
+++ b/src/app/mindroom/auth/authUi.ts
@@ -9,6 +9,7 @@ import {
   buildNativeSsoRedirectUrl,
   isNativeIOS,
   openNativeSsoBrowser,
+  signInWithNativeApple,
 } from '../native/nativeSso';
 import {
   isMindroomHomeserver,
@@ -32,6 +33,7 @@ export {
   isMindroomHomeserver,
   isNativeIOS,
   openNativeSsoBrowser,
+  signInWithNativeApple,
   shouldDisablePasswordLogin,
   shouldRequireAppleProvider,
   shouldUseSsoOnlyRegistration,

--- a/src/app/mindroom/native/nativeSso.test.ts
+++ b/src/app/mindroom/native/nativeSso.test.ts
@@ -8,9 +8,11 @@ import {
   isNativeIOS,
   openNativeSsoBrowser,
   routeNativeSsoCallback,
+  signInWithNativeApple,
 } from './nativeSso';
 
 const authenticate = vi.fn();
+const signInWithApple = vi.fn();
 
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
@@ -20,6 +22,7 @@ vi.mock('@capacitor/core', () => ({
   },
   registerPlugin: vi.fn(() => ({
     authenticate,
+    signInWithApple,
   })),
 }));
 
@@ -52,6 +55,7 @@ describe('nativeSso', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authenticate.mockReset();
+    signInWithApple.mockReset();
     vi.mocked(Capacitor.isPluginAvailable).mockReset();
     vi.mocked(Capacitor.isNativePlatform).mockReset();
     vi.mocked(Capacitor.getPlatform).mockReset();
@@ -236,5 +240,87 @@ describe('nativeSso', () => {
     expect(Browser.close).toHaveBeenCalled();
     expect(replaceState).toHaveBeenCalledWith(null, '', '/login/mindroom.chat?loginToken=abc123');
     expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'popstate' }));
+  });
+
+  it('exchanges native Apple credentials for a Matrix login token and routes it', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.getPlatform).mockReturnValue('ios');
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    signInWithApple.mockResolvedValue({
+      authorizationCode: 'apple-code',
+      identityToken: 'apple-id-token',
+      nonce: 'native-nonce',
+      user: 'apple-user',
+    });
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ loginToken: 'matrix-login-token' }),
+    });
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      value: fetch,
+    });
+    const replaceState = vi.fn();
+    const dispatchEvent = vi.fn();
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        dispatchEvent,
+        history: { replaceState },
+        location: { replace: vi.fn() },
+      },
+    });
+
+    await signInWithNativeApple({
+      baseUrl: 'https://mindroom.chat/',
+      providerId: 'chat.mindroom.matrix.apple',
+      redirectUrl: 'mindroom://auth/login/mindroom.chat',
+    });
+
+    expect(signInWithApple).toHaveBeenCalledWith({});
+    expect(fetch).toHaveBeenCalledWith(
+      'https://mindroom.chat/_matrix/client/unstable/org.mindroom.login/apple',
+      {
+        body: JSON.stringify({
+          authorizationCode: 'apple-code',
+          identityToken: 'apple-id-token',
+          nonce: 'native-nonce',
+          providerId: 'chat.mindroom.matrix.apple',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      }
+    );
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      '',
+      '/login/mindroom.chat?loginToken=matrix-login-token'
+    );
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'popstate' }));
+  });
+
+  it('rejects native Apple sign-in when the Matrix exchange does not return a login token', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.getPlatform).mockReturnValue('ios');
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    signInWithApple.mockResolvedValue({
+      identityToken: 'apple-id-token',
+      nonce: 'native-nonce',
+    });
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({}),
+      }),
+    });
+
+    await expect(
+      signInWithNativeApple({
+        baseUrl: 'https://mindroom.chat',
+        providerId: 'chat.mindroom.matrix.apple',
+        redirectUrl: 'mindroom://auth/login/mindroom.chat',
+      })
+    ).rejects.toThrow('login token');
   });
 });

--- a/src/app/mindroom/native/nativeSso.ts
+++ b/src/app/mindroom/native/nativeSso.ts
@@ -6,9 +6,31 @@ const NATIVE_SSO_HOST = 'auth';
 type StandaloneNavigator = Navigator & { standalone?: boolean };
 type MindRoomAuthPlugin = {
   authenticate(options: { url: string; callbackScheme: string }): Promise<{ url?: string }>;
+  signInWithApple(options?: Record<string, never>): Promise<NativeAppleCredential>;
 };
 
 let mindRoomAuthPlugin: MindRoomAuthPlugin | undefined;
+
+type NativeAppleCredential = {
+  authorizationCode?: string;
+  email?: string;
+  familyName?: string;
+  givenName?: string;
+  identityToken?: string;
+  nonce?: string;
+  user?: string;
+};
+
+type NativeAppleLoginResponse = {
+  expiresInMs?: number;
+  loginToken?: string;
+};
+
+type NativeAppleLoginOptions = {
+  baseUrl: string;
+  providerId?: string;
+  redirectUrl: string;
+};
 
 const normalizePath = (path: string): string => path.replace(/\/{2,}/g, '/');
 
@@ -78,6 +100,22 @@ export const routeNativeSsoCallback = (incomingUrl: string): boolean => {
   return true;
 };
 
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+
+const buildLoginTokenRedirectUrl = (redirectUrl: string, loginToken: string): string => {
+  const target = new URL(redirectUrl);
+  target.searchParams.set('loginToken', loginToken);
+  return target.toString();
+};
+
+const routeLoginTokenRedirect = (redirectUrl: string, loginToken: string): void => {
+  const targetUrl = buildLoginTokenRedirectUrl(redirectUrl, loginToken);
+
+  if (routeNativeSsoCallback(targetUrl)) return;
+
+  window.location.replace(targetUrl);
+};
+
 export const openNativeSsoBrowser = async (url: string): Promise<void> => {
   if (isNativeIOS() && Capacitor.isPluginAvailable('MindRoomAuth')) {
     const result = await getMindRoomAuthPlugin().authenticate({
@@ -93,6 +131,47 @@ export const openNativeSsoBrowser = async (url: string): Promise<void> => {
   }
 
   await Browser.open({ url, presentationStyle: 'fullscreen' });
+};
+
+export const signInWithNativeApple = async ({
+  baseUrl,
+  providerId,
+  redirectUrl,
+}: NativeAppleLoginOptions): Promise<void> => {
+  if (!isNativeIOS() || !Capacitor.isPluginAvailable('MindRoomAuth')) {
+    throw new Error('Native Apple sign-in is unavailable');
+  }
+
+  const credential = await getMindRoomAuthPlugin().signInWithApple({});
+
+  if (!credential.identityToken) {
+    throw new Error('Native Apple sign-in did not return an identity token');
+  }
+
+  const response = await fetch(
+    `${trimTrailingSlash(baseUrl)}/_matrix/client/unstable/org.mindroom.login/apple`,
+    {
+      body: JSON.stringify({
+        authorizationCode: credential.authorizationCode,
+        identityToken: credential.identityToken,
+        nonce: credential.nonce,
+        providerId,
+      }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Native Apple sign-in exchange failed with HTTP ${response.status}`);
+  }
+
+  const body = (await response.json()) as NativeAppleLoginResponse;
+  if (!body.loginToken) {
+    throw new Error('Native Apple sign-in exchange did not return a Matrix login token');
+  }
+
+  routeLoginTokenRedirect(redirectUrl, body.loginToken);
 };
 
 export const getAppPathFromNativeSsoUrl = (incomingUrl: string): string | undefined => {

--- a/src/app/pages/auth/SSOLogin.test.ts
+++ b/src/app/pages/auth/SSOLogin.test.ts
@@ -8,6 +8,9 @@ import { createMatrixClient } from '../../mindroom/matrix/matrixClientFactory';
 import { useAutoDiscoveryInfo } from '../../hooks/useAutoDiscoveryInfo';
 import { SSOLogin } from './SSOLogin';
 
+const authenticate = vi.fn();
+const signInWithApple = vi.fn();
+
 vi.mock('folds', async () => {
   const reactModule = await import('react');
 
@@ -30,7 +33,10 @@ vi.mock('@capacitor/core', () => ({
     isNativePlatform: vi.fn(),
     getPlatform: vi.fn(),
   },
-  registerPlugin: vi.fn(),
+  registerPlugin: vi.fn(() => ({
+    authenticate,
+    signInWithApple,
+  })),
 }));
 
 vi.mock('@capacitor/browser', () => ({
@@ -60,6 +66,8 @@ describe('SSOLogin', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    authenticate.mockReset();
+    signInWithApple.mockReset();
     Object.defineProperty(globalThis, 'window', {
       value: {
         setTimeout: vi.fn(),
@@ -170,5 +178,64 @@ describe('SSOLogin', () => {
     expect(continueButton?.props.as).toBe('a');
     expect(preventDefault).not.toHaveBeenCalled();
     expect(vi.mocked(Browser.open)).not.toHaveBeenCalled();
+  });
+
+  it('uses native Sign in with Apple for Apple providers on native iOS', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.getPlatform).mockReturnValue('ios');
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    signInWithApple.mockResolvedValue({
+      authorizationCode: 'apple-code',
+      identityToken: 'apple-id-token',
+      nonce: 'native-nonce',
+    });
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ loginToken: 'matrix-login-token' }),
+      }),
+    });
+    const replaceState = vi.fn();
+    const dispatchEvent = vi.fn();
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        dispatchEvent,
+        history: { replaceState },
+        location: { replace: vi.fn() },
+        setTimeout: vi.fn(),
+      },
+      configurable: true,
+    });
+
+    const renderer = create(
+      React.createElement(SSOLogin, {
+        action: SSOAction.LOGIN,
+        providers: [
+          {
+            brand: 'apple',
+            id: 'chat.mindroom.matrix.apple',
+            name: 'Apple',
+          },
+        ],
+        redirectUrl: 'mindroom://auth/login/mindroom.chat',
+      })
+    );
+
+    const appleButton = findButtonByText(renderer, 'Sign in with Apple');
+    const preventDefault = vi.fn();
+
+    await act(async () => {
+      await appleButton?.props.onClick({ preventDefault });
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(signInWithApple).toHaveBeenCalledWith({});
+    expect(vi.mocked(Browser.open)).not.toHaveBeenCalled();
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      '',
+      '/login/mindroom.chat?loginToken=matrix-login-token'
+    );
   });
 });

--- a/src/app/pages/auth/SSOLogin.tsx
+++ b/src/app/pages/auth/SSOLogin.tsx
@@ -15,7 +15,12 @@ import AppleLogo from '../../../../public/res/svg/sso-apple-white.svg';
 import GoogleLogo from '../../../../public/res/svg/sso-google.svg';
 import GitHubLogo from '../../../../public/res/svg/sso-github.svg';
 import { mxcUrlToHttp } from '../../utils/mediaUrl';
-import { isNativeIOS, openNativeSsoBrowser } from '../../mindroom/auth/authUi';
+import {
+  isMindroomHomeserver,
+  isNativeIOS,
+  openNativeSsoBrowser,
+  signInWithNativeApple,
+} from '../../mindroom/auth/authUi';
 
 type SSOLoginProps = {
   providers?: IIdentityProvider[];
@@ -33,7 +38,7 @@ export function SSOLogin({ providers, redirectUrl, action, saveScreenSpace }: SS
   const openingNativeSSORef = useRef(false);
 
   const handleSSONavigate =
-    (url: string) =>
+    (url: string, provider?: IIdentityProvider) =>
     async (evt: React.MouseEvent<HTMLElement>): Promise<void> => {
       if (!nativeIOS) return;
 
@@ -41,7 +46,15 @@ export function SSOLogin({ providers, redirectUrl, action, saveScreenSpace }: SS
       if (openingNativeSSORef.current) return;
       openingNativeSSORef.current = true;
       try {
-        await openNativeSsoBrowser(url);
+        if (provider && isAppleIdentityProvider(provider) && isMindroomHomeserver(baseUrl)) {
+          await signInWithNativeApple({
+            baseUrl,
+            providerId: provider.id,
+            redirectUrl,
+          });
+        } else {
+          await openNativeSsoBrowser(url);
+        }
       } catch (error) {
         console.error('[SSO] Failed to open native iOS in-app browser', error);
       } finally {
@@ -56,7 +69,8 @@ export function SSOLogin({ providers, redirectUrl, action, saveScreenSpace }: SS
     if (isAppleIdentityProvider(provider)) return AppleLogo;
     if (isGoogleIdentityProvider(provider)) return GoogleLogo;
     if (isGitHubIdentityProvider(provider)) return GitHubLogo;
-    const homeserverIcon = provider.icon && mxcUrlToHttp(mx, provider.icon, false, 96, 96, 'crop', false);
+    const homeserverIcon =
+      provider.icon && mxcUrlToHttp(mx, provider.icon, false, 96, 96, 'crop', false);
     if (homeserverIcon) return homeserverIcon;
 
     return undefined;
@@ -90,7 +104,7 @@ export function SSOLogin({ providers, redirectUrl, action, saveScreenSpace }: SS
                 style={{ cursor: 'pointer' }}
                 key={id}
                 {...navigationProps}
-                onClick={handleSSONavigate(ssoUrl)}
+                onClick={handleSSONavigate(ssoUrl, provider)}
                 aria-label={buttonTitle}
                 size="300"
                 radii="300"
@@ -109,7 +123,7 @@ export function SSOLogin({ providers, redirectUrl, action, saveScreenSpace }: SS
               }
               key={id}
               {...navigationProps}
-              onClick={handleSSONavigate(ssoUrl)}
+              onClick={handleSSONavigate(ssoUrl, provider)}
               size="500"
               variant={appleProvider ? 'Primary' : 'Secondary'}
               fill={appleProvider ? 'Solid' : 'Soft'}


### PR DESCRIPTION
## Summary
- add native iOS Sign in with Apple via ASAuthorizationAppleIDProvider
- exchange the native Apple identity token with MindRoom Tuwunel for a Matrix loginToken
- enable the Sign in with Apple entitlement and document the runbook entry

## Verification
- npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts
- npm run typecheck
- xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift
- npm run build
- npx cap sync ios
- npm run appstore:preflight
- git diff --check

## Note
Local xcodebuild still cannot run because this Mac has an out-of-date CoreSimulator and no eligible iOS 26.5 destination installed.

## Summary by Sourcery

Add native iOS Sign in with Apple support that exchanges device credentials for a Matrix login token and integrates it into the existing SSO flow.

New Features:
- Introduce a native iOS Sign in with Apple flow via the MindRoomAuth Capacitor plugin that surfaces Apple credentials to the web layer.
- Add a client-side exchange endpoint call that trades native Apple credentials for a Matrix login token and routes the user via the existing token-login path.

Enhancements:
- Extend the SSO login UI to prefer native Sign in with Apple on iOS for Apple providers on the Mindroom homeserver while falling back to the existing browser-based flow otherwise.
- Refactor native SSO routing helpers to support redirect URL construction and reuse for token-based navigation.

Deployment:
- Enable the iOS Sign in with Apple entitlement in the app entitlements configuration.

Documentation:
- Document the native Sign in with Apple exchange runbook entry in FORK_CHANGES.md.

Tests:
- Add unit tests for the native Apple sign-in exchange and routing logic in nativeSso and SSOLogin components.