### PR TITLE
refactor(editor): isolate MindRoom paste marker and math extensions

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,68 @@
 
 ## Runbook
 
+### CINNY-124 - MindRoom editor extension boundary (2026-05-28)
+
+- Status:
+  - Complete locally; rebased on `origin/dev` and PR review comments addressed.
+- Summary:
+  - Added a fork-owned editor namespace under `src/app/mindroom/editor/`.
+  - Moved MindRoom paste-marker editor import/export helpers into
+    `MindroomEditorExtensions.ts`.
+  - Moved Matrix math editor markdown reconstruction helpers into
+    `MindroomEditorExtensions.ts`.
+  - Moved the MindRoom paste-marker Slate renderer into
+    `MindroomEditorElements.tsx`.
+  - Reduced generic editor ownership in `input.ts`, `output.ts`, and
+    `Elements.tsx` to small extension call sites.
+  - PR review follow-up: kept `isMindroomEditorMathElement` internal instead of
+    exporting it, added direct tests for exported helper contracts, and
+    documented risks in this runbook entry.
+- Decisions:
+  - Kept the generic editor's `BlockType.PasteMarker` and Slate
+    `PasteMarkerElement` type as unavoidable schema seams because Slate needs to
+    recognize the atomic node shape.
+  - Kept sanitizer/render/CSS files unchanged in this task; the render pipeline
+    remains separate.
+  - Kept Matrix event output stable by delegating the same paste-marker HTML and
+    plain-text serialization through the new extension API.
+- Risks:
+  - Concurrent render-policy work can make validation failures look editor
+    related; isolate failures by running the focused editor/math/paste-marker
+    tests before investigating renderer CSS setup.
+  - `BlockType.PasteMarker` and `PasteMarkerElement` remain exposed in the
+    generic editor schema; keep the atomic paste-marker node shape stable and
+    route policy changes through the MindRoom editor extension.
+  - Thin call sites in `input.ts`, `output.ts`, and `Elements.tsx` can still
+    regress generic editor behavior during upstream rebases; keep focused
+    editor math and paste-marker tests in normal Vitest discovery.
+  - If Matrix event output changes unexpectedly, compare
+    `pasteMarker.test.ts` serializer expectations and roll back the extension
+    delegation before changing paste-marker marker text or HTML attributes.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/components/editor/Elements.tsx`
+  - `src/app/components/editor/input.ts`
+  - `src/app/components/editor/output.ts`
+  - `src/app/mindroom/editor/MindroomEditorElements.tsx`
+  - `src/app/mindroom/editor/MindroomEditorExtensions.test.ts`
+  - `src/app/mindroom/editor/MindroomEditorExtensions.ts`
+- Tests and validation:
+  - Red check: `npm test -- src/app/mindroom/editor/MindroomEditorExtensions.test.ts`
+    initially failed because `MindroomEditorExtensions` did not exist.
+  - Green check: `npm test -- src/app/mindroom/editor/MindroomEditorExtensions.test.ts`
+    (2 tests).
+  - Green check: `npm test -- src/app/components/editor/math.test.ts src/app/components/editor/pasteMarker.test.ts src/app/mindroom/messages/pasteAttachmentMarker.test.ts`
+    (3 files, 15 tests).
+  - Green check after rebase/review follow-up: `npm test -- src/app/mindroom/editor/MindroomEditorExtensions.test.ts src/app/components/editor/math.test.ts src/app/components/editor/pasteMarker.test.ts src/app/mindroom/messages/pasteAttachmentMarker.test.ts`
+    (4 files, 20 tests).
+  - Green check: `npm run typecheck`.
+  - Green independent review: no task-specific findings in the inspected diff.
+  - Green check after rebase: `npm test` (294 files, 2223 tests).
+  - Green check: `git diff --check`.
+- Next steps:
+  - Monitor PR review bots for follow-up comments after the force-push.
+
 ### CINNY-117 - Currency-like dollar text stays out of math rendering (2026-05-28)
 
 - Status:

--- a/src/app/components/editor/Elements.tsx
+++ b/src/app/components/editor/Elements.tsx
@@ -14,13 +14,13 @@ import {
   EmoticonElement,
   LinkElement,
   MentionElement,
-  PasteMarkerElement,
 } from './slate';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { getBeginCommand } from './utils';
 import { BlockType } from './types';
 import { mxcUrlToHttp } from '../../utils/matrix';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { RenderMindroomEditorPasteMarkerElement } from '../../mindroom/editor/MindroomEditorElements';
 
 // Put this at the start and end of an inline component to work around this Chromium bug:
 // https://bugs.chromium.org/p/chromium/issues/detail?id=1249405
@@ -73,34 +73,6 @@ function RenderCommandElement({
       contentEditable={false}
     >
       {`/${element.command}`}
-      {children}
-    </span>
-  );
-}
-
-function RenderPasteMarkerElement({
-  attributes,
-  element,
-  children,
-}: { element: PasteMarkerElement } & RenderElementProps) {
-  const selected = useSelected();
-  const focused = useFocused();
-  const charLabel = `${element.chars.toLocaleString('en-US')} chars`;
-
-  return (
-    <span
-      {...attributes}
-      className={css.PasteMarker({
-        focus: selected && focused,
-      })}
-      contentEditable={false}
-      data-mindroom-paste-composer-badge
-      title={element.marker}
-    >
-      <span>Pasted text</span>
-      <span className={css.PasteMarkerMeta}>{element.id}</span>
-      <span className={css.PasteMarkerMeta}>{charLabel}</span>
-      <span className={css.PasteMarkerMeta}>{element.fileName}</span>
       {children}
     </span>
   );
@@ -252,9 +224,9 @@ export function RenderElement({ attributes, element, children }: RenderElementPr
       );
     case BlockType.PasteMarker:
       return (
-        <RenderPasteMarkerElement attributes={attributes} element={element}>
+        <RenderMindroomEditorPasteMarkerElement attributes={attributes} element={element}>
           {children}
-        </RenderPasteMarkerElement>
+        </RenderMindroomEditorPasteMarkerElement>
       );
     default:
       return (

--- a/src/app/components/editor/input.ts
+++ b/src/app/components/editor/input.ts
@@ -16,7 +16,6 @@ import {
   MentionElement,
   OrderedListElement,
   ParagraphElement,
-  PasteMarkerElement,
   UnorderedListElement,
 } from './slate';
 import { createEmoticonElement, createMentionElement } from './utils';
@@ -31,12 +30,14 @@ import {
   escapeMarkdownInlineSequences,
   escapeMarkdownBlockSequences,
 } from '../../plugins/markdown';
-import { parseMindroomPasteMarker } from '../../mindroom/messages/pasteAttachmentMarker';
+import {
+  getMindroomEditorMathText,
+  getMindroomEditorPasteMarkerElement,
+  isMindroomEditorMathBlockElement,
+  parseMindroomEditorMathBlock,
+} from '../../mindroom/editor/MindroomEditorExtensions';
 
 type ProcessTextCallback = (text: string) => string;
-
-const formatMathMarkdown = (latex: string, displayMode: boolean): string =>
-  displayMode ? `$$${latex}$$` : `$${latex}$`;
 
 const getText = (node: ChildNode): string => {
   if (isText(node)) {
@@ -46,16 +47,6 @@ const getText = (node: ChildNode): string => {
     return node.children.map((child) => getText(child)).join('');
   }
   return '';
-};
-
-const getMathLatex = (node: Element): string | undefined => {
-  const latex = node.attribs['data-mx-maths'];
-  if (typeof latex === 'string' && latex.length > 0) {
-    return latex;
-  }
-
-  const text = getText(node);
-  return text.length > 0 ? text : undefined;
 };
 
 const getInlineNodeMarkType = (node: Element): MarkType | undefined => {
@@ -148,24 +139,6 @@ const getInlineNonMarkElement = (node: Element): MentionElement | EmoticonElemen
   return undefined;
 };
 
-const getPasteMarkerElement = (node: Element): PasteMarkerElement | undefined => {
-  if (node.name !== 'span' || node.attribs['data-mindroom-paste-marker'] !== 'true') {
-    return undefined;
-  }
-
-  const marker = parseMindroomPasteMarker(getText(node));
-  if (!marker) return undefined;
-
-  return {
-    type: BlockType.PasteMarker,
-    id: marker.id,
-    chars: marker.chars,
-    fileName: marker.fileName,
-    marker: marker.raw,
-    children: [{ text: '' }],
-  };
-};
-
 const getInlineElement = (
   node: ChildNode,
   processText: ProcessTextCallback,
@@ -176,16 +149,10 @@ const getInlineElement = (
   }
 
   if (isTag(node)) {
-    const mathLatex =
-      (node.name === 'span' || node.name === 'div') && node.attribs['data-mx-maths'] !== undefined
-        ? getMathLatex(node)
-        : undefined;
-    if (mathLatex) {
-      const displayMode = node.name === 'div';
-      return [{ text: markdown ? formatMathMarkdown(mathLatex, displayMode) : mathLatex }];
-    }
+    const mathText = getMindroomEditorMathText(node, getText, markdown);
+    if (mathText) return [{ text: mathText }];
 
-    const pasteMarker = getPasteMarkerElement(node);
+    const pasteMarker = getMindroomEditorPasteMarkerElement(node, getText);
     if (pasteMarker) return [pasteMarker];
 
     const markType = getInlineNodeMarkType(node);
@@ -212,42 +179,6 @@ const getInlineElement = (
   }
 
   return [];
-};
-
-const parseMathBlockNode = (node: Element, markdown?: boolean): ParagraphElement[] => {
-  const latex = getMathLatex(node);
-  if (!latex) return [];
-
-  if (!markdown) {
-    return latex.split('\n').map<ParagraphElement>((lineText) => ({
-      type: BlockType.Paragraph,
-      children: [{ text: lineText }],
-    }));
-  }
-
-  if (!latex.includes('\n')) {
-    return [
-      {
-        type: BlockType.Paragraph,
-        children: [{ text: formatMathMarkdown(latex, true) }],
-      },
-    ];
-  }
-
-  return [
-    {
-      type: BlockType.Paragraph,
-      children: [{ text: '$$' }],
-    },
-    ...latex.split('\n').map<ParagraphElement>((lineText) => ({
-      type: BlockType.Paragraph,
-      children: [{ text: lineText }],
-    })),
-    {
-      type: BlockType.Paragraph,
-      children: [{ text: '$$' }],
-    },
-  ];
 };
 
 const parseBlockquoteNode = (
@@ -486,9 +417,9 @@ export const domToEditorInput = (
         return;
       }
 
-      if (node.name === 'div' && node.attribs['data-mx-maths'] !== undefined) {
+      if (isMindroomEditorMathBlockElement(node)) {
         appendLine();
-        children.push(...parseMathBlockNode(node, markdown));
+        children.push(...parseMindroomEditorMathBlock(node, getText, markdown));
         return;
       }
 

--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -13,9 +13,9 @@ import { findAndReplace } from '../../utils/findAndReplace';
 import { sanitizeForRegex } from '../../utils/regex';
 import { isUserId } from '../../utils/matrix';
 import {
-  formatMindroomPasteMarkerAsHtml,
-  parseMindroomPasteMarker,
-} from '../../mindroom/messages/pasteAttachmentMarker';
+  mindroomEditorPasteMarkerElementToCustomHtml,
+  mindroomEditorPasteMarkerElementToPlainText,
+} from '../../mindroom/editor/MindroomEditorExtensions';
 
 export type OutputOptions = {
   allowTextFormatting?: boolean;
@@ -85,10 +85,8 @@ const elementToCustomHtml = (node: CustomElement, children: string): string => {
       return `<a href="${encodeURI(node.href)}">${node.children}</a>`;
     case BlockType.Command:
       return `/${sanitizeText(node.command)}`;
-    case BlockType.PasteMarker: {
-      const marker = parseMindroomPasteMarker(node.marker);
-      return marker ? formatMindroomPasteMarkerAsHtml(marker) : sanitizeText(node.marker);
-    }
+    case BlockType.PasteMarker:
+      return mindroomEditorPasteMarkerElementToCustomHtml(node);
     default:
       return children;
   }
@@ -168,7 +166,7 @@ const elementToPlainText = (node: CustomElement, children: string): string => {
     case BlockType.Command:
       return `/${node.command}`;
     case BlockType.PasteMarker:
-      return node.marker;
+      return mindroomEditorPasteMarkerElementToPlainText(node);
     default:
       return children;
   }

--- a/src/app/mindroom/editor/MindroomEditorElements.tsx
+++ b/src/app/mindroom/editor/MindroomEditorElements.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { RenderElementProps, useFocused, useSelected } from 'slate-react';
+
+import type { PasteMarkerElement } from '../../components/editor/slate';
+import * as css from '../../styles/CustomHtml.css';
+
+export function RenderMindroomEditorPasteMarkerElement({
+  attributes,
+  element,
+  children,
+}: { element: PasteMarkerElement } & RenderElementProps) {
+  const selected = useSelected();
+  const focused = useFocused();
+  const charLabel = `${element.chars.toLocaleString('en-US')} chars`;
+
+  return (
+    <span
+      {...attributes}
+      className={css.PasteMarker({
+        focus: selected && focused,
+      })}
+      contentEditable={false}
+      data-mindroom-paste-composer-badge
+      title={element.marker}
+    >
+      <span>Pasted text</span>
+      <span className={css.PasteMarkerMeta}>{element.id}</span>
+      <span className={css.PasteMarkerMeta}>{charLabel}</span>
+      <span className={css.PasteMarkerMeta}>{element.fileName}</span>
+      {children}
+    </span>
+  );
+}

--- a/src/app/mindroom/editor/MindroomEditorExtensions.test.ts
+++ b/src/app/mindroom/editor/MindroomEditorExtensions.test.ts
@@ -1,0 +1,92 @@
+import parse from 'html-dom-parser';
+import { ChildNode, isTag } from 'domhandler';
+import { describe, expect, it } from 'vitest';
+
+import { BlockType } from '../../components/editor/types';
+import {
+  formatMindroomEditorMathMarkdown,
+  getMindroomEditorMathLatex,
+  getMindroomEditorMathText,
+  getMindroomEditorPasteMarkerElement,
+  isMindroomEditorMathBlockElement,
+  mindroomEditorPasteMarkerElementToCustomHtml,
+  mindroomEditorPasteMarkerElementToPlainText,
+  parseMindroomEditorMathBlock,
+} from './MindroomEditorExtensions';
+
+const marker =
+  '[[mindroom-paste:{"v":1,"id":"paste-a3f19c","chars":11,"file":"mindroom-paste-a3f19c.txt"}]]';
+
+const getText = (node: ChildNode): string => {
+  if ('data' in node && typeof node.data === 'string') return node.data;
+  if (isTag(node)) return node.children.map((child) => getText(child)).join('');
+  return '';
+};
+
+const parseSingleTag = (html: string) => {
+  const [node] = parse(html);
+  if (!isTag(node)) throw new Error('Expected one tag node.');
+  return node;
+};
+
+describe('Mindroom editor extension API', () => {
+  it('owns paste marker import and Matrix custom HTML export', () => {
+    const node = parseSingleTag(
+      [
+        '<span data-mindroom-paste-marker="true" data-mindroom-paste-id="paste-a3f19c" data-mindroom-paste-chars="11" data-mindroom-paste-file="mindroom-paste-a3f19c.txt">',
+        marker,
+        '</span>',
+      ].join('')
+    );
+
+    const element = getMindroomEditorPasteMarkerElement(node, getText);
+
+    expect(element).toEqual({
+      type: BlockType.PasteMarker,
+      id: 'paste-a3f19c',
+      chars: 11,
+      fileName: 'mindroom-paste-a3f19c.txt',
+      marker,
+      children: [{ text: '' }],
+    });
+    expect(mindroomEditorPasteMarkerElementToCustomHtml(element!)).toBe(
+      [
+        '<span data-mindroom-paste-marker="true" data-mindroom-paste-id="paste-a3f19c" data-mindroom-paste-chars="11" data-mindroom-paste-file="mindroom-paste-a3f19c.txt">',
+        '[[mindroom-paste:{&quot;v&quot;:1,&quot;id&quot;:&quot;paste-a3f19c&quot;,&quot;chars&quot;:11,&quot;file&quot;:&quot;mindroom-paste-a3f19c.txt&quot;}]]',
+        '</span>',
+      ].join('')
+    );
+    expect(mindroomEditorPasteMarkerElementToPlainText(element!)).toBe(marker);
+  });
+
+  it('owns Matrix math editor markdown reconstruction', () => {
+    const inlineNode = parseSingleTag('<span data-mx-maths="x^2">fallback</span>');
+    const blockNode = parseSingleTag(`<div data-mx-maths="a
+b">fallback</div>`);
+
+    expect(getMindroomEditorMathLatex(inlineNode, getText)).toBe('x^2');
+    expect(formatMindroomEditorMathMarkdown('x^2', false)).toBe('$x^2$');
+    expect(getMindroomEditorMathText(inlineNode, getText, true)).toBe('$x^2$');
+    expect(getMindroomEditorMathText(inlineNode, getText, false)).toBe('x^2');
+    expect(isMindroomEditorMathBlockElement(inlineNode)).toBe(false);
+    expect(isMindroomEditorMathBlockElement(blockNode)).toBe(true);
+    expect(parseMindroomEditorMathBlock(blockNode, getText, true)).toEqual([
+      {
+        type: BlockType.Paragraph,
+        children: [{ text: '$$' }],
+      },
+      {
+        type: BlockType.Paragraph,
+        children: [{ text: 'a' }],
+      },
+      {
+        type: BlockType.Paragraph,
+        children: [{ text: 'b' }],
+      },
+      {
+        type: BlockType.Paragraph,
+        children: [{ text: '$$' }],
+      },
+    ]);
+  });
+});

