### PR TITLE
fix(CINNY-113): avoid duplicate invite option labels

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,50 @@
 
 ## Runbook
 
+### CINNY-113 - Invite autocomplete non-duplicative option labels (2026-05-19)
+
+- Status:
+  - Complete.
+- Summary:
+  - Followed up on PR #23 accessibility review feedback by making invite
+    autocomplete option labels avoid repeating the MXID when the display name
+    already equals the user ID.
+  - PR #24 review follow-up: trim display names at the invite option render
+    boundary so whitespace-only names behave like missing names and fall back to
+    the MXID localpart/userId identity. Did not add case-insensitive MXID
+    dedupe because Matrix IDs should remain exact identifiers.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx`
+  - `src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+- Regression tests:
+  - Added coverage proving a suggestion whose display name is the same as its
+    MXID announces just the MXID instead of `<mxid>, <mxid>`.
+  - Added coverage proving a whitespace-only display name renders and announces
+    via the existing localpart/userId fallback rather than as a blank name.
+- Validation:
+  - RED observed:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+    failed because the old `aria-label` duplicated the MXID.
+  - PR #24 review RED observed:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+    failed because the whitespace-only display name was preserved instead of
+    falling back to the localpart.
+  - Green focused check:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`
+    (1 file, 15 tests).
+  - Green prompt/autocomplete check:
+    `npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx`
+    (2 files, 18 tests).
+  - Green: `npm run typecheck`.
+  - Green: `npm test` (293 files, 2207 tests).
+  - Green: `npm run lint` (16 warnings, 0 errors — pre-existing baseline).
+  - Green: `npm run build` (existing Vite runtime-config/source-map/chunk-size
+    warnings only).
+  - Green:
+    `npx prettier --check src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx`.
+  - Green: `git diff --check`.
+
 ### CINNY-112 - Invite autocomplete readable agent identities (2026-05-19)
 
 - Status:

--- a/src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx
+++ b/src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx
@@ -351,6 +351,42 @@ describe('InviteUserAutocomplete', () => {
     expect(userIdNode.props.truncate).toBeUndefined();
   });
 
+  it('does not duplicate the MXID in the option label when it is also the display name', () => {
+    const userId = '@mindroom_assistant:mindroom.chat';
+    const { renderer } = renderAutocomplete({
+      cacheState: readyCache([
+        {
+          userId,
+          displayName: userId,
+        },
+      ]),
+      initialValue: 'mind',
+    });
+
+    const [option] = getOptions(renderer);
+
+    expect(option.props['aria-label']).toBe(userId);
+  });
+
+  it('falls back from a whitespace-only display name before labeling the option', () => {
+    const userId = '@space:example.org';
+    const { renderer } = renderAutocomplete({
+      cacheState: readyCache([
+        {
+          userId,
+          displayName: '   ',
+        },
+      ]),
+      initialValue: 'space',
+    });
+
+    const [option] = getOptions(renderer);
+    const displayNameNode = renderer.root.findByProps({ title: 'space' });
+
+    expect(option.props['aria-label']).toBe(`space, ${userId}`);
+    expect(displayNameNode.props.children).toBe('space');
+  });
+
   it('keeps the suggestion popup anchored inside the input bounds', () => {
     const cssSource = readFileSync(new URL('./InviteAutocompleteMenu.css.ts', import.meta.url), {
       encoding: 'utf8',

--- a/src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx
+++ b/src/app/components/invite-user-prompt/InviteUserAutocomplete.tsx
@@ -38,7 +38,10 @@ const getOptionId = (userId: string): string =>
   `invite-autocomplete-option-${sanitizeInviteAutocompleteOptionId(userId)}`;
 
 const getDisplayName = (user: ServerUserDirectoryUser): string =>
-  user.displayName || getMxIdLocalPart(user.userId) || user.userId;
+  user.displayName?.trim() || getMxIdLocalPart(user.userId) || user.userId;
+
+const getOptionLabel = (displayName: string, userId: string): string =>
+  displayName && displayName !== userId ? `${displayName}, ${userId}` : userId;
 
 const setForwardedRef = (
   ref: ForwardedRef<HTMLInputElement>,
@@ -202,7 +205,7 @@ export const InviteUserAutocomplete = forwardRef<HTMLInputElement, InviteUserAut
                     id={getOptionId(user.userId)}
                     role="option"
                     aria-selected={active}
-                    aria-label={`${displayName}, ${user.userId}`}
+                    aria-label={getOptionLabel(displayName, user.userId)}
                     data-focus={active || undefined}
                     className={css.InviteAutocompleteOption}
                     type="button"


### PR DESCRIPTION
## Summary
- Avoid duplicate screen-reader labels when an invite suggestion display name already equals the Matrix user ID.
- Add a focused regression test for the duplicate-MXID case.
- Record CINNY-113 status and validation in FORK_CHANGES.md.

## Test plan
- [x] npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx
- [x] npx vitest run src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx
- [x] npm run typecheck
- [x] npm test
- [x] npm run lint (0 errors, existing 16 warnings)
- [x] npm run build
- [x] git diff --check

## Summary by Sourcery

Improve invite autocomplete accessibility by avoiding duplicated MXID in option labels and documenting the associated fork change.

Bug Fixes:
- Ensure invite autocomplete option aria-labels do not repeat the MXID when it is already used as the display name.

Documentation:
- Document CINNY-113 invite autocomplete label changes and validation steps in FORK_CHANGES.md.

Tests:
- Add a regression test covering invite suggestions whose display name is identical to their MXID.