### PR TITLE
fix(ios): declare Apple sign-in capability

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,31 @@
 
 ## Runbook
 
+### CINNY-096 - Xcode target Apple Sign In capability (2026-05-17)
+
+- Status:
+  - Complete.
+- Summary:
+  - Xcode Cloud passed the Swift compile step after CINNY-095, then failed
+    during export for distribution.
+  - Added the `com.apple.SignInWithApple` system capability to the Xcode target
+    attributes so automatic signing/export sees the target capability as well as
+    the entitlement file.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `ios/App/App.xcodeproj/project.pbxproj`
+- Tests and validation:
+  - Green check:
+    `plutil -lint ios/App/App.xcodeproj/project.pbxproj ios/App/App/App.entitlements`.
+  - Green check: `xcodebuild -list -workspace ios/App/App.xcworkspace`
+    listed the `App` scheme; it still prints the local CoreSimulator mismatch
+    warning from this Mac.
+  - Green check: `xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift`.
+  - Green check: `npm run appstore:preflight`.
+  - Green check: `git diff --check`.
+  - Green check:
+    `npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts`.
+
 ### CINNY-095 - Xcode Cloud native Apple nonce compile fix (2026-05-17)
 
 - Status:

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -135,6 +135,11 @@
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.SignInWithApple = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};


### PR DESCRIPTION
## Summary
- declare Sign in with Apple in the Xcode target SystemCapabilities
- keep the entitlement and target capability aligned for Xcode Cloud automatic signing/export
- document the Xcode Cloud export follow-up in the runbook

## Validation
- plutil -lint ios/App/App.xcodeproj/project.pbxproj ios/App/App/App.entitlements
- xcodebuild -list -workspace ios/App/App.xcworkspace
- xcrun swiftc -parse ios/App/App/MindRoomAuthPlugin.swift
- npm run appstore:preflight
- npm test -- src/app/mindroom/native/nativeSso.test.ts src/app/pages/auth/SSOLogin.test.ts
- git diff --check

## Summary by Sourcery

Align iOS Sign in with Apple configuration for Xcode Cloud distribution and document the change in the fork runbook.

Enhancements:
- Declare the Sign in with Apple system capability on the iOS Xcode target to match the existing entitlement and support Xcode Cloud automatic signing and export.

Documentation:
- Extend the fork runbook with a CINNY-096 entry describing the Xcode Cloud export failure and the Sign in with Apple capability fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Sign in with Apple authentication capability for the iOS app, allowing users to authenticate using their Apple credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->