### PR TITLE
fix(ios): avoid Swift exclusivity in Apple nonce

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,25 @@
 
 ## Runbook
 
+### CINNY-095 - Xcode Cloud native Apple nonce compile fix (2026-05-17)
+
+- Status:
+  - Complete.
+- Summary:
+  - Fixed the Xcode Cloud Swift exclusivity error in native Apple nonce
+    generation by using the mutable byte buffer's own count and base address
+    inside `withUnsafeMutableBytes`.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `ios/App/App/MindRoomAuthPlugin.swift`
+- Tests and validation:
+  - Green check: `xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift`.
+  - Green check:
+    `npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts`.
+  - Green check: `npm run typecheck`.
+  - Green check: `npm run appstore:preflight`.
+  - Green check: `git diff --check`.
+
 ### CINNY-094 - Native Sign in with Apple exchange (2026-05-17)
 
 - Status:

--- a/ios/App/App/MindRoomAuthPlugin.swift
+++ b/ios/App/App/MindRoomAuthPlugin.swift
@@ -189,7 +189,11 @@ public class MindRoomAuthPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticatio
         while remainingLength > 0 {
             var randomBytes = [UInt8](repeating: 0, count: 16)
             let status = randomBytes.withUnsafeMutableBytes { buffer in
-                SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, buffer.baseAddress!)
+                guard let baseAddress = buffer.baseAddress else {
+                    return errSecParam
+                }
+
+                return SecRandomCopyBytes(kSecRandomDefault, buffer.count, baseAddress)
             }
 
             if status != errSecSuccess {


### PR DESCRIPTION
## Summary
- fix the Xcode Cloud Swift exclusivity error in native Apple nonce generation
- use the mutable byte buffer's count/base address inside withUnsafeMutableBytes
- update the fork runbook with the Xcode Cloud follow-up

## Validation
- xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift
- npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts
- npm run typecheck
- npm run appstore:preflight
- git diff --check

## Summary by Sourcery

Fix Swift native Apple nonce generation to avoid Xcode Cloud exclusivity errors and document the change in the fork runbook.

Bug Fixes:
- Resolve a Swift exclusivity violation in native Apple nonce generation by adjusting how the random byte buffer is passed to SecRandomCopyBytes.

Documentation:
- Add a new fork runbook entry documenting the Xcode Cloud native Apple nonce compile fix, affected files, and validation steps.