### PR TITLE
Fix currency amounts rendering as math

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,46 @@
 
 ## Runbook
 
+### CINNY-117 - Currency-like dollar text stays out of math rendering (2026-05-28)
+
+- Status:
+  - Complete.
+- Summary:
+  - Investigated reports that currency text was failing after dollar-delimited
+    math support.
+  - Root cause: the shared inline math detector only excluded pure numeric
+    content such as `$5+$10$`; formatted amount content such as `$1,000.00$`,
+    `$5 USD$`, and `$19.99/mo$` still matched `$...$` and was sent through
+    KaTeX.
+  - Added a shared currency-like detector for grouped/decimal amounts, common
+    currency words/codes, unit suffixes, and simple ranges before accepting an
+    inline math match.
+  - Independent self-review caught an over-broad first pass that would have
+    missed ungrouped four-digit amounts and rejected numeric-leading math like
+    `$2sin(x)$`; tightened the detector and added coverage for both.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/plugins/math.tsx`
+  - `src/app/components/editor/math.test.ts`
+  - `src/app/plugins/react-custom-html-parser.test.ts`
+- Regression tests:
+  - Added compose and raw-render coverage proving formatted currency-like
+    dollar text remains literal instead of becoming Matrix math HTML or KaTeX.
+  - Added guard coverage proving numeric-leading math expressions still render
+    as math.
+- Validation:
+  - Green focused check:
+    `npm test -- src/app/components/editor/math.test.ts src/app/plugins/react-custom-html-parser.test.ts`
+    (2 files, 27 tests).
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (16 warnings, 0 errors - pre-existing baseline).
+  - Green: `npm test` (293 files, 2219 tests).
+  - Green: `npm run build` (existing Vite runtime-config/source-map/chunk-size
+    warnings only).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md src/app/plugins/math.tsx src/app/components/editor/math.test.ts src/app/plugins/react-custom-html-parser.test.ts`.
+  - Green: `git diff --check`.
+
 ### CINNY-116 - iOS App Store closed-train version bump (2026-05-20)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -19,6 +19,9 @@
   - Independent self-review caught an over-broad first pass that would have
     missed ungrouped four-digit amounts and rejected numeric-leading math like
     `$2sin(x)$`; tightened the detector and added coverage for both.
+  - PR review follow-up: added support for European-style grouped amounts like
+    `$1.000,00$`, lifted the amount-start regex out of the hot path, and covered
+    currency ranges such as `$5-10$`, `$5–10$`, and `$5-$10$`.
 - Files changed:
   - `FORK_CHANGES.md`
   - `src/app/plugins/math.tsx`
@@ -29,10 +32,12 @@
     dollar text remains literal instead of becoming Matrix math HTML or KaTeX.
   - Added guard coverage proving numeric-leading math expressions still render
     as math.
+  - Added review follow-up coverage for European formatted amounts and currency
+    ranges in both compose and raw-render paths.
 - Validation:
   - Green focused check:
     `npm test -- src/app/components/editor/math.test.ts src/app/plugins/react-custom-html-parser.test.ts`
-    (2 files, 27 tests).
+    (2 files, 29 tests).
   - Green: `npm run typecheck`.
   - Green: `npm run lint` (16 warnings, 0 errors - pre-existing baseline).
   - Green: `npm test` (293 files, 2219 tests).

--- a/src/app/components/editor/math.test.ts
+++ b/src/app/components/editor/math.test.ts
@@ -40,6 +40,22 @@ describe('editor math markdown integration', () => {
     expect(customHtml).toBe('$5+$10$');
   });
 