--- a/src/app/mindroom/editor/MindroomEditorExtensions.ts
+++ b/src/app/mindroom/editor/MindroomEditorExtensions.ts
@@ -1,0 +1,118 @@
+import { ChildNode, Element } from 'domhandler';
+
+import type { ParagraphElement, PasteMarkerElement } from '../../components/editor/slate';
+import { BlockType } from '../../components/editor/types';
+import { sanitizeText } from '../../utils/sanitize';
+import {
+  formatMindroomPasteMarkerAsHtml,
+  parseMindroomPasteMarker,
+} from '../messages/pasteAttachmentMarker';
+
+export type MindroomEditorTextExtractor = (node: ChildNode) => string;
+
+export const formatMindroomEditorMathMarkdown = (latex: string, displayMode: boolean): string =>
+  displayMode ? `$$${latex}$$` : `$${latex}$`;
+
+const isMindroomEditorMathElement = (node: Element): boolean =>
+  (node.name === 'span' || node.name === 'div') && node.attribs['data-mx-maths'] !== undefined;
+
+export const isMindroomEditorMathBlockElement = (node: Element): boolean =>
+  node.name === 'div' && node.attribs['data-mx-maths'] !== undefined;
+
+export const getMindroomEditorMathLatex = (
+  node: Element,
+  getText: MindroomEditorTextExtractor
+): string | undefined => {
+  const latex = node.attribs['data-mx-maths'];
+  if (typeof latex === 'string' && latex.length > 0) {
+    return latex;
+  }
+
+  const text = getText(node);
+  return text.length > 0 ? text : undefined;
+};
+
+export const getMindroomEditorMathText = (
+  node: Element,
+  getText: MindroomEditorTextExtractor,
+  markdown?: boolean
+): string | undefined => {
+  if (!isMindroomEditorMathElement(node)) return undefined;
+
+  const latex = getMindroomEditorMathLatex(node, getText);
+  if (!latex) return undefined;
+
+  const displayMode = node.name === 'div';
+  return markdown ? formatMindroomEditorMathMarkdown(latex, displayMode) : latex;
+};
+
+export const parseMindroomEditorMathBlock = (
+  node: Element,
+  getText: MindroomEditorTextExtractor,
+  markdown?: boolean
+): ParagraphElement[] => {
+  const latex = getMindroomEditorMathLatex(node, getText);
+  if (!latex) return [];
+
+  if (!markdown) {
+    return latex.split('\n').map<ParagraphElement>((lineText) => ({
+      type: BlockType.Paragraph,
+      children: [{ text: lineText }],
+    }));
+  }
+
+  if (!latex.includes('\n')) {
+    return [
+      {
+        type: BlockType.Paragraph,
+        children: [{ text: formatMindroomEditorMathMarkdown(latex, true) }],
+      },
+    ];
+  }
+
+  return [
+    {
+      type: BlockType.Paragraph,
+      children: [{ text: '$$' }],
+    },
+    ...latex.split('\n').map<ParagraphElement>((lineText) => ({
+      type: BlockType.Paragraph,
+      children: [{ text: lineText }],
+    })),
+    {
+      type: BlockType.Paragraph,
+      children: [{ text: '$$' }],
+    },
+  ];
+};
+
+export const getMindroomEditorPasteMarkerElement = (
+  node: Element,
+  getText: MindroomEditorTextExtractor
+): PasteMarkerElement | undefined => {
+  if (node.name !== 'span' || node.attribs['data-mindroom-paste-marker'] !== 'true') {
+    return undefined;
+  }
+
+  const marker = parseMindroomPasteMarker(getText(node));
+  if (!marker) return undefined;
+
+  return {
+    type: BlockType.PasteMarker,
+    id: marker.id,
+    chars: marker.chars,
+    fileName: marker.fileName,
+    marker: marker.raw,
+    children: [{ text: '' }],
+  };
+};
+
+export const mindroomEditorPasteMarkerElementToCustomHtml = (
+  node: PasteMarkerElement
+): string => {
+  const marker = parseMindroomPasteMarker(node.marker);
+  return marker ? formatMindroomPasteMarkerAsHtml(marker) : sanitizeText(node.marker);
+};
+
+export const mindroomEditorPasteMarkerElementToPlainText = (node: PasteMarkerElement): string =>
+  node.marker;


### PR DESCRIPTION
## Summary
- Add a fork-owned `src/app/mindroom/editor/` boundary for paste-marker editor import/export and Matrix math editor reconstruction.
- Move paste-marker Slate rendering into the MindRoom editor namespace.
- Keep generic editor files as thin extension callers without changing Matrix event output behavior.

## Validation
- `npm test -- src/app/mindroom/editor/MindroomEditorExtensions.test.ts`
- `npm test -- src/app/components/editor/math.test.ts src/app/components/editor/pasteMarker.test.ts src/app/mindroom/messages/pasteAttachmentMarker.test.ts`
- `npm run typecheck`
- `git diff --check`
- Independent review: no task-specific findings.

## Note
Full `npm test` was run in the shared worktree and failed only in unrelated concurrent render-policy work: `src/app/mindroom/messages/renderMindroomMessageContent.test.ts` hits a vanilla-extract file-scope error from `MindroomHtmlBlocks.css.ts`, which this PR does not touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured editor architecture for paste markers and mathematical content handling within the Mindroom editor extension namespace to improve code organization and reduce duplication across components.

* **Tests**
  * Added test coverage for paste marker import/export and mathematical content reconstruction.

* **Chores**
  * Updated documentation to record refactoring details and validation status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->