### PR TITLE
fix(CINNY-112): make invite matches readable

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,60 @@
 
 ## Runbook
 
+### CINNY-112 - Invite autocomplete readable agent identities (2026-05-19)
+
+- Status:
+  - Complete.
+- Summary:
+  - Reworked invite autocomplete suggestions so agent/user search results show
+    display name and full MXID in the main row body instead of truncating the
+    MXID in the trailing slot.
+  - PR follow-up: kept the suggestion popup anchored inside the input/dialog
+    bounds after screenshot review showed the widened centered popup being
+    clipped by the dialog; widened the Invite dialog itself modestly on desktop
+    so the two-line identities have more room without escaping the modal.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/components/invite-user-prompt/InviteAutocompleteMenu.css.ts`
+  - `src/app/components/invite-user-prompt/InviteUserPrompt.tsx`
+  - `src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx`
+  - `src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx`
+  - `src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+- Regression tests:
+  - Added `InviteUserAutocomplete` coverage proving a long MindRoom-style match
+    exposes the display name and full MXID in the suggestion row without using
+    the narrow trailing `after` slot.
+  - Added guards proving the suggestion popup stays input-bounded and the Invite
+    dialog uses the wider responsive width cap.
+- Validation:
+  - RED observed:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+    failed because the old row had no full-identity text nodes.
+  - Green focused check:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+    (1 file, 12 tests).
+  - Green prompt/autocomplete check:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx`
+    (2 files, 14 tests).
+  - PR follow-up RED checks:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+    failed on the escaping centered popup rule, and
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx`
+    failed before the wider responsive dialog style existed.
+  - PR follow-up green focused check:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx`
+    (2 files, 16 tests).
+  - Green: `npm run typecheck`.
+  - Green: `npm test` (293 files, 2205 tests).
+  - Green: `npm run lint` (16 warnings, 0 errors — pre-existing baseline).
+  - Green: `npm run build` (existing Vite runtime-config/source-map/chunk-size
+    warnings only).
+  - Green:
+    `npx prettier --check src/app/components/invite-user-prompt/InviteAutocompleteMenu.css.ts src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx`.
+  - Green: `git diff --check`.
+  - Independent review: second self-review found no issues; subagent review was
+    not used because this session was not explicitly authorized to spawn agents.
+
 ### CINNY-111 - Thread list horizontal scroll + long-string overflow (2026-05-15)
 
 - Applied scoped compact room view x-overflow clipping and long unbreakable title wrapping with live Playwright coverage for 360/480/768/1440 viewport widths; Bas iPhone PWA verification remains pending.

--- a/src/app/components/invite-user-prompt/InviteAutocompleteMenu.css.ts
+++ b/src/app/components/invite-user-prompt/InviteAutocompleteMenu.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { DefaultReset, config } from 'folds';
+import { DefaultReset, config, toRem } from 'folds';
 
 export const InviteAutocompleteMenuRoot = style([
   DefaultReset,
@@ -29,7 +29,7 @@ export const InviteAutocompleteMenuContainer = style([
 export const InviteAutocompleteMenu = style([
   DefaultReset,
   {
-    maxHeight: '30vh',
+    maxHeight: `min(52vh, ${toRem(448)})`,
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
@@ -40,3 +40,36 @@ export const InviteAutocompleteMenuHeader = style([
   DefaultReset,
   { padding: `0 ${config.space.S300}`, flexShrink: 0 },
 ]);
+
+export const InviteAutocompleteOption = style([
+  DefaultReset,
+  {
+    alignItems: 'flex-start',
+    height: 'auto',
+    minHeight: toRem(56),
+    paddingTop: config.space.S200,
+    paddingBottom: config.space.S200,
+  },
+]);
+
+export const InviteAutocompleteIdentity = style([
+  DefaultReset,
+  {
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: config.space.S100,
+    flexGrow: 1,
+  },
+]);
+
+export const InviteAutocompleteDisplayName = style({
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+});
+
+export const InviteAutocompleteUserId = style({
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+});

--- a/src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx
+++ b/src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import React, { useState } from 'react';
 import { Provider, createStore } from 'jotai';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
@@ -38,6 +39,10 @@ vi.mock('./InviteAutocompleteMenu.css', () => ({
   InviteAutocompleteMenuContainer: 'InviteAutocompleteMenuContainer',
   InviteAutocompleteMenu: 'InviteAutocompleteMenu',
   InviteAutocompleteMenuHeader: 'InviteAutocompleteMenuHeader',
+  InviteAutocompleteOption: 'InviteAutocompleteOption',
+  InviteAutocompleteIdentity: 'InviteAutocompleteIdentity',
+  InviteAutocompleteDisplayName: 'InviteAutocompleteDisplayName',
+  InviteAutocompleteUserId: 'InviteAutocompleteUserId',
 }));
 
 vi.mock('../../hooks/useMediaAuthentication', () => ({
@@ -320,6 +325,41 @@ describe('InviteUserAutocomplete', () => {
       undefined,
       false
     );
+  });
+
+  it('keeps long matching user identities readable inside each suggestion row', () => {
+    const userId = '@mindroom_assistant_829sujms:mindroom.example.org';
+    const displayName = 'MindRoom Assistant 829';
+    const { renderer } = renderAutocomplete({
+      cacheState: readyCache([
+        {
+          userId,
+          displayName,
+        },
+      ]),
+      initialValue: 'mind',
+    });
+
+    const [option] = getOptions(renderer);
+    const displayNameNode = renderer.root.findByProps({ title: displayName });
+    const userIdNode = renderer.root.findByProps({ title: userId });
+
+    expect(option.props['aria-label']).toBe(`${displayName}, ${userId}`);
+    expect(option.props['data-ui-after']).toBeUndefined();
+    expect(displayNameNode.props.children).toBe(displayName);
+    expect(userIdNode.props.children).toBe(userId);
+    expect(userIdNode.props.truncate).toBeUndefined();
+  });
+
+  it('keeps the suggestion popup anchored inside the input bounds', () => {
+    const cssSource = readFileSync(new URL('./InviteAutocompleteMenu.css.ts', import.meta.url), {
+      encoding: 'utf8',
+    });
+
+    expect(cssSource).toContain('left: 0');
+    expect(cssSource).toContain('right: 0');
+    expect(cssSource).not.toContain("left: '50%'");
+    expect(cssSource).not.toContain('translateX(-50%)');
   });
 
   it('moves the active row with arrows and commits it with Enter', () => {

--- a/src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx
+++ b/src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx
@@ -22,6 +22,7 @@ import { sanitizeInviteAutocompleteOptionId } from '../../utils/userDirectorySea
 import { onTabPress } from '../../utils/keyboard';
 import { UserAvatar } from '../user-avatar';
 import { InviteAutocompleteMenu } from './InviteAutocompleteMenu';
+import * as css from './InviteAutocompleteMenu.css';
 
 type InviteUserAutocompleteProps = {
   room: Room;
@@ -201,7 +202,9 @@ export const InviteUserAutocomplete = forwardRef<HTMLInputElement, InviteUserAut
                     id={getOptionId(user.userId)}
                     role="option"
                     aria-selected={active}
+                    aria-label={`${displayName}, ${user.userId}`}
                     data-focus={active || undefined}
+                    className={css.InviteAutocompleteOption}
                     type="button"
                     radii="300"
                     disabled={disabled}
@@ -225,15 +228,26 @@ export const InviteUserAutocomplete = forwardRef<HTMLInputElement, InviteUserAut
                         />
                       </Avatar>
                     }
-                    after={
-                      <Text size="T200" priority="300" truncate>
+                  >
+                    <span className={css.InviteAutocompleteIdentity}>
+                      <Text
+                        as="span"
+                        className={css.InviteAutocompleteDisplayName}
+                        size="B400"
+                        title={displayName}
+                      >
+                        {displayName}
+                      </Text>
+                      <Text
+                        as="span"
+                        className={css.InviteAutocompleteUserId}
+                        size="T200"
+                        priority="300"
+                        title={user.userId}
+                      >
                         {user.userId}
                       </Text>
-                    }
-                  >
-                    <Text style={{ flexGrow: 1 }} size="B400" truncate>
-                      {displayName}
-                    </Text>
+                    </span>
                   </MenuItem>
                 );
               })}

--- a/src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx
+++ b/src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx
@@ -3,6 +3,7 @@ import { Provider, createStore } from 'jotai';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MatrixClient, Room } from 'matrix-js-sdk';
+import { config, toRem } from 'folds';
 
 import { MatrixClientProvider } from '../../hooks/useMatrixClient';
 import {
@@ -43,6 +44,10 @@ vi.mock('./InviteAutocompleteMenu.css', () => ({
   InviteAutocompleteMenuContainer: 'InviteAutocompleteMenuContainer',
   InviteAutocompleteMenu: 'InviteAutocompleteMenu',
   InviteAutocompleteMenuHeader: 'InviteAutocompleteMenuHeader',
+  InviteAutocompleteOption: 'InviteAutocompleteOption',
+  InviteAutocompleteIdentity: 'InviteAutocompleteIdentity',
+  InviteAutocompleteDisplayName: 'InviteAutocompleteDisplayName',
+  InviteAutocompleteUserId: 'InviteAutocompleteUserId',
 }));
 
 vi.mock('../../hooks/useMediaAuthentication', () => ({
@@ -131,6 +136,14 @@ const getInput = (renderer: ReactTestRenderer) => renderer.root.findByProps({ ro
 
 const getForm = (renderer: ReactTestRenderer) => renderer.root.find((node) => node.type === 'form');
 
+const getDialog = (renderer: ReactTestRenderer) =>
+  renderer.root.find(
+    (node) =>
+      node.type === 'div' &&
+      node.props.style?.width === '100%' &&
+      typeof node.props.style?.maxWidth === 'string'
+  );
+
 const getOptions = (renderer: ReactTestRenderer) =>
   renderer.root.findAll((node) => node.type === 'button' && node.props.role === 'option');
 
@@ -216,6 +229,15 @@ afterEach(() => {
 });
 
 describe('InviteUserPrompt', () => {
+  it('uses a wider responsive dialog so invite matches have room to breathe', () => {
+    const { renderer } = renderPrompt();
+
+    expect(getDialog(renderer).props.style).toMatchObject({
+      width: '100%',
+      maxWidth: `min(calc(100vw - 2 * ${config.space.S400}), ${toRem(680)})`,
+    });
+  });
+
   it.each([
     { key: 'Enter', closesSuggestions: false },
     { key: 'Tab', closesSuggestions: true },

--- a/src/app/components/invite-user-prompt/InviteUserPrompt.tsx
+++ b/src/app/components/invite-user-prompt/InviteUserPrompt.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FormEventHandler,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { FormEventHandler, useCallback, useMemo, useRef, useState } from 'react';
 import {
   Overlay,
   OverlayBackdrop,
@@ -21,6 +15,7 @@ import {
   color,
   TextArea,
   Dialog,
+  toRem,
 } from 'folds';
 import { Room } from 'matrix-js-sdk';
 import FocusTrap from 'focus-trap-react';
@@ -95,7 +90,12 @@ export function InviteUserPrompt({ room, requestClose }: InviteUserProps) {
             escapeDeactivates: stopPropagation,
           }}
         >
-          <Dialog>
+          <Dialog
+            style={{
+              width: '100%',
+              maxWidth: `min(calc(100vw - 2 * ${config.space.S400}), ${toRem(680)})`,
+            }}
+          >
             <Box grow="Yes" direction="Column">
               <Header
                 size="500"


### PR DESCRIPTION
## Summary
- Show invite autocomplete matches as display name plus full Matrix user ID in the main row body.
- Allow the suggestion popup to grow wider/taller within the viewport for dense MindRoom agent searches.
- Record CINNY-112 status and validation in FORK_CHANGES.md.

## Test plan
- [x] npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx
- [x] npm run typecheck
- [x] npm test
- [x] npm run lint (0 errors, existing 16 warnings)
- [x] npm run build
- [x] git diff --check

## Summary by Sourcery

Make invite autocomplete suggestions display readable user identities and improve the popup layout for dense agent searches.

New Features:
- Show both display name and full Matrix user ID within each invite autocomplete suggestion row to keep long identities readable.

Enhancements:
- Allow the invite autocomplete popup to expand in width and height within viewport constraints for better usability with large result sets.

Documentation:
- Document CINNY-112 implementation details, status, and validation steps in FORK_CHANGES.md.

Tests:
- Extend invite autocomplete tests to cover readability of long MindRoom-style identities and update related prompt tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced invite autocomplete suggestions to show display names and full user IDs together without truncation, making it easier to identify users
  * Improved autocomplete popup sizing to better fit within the viewport, providing a better experience with longer user lists

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->