+  it('does not treat formatted currency amounts as math during compose', () => {
+    const customHtml = trimCustomHtml(
+      toMatrixCustomHTML([paragraph('$1234$ and $1,000.00$ and $5 USD$')], markdownOutputOptions)
+    );
+
+    expect(customHtml).toBe('$1234$ and $1,000.00$ and $5 USD$');
+  });
+
+  it('still treats numeric-leading expressions as math during compose', () => {
+    const customHtml = trimCustomHtml(
+      toMatrixCustomHTML([paragraph('$2sin(x)$')], markdownOutputOptions)
+    );
+
+    expect(customHtml).toContain('<span data-mx-maths="2sin(x)">2sin(x)</span>');
+  });
+
   it('preserves escaped dollar delimiters as literal text during compose', () => {
     const customHtml = trimCustomHtml(
       toMatrixCustomHTML([paragraph('\\$escaped\\$')], markdownOutputOptions)

--- a/src/app/components/editor/math.test.ts
+++ b/src/app/components/editor/math.test.ts
@@ -42,10 +42,21 @@ describe('editor math markdown integration', () => {
 
   it('does not treat formatted currency amounts as math during compose', () => {
     const customHtml = trimCustomHtml(
-      toMatrixCustomHTML([paragraph('$1234$ and $1,000.00$ and $5 USD$')], markdownOutputOptions)
+      toMatrixCustomHTML(
+        [paragraph('$1234$ and $1,000.00$ and $1.000,00$ and $5 USD$')],
+        markdownOutputOptions
+      )
     );
 
-    expect(customHtml).toBe('$1234$ and $1,000.00$ and $5 USD$');
+    expect(customHtml).toBe('$1234$ and $1,000.00$ and $1.000,00$ and $5 USD$');
+  });
+
+  it('does not treat currency ranges as math during compose', () => {
+    const customHtml = trimCustomHtml(
+      toMatrixCustomHTML([paragraph('$5-10$ and $5–10$ and $5-$10$')], markdownOutputOptions)
+    );
+
+    expect(customHtml).toBe('$5-10$ and $5–10$ and $5-$10$');
   });
 
   it('still treats numeric-leading expressions as math during compose', () => {

--- a/src/app/plugins/math.tsx
+++ b/src/app/plugins/math.tsx
@@ -36,8 +36,23 @@ const ALPHANUMERIC_REG = /[0-9A-Za-z]/;
 const isAlphanumeric = (value: string | undefined): boolean =>
   typeof value === 'string' && ALPHANUMERIC_REG.test(value);
 
-const isPlainNumericLatex = (latex: string): boolean =>
-  /^\d+(?:[.,]\d+)?$/.test(latex.trim());
+const CURRENCY_AMOUNT_REG = /(?:\d{1,3}(?:,\d{3})+|\d+)(?:[.,]\d+)?/;
+const CURRENCY_UNIT_REG =
+  /^(?:(?:USD|EUR|GBP|CAD|AUD|JPY|CHF|CNY|INR|BRL|MXN)\b|(?:bucks?|cents?|dollars?)\b|\/[A-Za-z][A-Za-z0-9-]*$)/i;
+
+const isCurrencyLikeLatex = (latex: string): boolean => {
+  const trimmed = latex.trim();
+  const amountMatch = trimmed.match(new RegExp(`^${CURRENCY_AMOUNT_REG.source}`));
+  if (!amountMatch) return false;
+
+  const rest = trimmed.slice(amountMatch[0].length).trim();
+  if (rest.length === 0) return true;
+
+  if (CURRENCY_UNIT_REG.test(rest)) return true;
+  if (/^[-–]\s*\d/.test(rest)) return true;
+
+  return false;
+};
 
 const isEscaped = (text: string, index: number): boolean => {
   let backslashCount = 0;
@@ -97,7 +112,7 @@ const getInlineLatexAt = (text: string, index: number): LatexMatch | undefined =
       }
 
       const latex = text.slice(index + 1, cursor);
-      if (!hasNonWhitespaceBoundary(latex) || isPlainNumericLatex(latex)) return undefined;
+      if (!hasNonWhitespaceBoundary(latex) || isCurrencyLikeLatex(latex)) return undefined;
 
       return {
         fullMatch: text.slice(index, cursor + 1),

--- a/src/app/plugins/math.tsx
+++ b/src/app/plugins/math.tsx
@@ -36,20 +36,22 @@ const ALPHANUMERIC_REG = /[0-9A-Za-z]/;
 const isAlphanumeric = (value: string | undefined): boolean =>
   typeof value === 'string' && ALPHANUMERIC_REG.test(value);
 
-const CURRENCY_AMOUNT_REG = /(?:\d{1,3}(?:,\d{3})+|\d+)(?:[.,]\d+)?/;
+const CURRENCY_AMOUNT_REG = /(?:\d{1,3}(?:[.,]\d{3})+|\d+)(?:[.,]\d+)?/;
+const CURRENCY_AMOUNT_START_REG = new RegExp(`^${CURRENCY_AMOUNT_REG.source}`);
 const CURRENCY_UNIT_REG =
   /^(?:(?:USD|EUR|GBP|CAD|AUD|JPY|CHF|CNY|INR|BRL|MXN)\b|(?:bucks?|cents?|dollars?)\b|\/[A-Za-z][A-Za-z0-9-]*$)/i;
+const CURRENCY_RANGE_REST_REG = /^[-–]\s*\\?\$?\d/;
 
 const isCurrencyLikeLatex = (latex: string): boolean => {
   const trimmed = latex.trim();
-  const amountMatch = trimmed.match(new RegExp(`^${CURRENCY_AMOUNT_REG.source}`));
+  const amountMatch = trimmed.match(CURRENCY_AMOUNT_START_REG);
   if (!amountMatch) return false;
 
   const rest = trimmed.slice(amountMatch[0].length).trim();
   if (rest.length === 0) return true;
 
   if (CURRENCY_UNIT_REG.test(rest)) return true;
-  if (/^[-–]\s*\d/.test(rest)) return true;
+  if (CURRENCY_RANGE_REST_REG.test(rest)) return true;
 
   return false;
 };

--- a/src/app/plugins/react-custom-html-parser.test.ts
+++ b/src/app/plugins/react-custom-html-parser.test.ts
@@ -478,12 +478,24 @@ describe('getReactCustomHtmlParser', () => {
   });
 
   it('does not render formatted currency amounts as math in raw text', () => {
-    const markup = renderLatexTextMarkup('$1234$ and $1,000.00$ and $5 USD$ and $19.99/mo$');
+    const markup = renderLatexTextMarkup(
+      '$1234$ and $1,000.00$ and $1.000,00$ and $5 USD$ and $19.99/mo$'
+    );
 
     expect(markup).toContain('$1234$');
     expect(markup).toContain('$1,000.00$');
+    expect(markup).toContain('$1.000,00$');
     expect(markup).toContain('$5 USD$');
     expect(markup).toContain('$19.99/mo$');
+    expect(markup).not.toContain('MathInline');
+  });
+
+  it('does not render currency ranges as math in raw text', () => {
+    const markup = renderLatexTextMarkup('$5-10$ and $5–10$ and $5-$10$');
+
+    expect(markup).toContain('$5-10$');
+    expect(markup).toContain('$5–10$');
+    expect(markup).toContain('$5-$10$');
     expect(markup).not.toContain('MathInline');
   });
 

--- a/src/app/plugins/react-custom-html-parser.test.ts
+++ b/src/app/plugins/react-custom-html-parser.test.ts
@@ -477,6 +477,23 @@ describe('getReactCustomHtmlParser', () => {
     expect(markup.match(/MathInline/g)).toHaveLength(1);
   });
 
+  it('does not render formatted currency amounts as math in raw text', () => {
+    const markup = renderLatexTextMarkup('$1234$ and $1,000.00$ and $5 USD$ and $19.99/mo$');
+
+    expect(markup).toContain('$1234$');
+    expect(markup).toContain('$1,000.00$');
+    expect(markup).toContain('$5 USD$');
+    expect(markup).toContain('$19.99/mo$');
+    expect(markup).not.toContain('MathInline');
+  });
+
+  it('renders numeric-leading expressions as math in raw text', () => {
+    const markup = renderLatexTextMarkup('$2sin(x)$');
+
+    expect(markup).toContain('MathInline');
+    expect(markup).toContain('katex');
+  });
+
   it('does not split URLs that contain dollar delimiters', () => {
     const markup = renderLatexTextMarkup('https://example.com/$x$/y');
 


### PR DESCRIPTION
## Summary
- Keep currency-like dollar-delimited text literal instead of rendering it through KaTeX.
- Cover formatted amounts such as `$1234$`, `$1,000.00$`, `$5 USD$`, and `$19.99/mo$` in compose and raw render paths.
- Preserve numeric-leading math expressions such as `$2sin(x)$`.

## Test Plan
- [x] `npm test -- src/app/components/editor/math.test.ts src/app/plugins/react-custom-html-parser.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint` (16 warnings, 0 errors - pre-existing baseline)
- [x] `npm test` (293 files, 2219 tests)
- [x] `npm run build`
- [x] `npx prettier --check FORK_CHANGES.md src/app/plugins/math.tsx src/app/components/editor/math.test.ts src/app/plugins/react-custom-html-parser.test.ts`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of currency-formatted text within messages. Currency amounts (e.g., "$5 USD$", "$1,234.00$", "$19.99/mo$") are now correctly rendered as plain text instead of being interpreted as mathematical equations. Mathematical expressions like "$2sin(x)$" continue to work properly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->