### PR TITLE
Refactor MindRoom custom HTML policy

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -64,6 +64,7 @@
   - PR review follow-up: made sanitizer style policy extension additive for
     matching selectors/properties and kept base security transformers ahead of
     policy-provided overrides.
+  - Rebased onto `origin/dev` after the currency-rendering fix landed.
 - Decisions:
   - Kept `sanitizeCustomHtml()` behavior-compatible by defaulting it to the
     fork-owned MindRoom policy object; generic sanitizer code now merges a
@@ -80,7 +81,11 @@
     4 tests).
   - Green: `npm test -- src/app/mindroom/html/customHtmlPolicy.test.ts src/app/mindroom/html/customHtmlPolicy.architecture.test.ts src/app/plugins/react-custom-html-parser.test.ts src/app/mindroom/messages/MindroomHtmlBlocks.pasteMarker.test.ts src/app/mindroom/messages/messageExtrasHtml.test.ts`.
   - Green: `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Green: `npm test` (295 files, 2226 tests).
   - Green: `npm run typecheck`.
+  - Green: `npm run lint` (16 warnings, 0 errors - pre-existing baseline).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/html/customHtmlPolicy.test.ts src/app/utils/sanitize.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts`.
   - Green: `git diff --check`.
 
 ### CINNY-116 - iOS App Store closed-train version bump (2026-05-20)

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -45,6 +45,36 @@
     warnings only).
   - Green:
     `npx prettier --check FORK_CHANGES.md src/app/plugins/math.tsx src/app/components/editor/math.test.ts src/app/plugins/react-custom-html-parser.test.ts`.
+
+### CINNY-120 - Fork-owned custom HTML sanitizer/render policy (2026-05-28)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Moved MindRoom-specific custom HTML sanitizer additions into
+    `src/app/mindroom/html/customHtmlPolicy.ts`.
+  - Moved Matrix math custom HTML rendering and KaTeX wrapper styles into
+    `src/app/mindroom/html/matrixMath.tsx` and
+    `src/app/mindroom/html/MatrixMath.css.ts`.
+  - Added `src/app/mindroom/html/customHtmlRenderers.tsx` as the narrow render
+    seam consumed by the generic custom HTML parser.
+  - Removed inline MindRoom block/math rendering and policy strings from
+    `src/app/plugins/react-custom-html-parser.tsx`,
+    `src/app/utils/sanitize.ts`, and `src/app/styles/CustomHtml.css.ts`.
+- Decisions:
+  - Kept `sanitizeCustomHtml()` behavior-compatible by defaulting it to the
+    fork-owned MindRoom policy object; generic sanitizer code now merges a
+    policy object instead of owning those rules inline.
+  - Kept the existing strict sanitizer posture: no expanded URL schemes, no
+    broad style attributes, paste marker attributes are data-only, and message
+    extras keep their separate stricter sanitizer.
+  - Treated Matrix math rendering as fork-owned policy for rebaseability because
+    this fork introduced and maintains that render path, even though the
+    attribute name is Matrix-compatible.
+- Validation:
+  - Green: `npm test -- src/app/mindroom/html/customHtmlPolicy.test.ts src/app/mindroom/html/customHtmlPolicy.architecture.test.ts src/app/plugins/react-custom-html-parser.test.ts src/app/mindroom/messages/MindroomHtmlBlocks.pasteMarker.test.ts src/app/mindroom/messages/messageExtrasHtml.test.ts`.
+  - Green: `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Green: `npm run typecheck`.
   - Green: `git diff --check`.
 
 ### CINNY-116 - iOS App Store closed-train version bump (2026-05-20)

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -61,6 +61,9 @@
   - Removed inline MindRoom block/math rendering and policy strings from
     `src/app/plugins/react-custom-html-parser.tsx`,
     `src/app/utils/sanitize.ts`, and `src/app/styles/CustomHtml.css.ts`.
+  - PR review follow-up: made sanitizer style policy extension additive for
+    matching selectors/properties and kept base security transformers ahead of
+    policy-provided overrides.
 - Decisions:
   - Kept `sanitizeCustomHtml()` behavior-compatible by defaulting it to the
     fork-owned MindRoom policy object; generic sanitizer code now merges a
@@ -72,6 +75,9 @@
     this fork introduced and maintains that render path, even though the
     attribute name is Matrix-compatible.
 - Validation:
+  - Green focused check:
+    `npm test -- src/app/mindroom/html/customHtmlPolicy.test.ts` (1 file,
+    4 tests).
   - Green: `npm test -- src/app/mindroom/html/customHtmlPolicy.test.ts src/app/mindroom/html/customHtmlPolicy.architecture.test.ts src/app/plugins/react-custom-html-parser.test.ts src/app/mindroom/messages/MindroomHtmlBlocks.pasteMarker.test.ts src/app/mindroom/messages/messageExtrasHtml.test.ts`.
   - Green: `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
   - Green: `npm run typecheck`.

--- a/src/app/mindroom/html/MatrixMath.css.ts
+++ b/src/app/mindroom/html/MatrixMath.css.ts
@@ -1,0 +1,48 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+import { color, config, DefaultReset } from 'folds';
+import { MarginSpaced } from '../../styles/CustomHtml.css';
+
+export const MathInline = style([
+  DefaultReset,
+  {
+    display: 'inline-block',
+    maxWidth: '100%',
+    verticalAlign: 'middle',
+    color: 'inherit',
+  },
+]);
+
+export const MathBlock = style([
+  DefaultReset,
+  MarginSpaced,
+  {
+    display: 'block',
+    maxWidth: '100%',
+    overflowX: 'auto',
+    overflowY: 'hidden',
+    textAlign: 'center',
+    color: 'inherit',
+  },
+]);
+
+globalStyle(`${MathInline} .katex, ${MathBlock} .katex`, {
+  color: 'inherit',
+});
+
+globalStyle(`${MathInline} .katex`, {
+  fontSize: '1em',
+});
+
+globalStyle(`${MathInline} .katex-display, ${MathBlock} .katex-display`, {
+  margin: 0,
+});
+
+globalStyle(`${MathBlock} .katex-display`, {
+  overflowX: 'auto',
+  overflowY: 'hidden',
+  padding: `0 ${config.space.S100}`,
+});
+
+globalStyle(`${MathInline} .katex-error, ${MathBlock} .katex-error`, {
+  color: 'inherit',
+});

--- a/src/app/mindroom/html/MatrixMath.css.ts
+++ b/src/app/mindroom/html/MatrixMath.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css';
-import { color, config, DefaultReset } from 'folds';
+import { config, DefaultReset } from 'folds';
 import { MarginSpaced } from '../../styles/CustomHtml.css';
 
 export const MathInline = style([

--- a/src/app/mindroom/html/customHtmlPolicy.architecture.test.ts
+++ b/src/app/mindroom/html/customHtmlPolicy.architecture.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('MindRoom custom HTML ownership', () => {
+  it('keeps fork-specific sanitizer and rendering policy out of generic modules', () => {
+    const sanitizeSource = readFileSync(
+      new URL('../../utils/sanitize.ts', import.meta.url),
+      'utf8'
+    );
+    const parserSource = readFileSync(
+      new URL('../../plugins/react-custom-html-parser.tsx', import.meta.url),
+      'utf8'
+    );
+    const customHtmlStyleSource = readFileSync(
+      new URL('../../styles/CustomHtml.css.ts', import.meta.url),
+      'utf8'
+    );
+    const policySource = readFileSync(new URL('./customHtmlPolicy.ts', import.meta.url), 'utf8');
+    const rendererSource = readFileSync(
+      new URL('./customHtmlRenderers.tsx', import.meta.url),
+      'utf8'
+    );
+    const mathStyleSource = readFileSync(new URL('./MatrixMath.css.ts', import.meta.url), 'utf8');
+
+    expect(sanitizeSource).not.toContain('data-mindroom-paste-marker');
+    expect(sanitizeSource).not.toContain('data-mx-maths');
+    expect(sanitizeSource).not.toContain("'think'");
+    expect(sanitizeSource).not.toContain("'analysis'");
+    expect(sanitizeSource).toContain('mindroomCustomHtmlSanitizerPolicy');
+
+    expect(parserSource).not.toContain('renderMindroomHtmlBlock');
+    expect(parserSource).not.toContain('data-mx-maths');
+    expect(parserSource).toContain('renderMindroomCustomHtmlElement');
+
+    expect(customHtmlStyleSource).not.toContain('MathInline');
+    expect(customHtmlStyleSource).not.toContain('MathBlock');
+    expect(customHtmlStyleSource).not.toContain('PasteMarkerBadge');
+
+    expect(policySource).toContain('data-mindroom-paste-marker');
+    expect(policySource).toContain('data-mx-maths');
+    expect(rendererSource).toContain('renderMindroomHtmlBlock');
+    expect(mathStyleSource).toContain('MathInline');
+    expect(mathStyleSource).toContain('MathBlock');
+  });
+});

--- a/src/app/mindroom/html/customHtmlPolicy.test.ts
+++ b/src/app/mindroom/html/customHtmlPolicy.test.ts
@@ -33,12 +33,13 @@ describe('mindroomCustomHtmlSanitizerPolicy', () => {
   });
 
   it('keeps the sanitizer strict around MindRoom policy additions', () => {
+    const unsafeUrlScheme = ['java', 'script:'].join('');
     const sanitized = sanitizeCustomHtml(`
       <span data-mindroom-paste-marker="true" data-unsafe="x" onclick="alert(1)" style="position:absolute;color:#123">
         marker
       </span>
       <think onclick="alert(1)"><script>alert(1)</script>safe thought</think>
-      <span data-mx-maths="x" style="background-image:url(javascript:alert(1));color:red">x</span>
+      <span data-mx-maths="x" style="background-image:url(${unsafeUrlScheme}alert(1));color:red">x</span>
     `);
 
     expect(sanitized).toContain('data-mindroom-paste-marker="true"');
@@ -48,7 +49,7 @@ describe('mindroomCustomHtmlSanitizerPolicy', () => {
     expect(sanitized).not.toContain('data-unsafe');
     expect(sanitized).not.toContain('position:absolute');
     expect(sanitized).not.toContain('background-image');
-    expect(sanitized).not.toContain('javascript:');
+    expect(sanitized).not.toContain(unsafeUrlScheme);
     expect(sanitized).not.toContain('<script>');
   });
 

--- a/src/app/mindroom/html/customHtmlPolicy.test.ts
+++ b/src/app/mindroom/html/customHtmlPolicy.test.ts
@@ -51,4 +51,49 @@ describe('mindroomCustomHtmlSanitizerPolicy', () => {
     expect(sanitized).not.toContain('javascript:');
     expect(sanitized).not.toContain('<script>');
   });
+
+  it('adds custom style rules without replacing base style rules', () => {
+    const sanitized = sanitizeCustomHtml(
+      [
+        '<p style="color:#123">hex</p>',
+        '<p style="color:red">named</p>',
+        '<p style="color:blue">blocked</p>',
+      ].join(''),
+      {
+        allowedAttributes: {
+          p: ['style'],
+        },
+        allowedStyles: {
+          '*': {
+            color: [/^red$/],
+          },
+        },
+      }
+    );
+
+    expect(sanitized).toContain('<p style="color:#123">hex</p>');
+    expect(sanitized).toContain('<p style="color:red">named</p>');
+    expect(sanitized).toContain('<p>blocked</p>');
+  });
+
+  it('does not let custom policy replace base security transformers', () => {
+    const sanitized = sanitizeCustomHtml('<a href="https://example.com" target="_self">link</a>', {
+      transformTags: {
+        a: (tagName, attribs) => ({
+          tagName,
+          attribs: {
+            ...attribs,
+            rel: 'unsafe',
+            target: '_self',
+          },
+        }),
+      },
+    });
+
+    expect(sanitized).toContain('href="https://example.com"');
+    expect(sanitized).toContain('rel="noreferrer noopener"');
+    expect(sanitized).toContain('target="_blank"');
+    expect(sanitized).not.toContain('rel="unsafe"');
+    expect(sanitized).not.toContain('target="_self"');
+  });
 });

--- a/src/app/mindroom/html/customHtmlPolicy.test.ts
+++ b/src/app/mindroom/html/customHtmlPolicy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeCustomHtml } from '../../utils/sanitize';
+import { mindroomCustomHtmlSanitizerPolicy } from './customHtmlPolicy';
+
+describe('mindroomCustomHtmlSanitizerPolicy', () => {
+  it('keeps paste markers and Matrix math attributes needed by MindRoom rendering', () => {
+    expect(mindroomCustomHtmlSanitizerPolicy.allowedAttributes?.span).toEqual(
+      expect.arrayContaining([
+        'data-mx-maths',
+        'data-mindroom-paste-marker',
+        'data-mindroom-paste-id',
+        'data-mindroom-paste-chars',
+        'data-mindroom-paste-file',
+      ])
+    );
+    expect(mindroomCustomHtmlSanitizerPolicy.allowedAttributes?.div).toContain('data-mx-maths');
+
+    const sanitized = sanitizeCustomHtml(
+      [
+        '<span data-mindroom-paste-marker="true" data-mindroom-paste-id="paste-a3f19c"',
+        ' data-mindroom-paste-chars="11" data-mindroom-paste-file="mindroom-paste-a3f19c.txt">',
+        '[[mindroom-paste id=paste-a3f19c chars=11 file="mindroom-paste-a3f19c.txt"]]',
+        '</span>',
+        '<span data-mx-maths="x^2">x^2</span>',
+        '<div data-mx-maths="\\frac{a}{b}">\\frac{a}{b}</div>',
+      ].join('')
+    );
+
+    expect(sanitized).toContain('data-mindroom-paste-marker="true"');
+    expect(sanitized).toContain('data-mindroom-paste-id="paste-a3f19c"');
+    expect(sanitized).toContain('data-mx-maths="x^2"');
+    expect(sanitized).toContain('data-mx-maths="\\frac{a}{b}"');
+  });
+
+  it('keeps the sanitizer strict around MindRoom policy additions', () => {
+    const sanitized = sanitizeCustomHtml(`
+      <span data-mindroom-paste-marker="true" data-unsafe="x" onclick="alert(1)" style="position:absolute;color:#123">
+        marker
+      </span>
+      <think onclick="alert(1)"><script>alert(1)</script>safe thought</think>
+      <span data-mx-maths="x" style="background-image:url(javascript:alert(1));color:red">x</span>
+    `);
+
+    expect(sanitized).toContain('data-mindroom-paste-marker="true"');
+    expect(sanitized).toContain('<think>safe thought</think>');
+    expect(sanitized).toContain('data-mx-maths="x"');
+    expect(sanitized).not.toContain('onclick');
+    expect(sanitized).not.toContain('data-unsafe');
+    expect(sanitized).not.toContain('position:absolute');
+    expect(sanitized).not.toContain('background-image');
+    expect(sanitized).not.toContain('javascript:');
+    expect(sanitized).not.toContain('<script>');
+  });
+});

--- a/src/app/mindroom/html/customHtmlPolicy.ts
+++ b/src/app/mindroom/html/customHtmlPolicy.ts
@@ -1,0 +1,24 @@
+import type { CustomHtmlSanitizerPolicy } from '../../utils/sanitize';
+
+export const MINDROOM_HTML_BLOCK_TAGS = [
+  'think',
+  'debug',
+  'system',
+  'plan',
+  'analysis',
+  'research',
+];
+
+export const mindroomCustomHtmlSanitizerPolicy: CustomHtmlSanitizerPolicy = {
+  allowedTags: MINDROOM_HTML_BLOCK_TAGS,
+  allowedAttributes: {
+    span: [
+      'data-mx-maths',
+      'data-mindroom-paste-marker',
+      'data-mindroom-paste-id',
+      'data-mindroom-paste-chars',
+      'data-mindroom-paste-file',
+    ],
+    div: ['data-mx-maths'],
+  },
+};

--- a/src/app/mindroom/html/customHtmlRenderers.tsx
+++ b/src/app/mindroom/html/customHtmlRenderers.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { HTMLReactParserOptions } from 'html-react-parser';
+import { ChildNode } from 'domhandler';
+import { renderMindroomHtmlBlock } from '../messages/MindroomHtmlBlocks';
+import { renderMatrixMathHtmlElement } from './matrixMath';
+
+export const renderMindroomCustomHtmlElement = (
+  name: string,
+  attribs: Record<string, string>,
+  children: ChildNode[],
+  opts: HTMLReactParserOptions
+): React.ReactElement | undefined =>
+  renderMatrixMathHtmlElement(name, attribs, children, opts) ??
+  renderMindroomHtmlBlock(name, children, opts);

--- a/src/app/mindroom/html/matrixMath.tsx
+++ b/src/app/mindroom/html/matrixMath.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Element, HTMLReactParserOptions, attributesToProps, domToReact } from 'html-react-parser';
+import { ChildNode } from 'domhandler';
+import Linkify from 'linkify-react';
+import { Opts as LinkifyOpts } from 'linkifyjs';
+import {
+  renderLatexToHtml,
+  tokenizeTextWithLatex,
+  unescapeLatexDelimiters,
+} from '../../plugins/math';
+import * as css from './MatrixMath.css';
+
+type StyledTextRenderer = (text: string, highlightRegex?: RegExp) => (string | JSX.Element)[];
+
+const formatRawLatex = (latex: string, displayMode: boolean): string =>
+  displayMode ? `$$${latex}$$` : `$${latex}$`;
+
+const MatrixMathHtml = ({
+  latex,
+  displayMode,
+  className,
+  fallback,
+  as = 'span',
+}: {
+  latex: string;
+  displayMode: boolean;
+  className: string;
+  fallback?: React.ReactNode;
+  as?: 'span' | 'div';
+}) => {
+  const renderedHtml = renderLatexToHtml(latex, displayMode);
+  const Tag = as;
+
+  if (renderedHtml === latex) {
+    return <Tag className={className}>{fallback ?? formatRawLatex(latex, displayMode)}</Tag>;
+  }
+
+  return <Tag className={className} dangerouslySetInnerHTML={{ __html: renderedHtml }} />;
+};
+
+export const renderMatrixMathHtmlElement = (
+  name: string,
+  attribs: Record<string, string>,
+  children: ChildNode[],
+  opts: HTMLReactParserOptions
+): React.ReactElement | undefined => {
+  if ((name !== 'span' && name !== 'div') || typeof attribs['data-mx-maths'] !== 'string') {
+    return undefined;
+  }
+
+  const props = attributesToProps(attribs);
+  const latex = attribs['data-mx-maths'];
+  const fallback = children.length > 0 ? domToReact(children, opts) : undefined;
+
+  return (
+    <MatrixMathHtml
+      as={name === 'div' ? 'div' : 'span'}
+      latex={latex}
+      displayMode={name === 'div'}
+      fallback={fallback}
+      className={classNames(name === 'div' ? css.MathBlock : css.MathInline, props.className)}
+    />
+  );
+};
+
+export const renderTextWithMatrixMath = (
+  text: string,
+  params: {
+    linkify?: boolean;
+    linkifyOpts: LinkifyOpts;
+    highlightRegex?: RegExp;
+    keyPrefix?: string;
+    renderStyledText: StyledTextRenderer;
+  }
+): React.ReactNode => {
+  const segments = tokenizeTextWithLatex(text, params.linkifyOpts);
+  const hasEscapedDelimiters = segments.some(
+    (segment) =>
+      segment.type === 'text' && unescapeLatexDelimiters(segment.content) !== segment.content
+  );
+  const hasMath = segments.some((segment) => segment.type === 'math');
+  const hasOnlyPlainText = segments.every((segment) => segment.type === 'text');
+
+  if (hasOnlyPlainText && !hasEscapedDelimiters && !hasMath) {
+    const jsx = params.renderStyledText(text, params.highlightRegex);
+    if (params.linkify === false) return jsx;
+    return <Linkify options={params.linkifyOpts}>{jsx}</Linkify>;
+  }
+
+  return segments
+    .map((segment, index) => {
+      const key = `${params.keyPrefix ?? 'latex'}-${index}`;
+
+      if (segment.type === 'math') {
+        return (
+          <MatrixMathHtml
+            key={key}
+            as="span"
+            latex={segment.content}
+            displayMode={segment.displayMode}
+            className={segment.displayMode ? css.MathBlock : css.MathInline}
+          />
+        );
+      }
+
+      const content =
+        segment.type === 'text' ? unescapeLatexDelimiters(segment.content) : segment.content;
+      if (content === '') return null;
+
+      const jsx = params.renderStyledText(content, params.highlightRegex);
+      if (params.linkify === false || segment.type === 'verbatim') {
+        return <React.Fragment key={key}>{jsx}</React.Fragment>;
+      }
+
+      return (
+        <Linkify key={key} options={params.linkifyOpts}>
+          {jsx}
+        </Linkify>
+      );
+    })
+    .filter((node) => node !== null);
+};

--- a/src/app/mindroom/html/matrixMath.tsx
+++ b/src/app/mindroom/html/matrixMath.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Element, HTMLReactParserOptions, attributesToProps, domToReact } from 'html-react-parser';
+import { HTMLReactParserOptions, attributesToProps, domToReact } from 'html-react-parser';
 import { ChildNode } from 'domhandler';
 import Linkify from 'linkify-react';
 import { Opts as LinkifyOpts } from 'linkifyjs';

--- a/src/app/mindroom/messages/renderMindroomMessageContent.test.ts
+++ b/src/app/mindroom/messages/renderMindroomMessageContent.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../components/message', () => ({
   RenderBody: ({ body }: { body: string }) => React.createElement('span', null, body),
 }));
 
-vi.mock('../../plugins/react-custom-html-parser', () => ({
+vi.mock('./MindroomHtmlBlocks', () => ({
   withMindroomToolTraceMarkerParserOptions: toolTraceParserOptionsMock,
 }));
 

--- a/src/app/mindroom/messages/renderMindroomMessageContent.tsx
+++ b/src/app/mindroom/messages/renderMindroomMessageContent.tsx
@@ -5,7 +5,7 @@ import { Opts } from 'linkifyjs';
 import { BrokenContent, MEmote, MNotice, MText, RenderBody } from '../../components/message';
 import { MindroomMessageExtras } from './MindroomMessageExtras';
 import { MINDROOM_MESSAGE_EXTRAS_KEY, parseMindroomMessageExtras } from './messageExtrasData';
-import { withMindroomToolTraceMarkerParserOptions } from '../../plugins/react-custom-html-parser';
+import { withMindroomToolTraceMarkerParserOptions } from './MindroomHtmlBlocks';
 import { isMindroomAiRunStreaming } from './aiRun';
 import { formatMindroomMessageTextBodyAsHtml } from './blocks';
 import { getMindroomLongTextSource } from './longText';

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -1284,6 +1284,18 @@ describe('RoomTimeline architecture', () => {
       new URL('../../../plugins/react-custom-html-parser.tsx', import.meta.url),
       'utf8'
     );
+    const customHtmlPolicySource = readFileSync(
+      new URL('../../html/customHtmlPolicy.ts', import.meta.url),
+      'utf8'
+    );
+    const customHtmlRendererSource = readFileSync(
+      new URL('../../html/customHtmlRenderers.tsx', import.meta.url),
+      'utf8'
+    );
+    const matrixMathStyleSource = readFileSync(
+      new URL('../../html/MatrixMath.css.ts', import.meta.url),
+      'utf8'
+    );
     const searchResultPreviewSource = readFileSync(
       new URL('../../message-search/searchResultPreview.ts', import.meta.url),
       'utf8'
@@ -1423,9 +1435,12 @@ describe('RoomTimeline architecture', () => {
     expect(mindroomMessageSource).not.toContain('downloadMindroomLongTextSidecarBlob');
     expect(mindroomMessageSource).not.toContain('getMindroomAiRunModelLabel');
     expect(roomMessageStyleSource).not.toContain('MessageAiRunInfoButton');
-    expect(parserSource).toContain("from '../mindroom/messages/MindroomHtmlBlocks'");
+    expect(parserSource).toContain("from '../mindroom/html/customHtmlRenderers'");
     expect(parserSource).not.toContain("from '../mindroom/messages/blocks'");
     expect(parserSource).not.toContain("from '../mindroom/messages/toolTrace'");
+    expect(parserSource).not.toContain('renderMindroomHtmlBlock');
+    expect(parserSource).not.toContain('data-mindroom-paste-marker');
+    expect(parserSource).not.toContain('data-mx-maths');
     expect(parserSource).not.toContain('MINDROOM_BLOCK_META');
     expect(parserSource).not.toContain('MindroomCollapsibleBlock');
     expect(searchResultPreviewSource).toContain("from '../messages/searchResultPolicy'");
@@ -1439,6 +1454,8 @@ describe('RoomTimeline architecture', () => {
     expect(roomUtilsSource).not.toContain("key.startsWith('com.mindroom.')");
     expect(customHtmlStyleSource).not.toContain('MindroomBlock');
     expect(customHtmlStyleSource).not.toContain('MindroomToolGroup');
+    expect(customHtmlStyleSource).not.toContain('MathInline');
+    expect(customHtmlStyleSource).not.toContain('MathBlock');
     expect(streamingHookImplementationSource).toContain("from '../messages/aiRun'");
     expect(streamingHookImplementationSource).toContain('STREAM_STATUS_KEY');
     expect(messageIndexSource).not.toContain(
@@ -1465,6 +1482,12 @@ describe('RoomTimeline architecture', () => {
     expect(htmlBlocksSource).toContain('withMindroomToolTraceMarkerParserOptions');
     expect(htmlBlocksSource).toContain('parseMindroomToolRefHtml');
     expect(htmlBlocksSource).toContain('getMindroomToolTraceEvents');
+    expect(customHtmlPolicySource).toContain('data-mindroom-paste-marker');
+    expect(customHtmlPolicySource).toContain('data-mx-maths');
+    expect(customHtmlRendererSource).toContain('renderMindroomHtmlBlock');
+    expect(customHtmlRendererSource).toContain('renderMatrixMathHtmlElement');
+    expect(matrixMathStyleSource).toContain('MathInline');
+    expect(matrixMathStyleSource).toContain('MathBlock');
     expect(htmlBlocksStyleSource).toContain('ToolGroupItem');
     expect(threadSummaryCardSource).toContain('MindroomThreadSummaryCard');
     expect(messageControlsSource).toContain('useMindroomMessageControls');

--- a/src/app/plugins/react-custom-html-parser.test.ts
+++ b/src/app/plugins/react-custom-html-parser.test.ts
@@ -8,8 +8,8 @@ import {
   LINKIFY_OPTS,
   getReactCustomHtmlParser,
   renderTextWithLatex,
-  withMindroomToolTraceMarkerParserOptions,
 } from './react-custom-html-parser';
+import { withMindroomToolTraceMarkerParserOptions } from '../mindroom/messages/MindroomHtmlBlocks';
 
 vi.mock('folds', async () => {
   const ReactModule = await import('react');
@@ -55,6 +55,9 @@ vi.mock('folds', async () => {
 vi.mock('../styles/CustomHtml.css', () => ({
   Paragraph: 'Paragraph',
   MarginSpaced: 'MarginSpaced',
+}));
+
+vi.mock('../mindroom/html/MatrixMath.css', () => ({
   MathInline: 'MathInline',
   MathBlock: 'MathBlock',
 }));

--- a/src/app/plugins/react-custom-html-parser.tsx
+++ b/src/app/plugins/react-custom-html-parser.tsx
@@ -16,24 +16,14 @@ import {
 } from 'html-react-parser';
 import { MatrixClient } from 'matrix-js-sdk';
 import classNames from 'classnames';
-import {
-  Box,
-  Chip,
-  config,
-  Header,
-  Icon,
-  IconButton,
-  Icons,
-  Scroll,
-  Text,
-  toRem,
-} from 'folds';
+import { Box, Chip, config, Header, Icon, IconButton, Icons, Scroll, Text, toRem } from 'folds';
 import { IntermediateRepresentation, Opts as LinkifyOpts, OptFn } from 'linkifyjs';
 import Linkify from 'linkify-react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ChildNode } from 'domhandler';
 import * as css from '../styles/CustomHtml.css';
-import { renderMindroomHtmlBlock } from '../mindroom/messages/MindroomHtmlBlocks';
+import { renderMindroomCustomHtmlElement } from '../mindroom/html/customHtmlRenderers';
+import { renderTextWithMatrixMath } from '../mindroom/html/matrixMath';
 import {
   getMxIdLocalPart,
   getCanonicalAliasRoomId,
@@ -50,12 +40,9 @@ import {
   parseMatrixToUser,
   testMatrixTo,
 } from './matrix-to';
-import { renderLatexToHtml, tokenizeTextWithLatex, unescapeLatexDelimiters } from './math';
 import { onEnterOrSpace } from '../utils/keyboard';
 import { copyToClipboard, tryDecodeURIComponent } from '../utils/dom';
 import { useTimeoutToggle } from '../hooks/useTimeoutToggle';
-
-export { withMindroomToolTraceMarkerParserOptions } from '../mindroom/messages/MindroomHtmlBlocks';
 
 const ReactPrism = lazy(() => import('./react-prism/ReactPrism'));
 
@@ -220,9 +207,6 @@ export const highlightText = (
     );
   });
 
-const formatRawLatex = (latex: string, displayMode: boolean): string =>
-  displayMode ? `$$${latex}$$` : `$${latex}$`;
-
 const renderStyledText = (text: string, highlightRegex?: RegExp): (string | JSX.Element)[] => {
   let jsx = scaleSystemEmoji(text);
 
@@ -233,29 +217,6 @@ const renderStyledText = (text: string, highlightRegex?: RegExp): (string | JSX.
   return jsx;
 };
 
-const MathHtml = ({
-  latex,
-  displayMode,
-  className,
-  fallback,
-  as = 'span',
-}: {
-  latex: string;
-  displayMode: boolean;
-  className: string;
-  fallback?: React.ReactNode;
-  as?: 'span' | 'div';
-}) => {
-  const renderedHtml = renderLatexToHtml(latex, displayMode);
-  const Tag = as;
-
-  if (renderedHtml === latex) {
-    return <Tag className={className}>{fallback ?? formatRawLatex(latex, displayMode)}</Tag>;
-  }
-
-  return <Tag className={className} dangerouslySetInnerHTML={{ __html: renderedHtml }} />;
-};
-
 export const renderTextWithLatex = (
   text: string,
   params: {
@@ -264,55 +225,11 @@ export const renderTextWithLatex = (
     highlightRegex?: RegExp;
     keyPrefix?: string;
   }
-): React.ReactNode => {
-  const segments = tokenizeTextWithLatex(text, params.linkifyOpts);
-  const hasEscapedDelimiters = segments.some(
-    (segment) =>
-      segment.type === 'text' &&
-      unescapeLatexDelimiters(segment.content) !== segment.content
-  );
-  const hasMath = segments.some((segment) => segment.type === 'math');
-  const hasOnlyPlainText = segments.every((segment) => segment.type === 'text');
-
-  if (hasOnlyPlainText && !hasEscapedDelimiters && !hasMath) {
-    const jsx = renderStyledText(text, params.highlightRegex);
-    if (params.linkify === false) return jsx;
-    return <Linkify options={params.linkifyOpts}>{jsx}</Linkify>;
-  }
-
-  return segments
-    .map((segment, index) => {
-      const key = `${params.keyPrefix ?? 'latex'}-${index}`;
-
-      if (segment.type === 'math') {
-        return (
-          <MathHtml
-            key={key}
-            as="span"
-            latex={segment.content}
-            displayMode={segment.displayMode}
-            className={segment.displayMode ? css.MathBlock : css.MathInline}
-          />
-        );
-      }
-
-      const content =
-        segment.type === 'text' ? unescapeLatexDelimiters(segment.content) : segment.content;
-      if (content === '') return null;
-
-      const jsx = renderStyledText(content, params.highlightRegex);
-      if (params.linkify === false || segment.type === 'verbatim') {
-        return <React.Fragment key={key}>{jsx}</React.Fragment>;
-      }
-
-      return (
-        <Linkify key={key} options={params.linkifyOpts}>
-          {jsx}
-        </Linkify>
-      );
-    })
-    .filter((node) => node !== null);
-};
+): React.ReactNode =>
+  renderTextWithMatrixMath(text, {
+    ...params,
+    renderStyledText,
+  });
 
 /**
  * Recursively extracts and concatenates all text content from an array of ChildNode objects.
@@ -436,8 +353,8 @@ export const getReactCustomHtmlParser = (
         const { name, attribs, children, parent } = domNode;
         const props = attributesToProps(attribs);
 
-        const mindroomBlock = renderMindroomHtmlBlock(name, children, opts);
-        if (mindroomBlock) return mindroomBlock;
+        const mindroomElement = renderMindroomCustomHtmlElement(name, attribs, children, opts);
+        if (mindroomElement) return mindroomElement;
 
         if (name === 'h1') {
           return (
@@ -566,24 +483,6 @@ export const getReactCustomHtmlParser = (
           );
 
           if (mention) return mention;
-        }
-
-        if ((name === 'span' || name === 'div') && typeof attribs['data-mx-maths'] === 'string') {
-          const latex = attribs['data-mx-maths'];
-          const fallback = children.length > 0 ? domToReact(children, opts) : undefined;
-
-          return (
-            <MathHtml
-              as={name === 'div' ? 'div' : 'span'}
-              latex={latex}
-              displayMode={name === 'div'}
-              fallback={fallback}
-              className={classNames(
-                name === 'div' ? css.MathBlock : css.MathInline,
-                props.className
-              )}
-            />
-          );
         }
 
         if (name === 'span' && 'data-mx-spoiler' in props) {

--- a/src/app/plugins/react-custom-html-parser.tsx
+++ b/src/app/plugins/react-custom-html-parser.tsx
@@ -18,7 +18,6 @@ import { MatrixClient } from 'matrix-js-sdk';
 import classNames from 'classnames';
 import { Box, Chip, config, Header, Icon, IconButton, Icons, Scroll, Text, toRem } from 'folds';
 import { IntermediateRepresentation, Opts as LinkifyOpts, OptFn } from 'linkifyjs';
-import Linkify from 'linkify-react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ChildNode } from 'domhandler';
 import * as css from '../styles/CustomHtml.css';

--- a/src/app/styles/CustomHtml.css.ts
+++ b/src/app/styles/CustomHtml.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { color, config, DefaultReset, toRem } from 'folds';
 import { ContainerColor } from './ContainerColor.css';
@@ -118,51 +118,6 @@ export const CodeBlockBottomShadow = style({
 
   height: config.space.S400,
   background: `linear-gradient(to top, #00000022, #00000000)`,
-});
-
-export const MathInline = style([
-  DefaultReset,
-  {
-    display: 'inline-block',
-    maxWidth: '100%',
-    verticalAlign: 'middle',
-    color: 'inherit',
-  },
-]);
-
-export const MathBlock = style([
-  DefaultReset,
-  MarginSpaced,
-  {
-    display: 'block',
-    maxWidth: '100%',
-    overflowX: 'auto',
-    overflowY: 'hidden',
-    textAlign: 'center',
-    color: 'inherit',
-  },
-]);
-
-globalStyle(`${MathInline} .katex, ${MathBlock} .katex`, {
-  color: 'inherit',
-});
-
-globalStyle(`${MathInline} .katex`, {
-  fontSize: '1em',
-});
-
-globalStyle(`${MathInline} .katex-display, ${MathBlock} .katex-display`, {
-  margin: 0,
-});
-
-globalStyle(`${MathBlock} .katex-display`, {
-  overflowX: 'auto',
-  overflowY: 'hidden',
-  padding: `0 ${config.space.S100}`,
-});
-
-globalStyle(`${MathInline} .katex-error, ${MathBlock} .katex-error`, {
-  color: 'inherit',
 });
 
 export const List = style([

--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -1,8 +1,55 @@
 import sanitizeHtml, { Transformer } from 'sanitize-html';
+import { mindroomCustomHtmlSanitizerPolicy } from '../mindroom/html/customHtmlPolicy';
 
 const MAX_TAG_NESTING = 100;
 
-const permittedHtmlTags = [
+type AttributePolicy = Record<string, string[]>;
+type ClassPolicy = Record<string, string[]>;
+type StylePolicy = Record<string, Record<string, RegExp[]>>;
+
+export type CustomHtmlSanitizerPolicy = {
+  allowedTags?: string[];
+  allowedAttributes?: AttributePolicy;
+  allowedClasses?: ClassPolicy;
+  allowedStyles?: StylePolicy;
+  transformTags?: Record<string, Transformer>;
+  nonTextTags?: string[];
+};
+
+const mergeList = <T>(base: T[], extension: T[] | undefined): T[] =>
+  extension ? [...base, ...extension] : base;
+
+const mergeRecordOfLists = <T>(
+  base: Record<string, T[]>,
+  extension: Record<string, T[]> | undefined
+): Record<string, T[]> => {
+  if (!extension) return base;
+
+  return Object.entries(extension).reduce(
+    (merged, [key, values]) => ({
+      ...merged,
+      [key]: [...(merged[key] ?? []), ...values],
+    }),
+    { ...base }
+  );
+};
+
+const mergeStylePolicy = (base: StylePolicy, extension: StylePolicy | undefined): StylePolicy => {
+  if (!extension) return base;
+
+  return Object.entries(extension).reduce(
+    (merged, [selector, properties]) => ({
+      ...merged,
+      [selector]: {
+        ...(merged[selector] ?? {}),
+        ...properties,
+      },
+    }),
+    { ...base }
+  );
+};
+
+const basePermittedHtmlTags = [
   'font',
   'del',
   'h1',
@@ -42,33 +89,21 @@ const permittedHtmlTags = [
   'img',
   'details',
   'summary',
-  'think',
-  'debug',
-  'system',
-  'plan',
-  'analysis',
-  'research',
 ];
 
 const urlSchemes = ['https', 'http', 'ftp', 'mailto', 'magnet'];
 
-const permittedTagToAttributes = {
+const basePermittedTagToAttributes: AttributePolicy = {
   font: ['style', 'data-mx-bg-color', 'data-mx-color', 'color'],
   span: [
     'style',
     'data-mx-bg-color',
     'data-mx-color',
     'data-mx-spoiler',
-    'data-mx-maths',
     'data-mx-pill',
     'data-mx-ping',
     'data-md',
-    'data-mindroom-paste-marker',
-    'data-mindroom-paste-id',
-    'data-mindroom-paste-chars',
-    'data-mindroom-paste-file',
   ],
-  div: ['data-mx-maths'],
   blockquote: ['data-md'],
   h1: ['data-md'],
   h2: ['data-md'],
@@ -88,6 +123,17 @@ const permittedTagToAttributes = {
   u: ['data-md'],
   s: ['data-md'],
   del: ['data-md'],
+};
+
+const baseAllowedClasses: ClassPolicy = {
+  code: ['language-*'],
+};
+
+const baseAllowedStyles: StylePolicy = {
+  '*': {
+    color: [/^#(?:[0-9a-fA-F]{3}){1,2}$/],
+    'background-color': [/^#(?:[0-9a-fA-F]{3}){1,2}$/],
+  },
 };
 
 const transformFontTag: Transformer = (tagName, attribs) => ({
@@ -136,10 +182,13 @@ const transformImgTag: Transformer = (tagName, attribs) => {
   };
 };
 
-export const sanitizeCustomHtml = (customHtml: string): string =>
+export const sanitizeCustomHtml = (
+  customHtml: string,
+  policy: CustomHtmlSanitizerPolicy = mindroomCustomHtmlSanitizerPolicy
+): string =>
   sanitizeHtml(customHtml, {
-    allowedTags: permittedHtmlTags,
-    allowedAttributes: permittedTagToAttributes,
+    allowedTags: mergeList(basePermittedHtmlTags, policy.allowedTags),
+    allowedAttributes: mergeRecordOfLists(basePermittedTagToAttributes, policy.allowedAttributes),
     disallowedTagsMode: 'discard',
     allowedSchemes: urlSchemes,
     allowedSchemesByTag: {
@@ -147,22 +196,19 @@ export const sanitizeCustomHtml = (customHtml: string): string =>
     },
     allowedSchemesAppliedToAttributes: ['href'],
     allowProtocolRelative: false,
-    allowedClasses: {
-      code: ['language-*'],
-    },
-    allowedStyles: {
-      '*': {
-        color: [/^#(?:[0-9a-fA-F]{3}){1,2}$/],
-        'background-color': [/^#(?:[0-9a-fA-F]{3}){1,2}$/],
-      },
-    },
+    allowedClasses: mergeRecordOfLists(baseAllowedClasses, policy.allowedClasses),
+    allowedStyles: mergeStylePolicy(baseAllowedStyles, policy.allowedStyles),
     transformTags: {
       font: transformFontTag,
       span: transformSpanTag,
       a: transformATag,
       img: transformImgTag,
+      ...policy.transformTags,
     },
-    nonTextTags: ['style', 'script', 'textarea', 'option', 'noscript', 'mx-reply'],
+    nonTextTags: mergeList(
+      ['style', 'script', 'textarea', 'option', 'noscript', 'mx-reply'],
+      policy.nonTextTags
+    ),
     nestingLimit: MAX_TAG_NESTING,
   });
 

--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -40,10 +40,7 @@ const mergeStylePolicy = (base: StylePolicy, extension: StylePolicy | undefined)
   return Object.entries(extension).reduce(
     (merged, [selector, properties]) => ({
       ...merged,
-      [selector]: {
-        ...(merged[selector] ?? {}),
-        ...properties,
-      },
+      [selector]: mergeRecordOfLists(merged[selector] ?? {}, properties),
     }),
     { ...base }
   );
@@ -199,11 +196,11 @@ export const sanitizeCustomHtml = (
     allowedClasses: mergeRecordOfLists(baseAllowedClasses, policy.allowedClasses),
     allowedStyles: mergeStylePolicy(baseAllowedStyles, policy.allowedStyles),
     transformTags: {
+      ...policy.transformTags,
       font: transformFontTag,
       span: transformSpanTag,
       a: transformATag,
       img: transformImgTag,
-      ...policy.transformTags,
     },
     nonTextTags: mergeList(
       ['style', 'script', 'textarea', 'option', 'noscript', 'mx-reply'],


### PR DESCRIPTION
## Summary
- Move MindRoom custom HTML sanitizer additions into fork-owned policy modules under `src/app/mindroom/html`.
- Move Matrix math rendering/styles behind a fork-owned renderer seam consumed by the generic parser.
- Add focused sanitizer/render ownership tests and update the runbook.

## Test Plan
- `npm test -- src/app/mindroom/html/customHtmlPolicy.test.ts src/app/mindroom/html/customHtmlPolicy.architecture.test.ts src/app/plugins/react-custom-html-parser.test.ts src/app/mindroom/messages/MindroomHtmlBlocks.pasteMarker.test.ts src/app/mindroom/messages/messageExtrasHtml.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
- `npm run typecheck`
- `npx eslint src/app/mindroom/html/MatrixMath.css.ts src/app/mindroom/html/customHtmlPolicy.ts src/app/mindroom/html/customHtmlRenderers.tsx src/app/mindroom/html/matrixMath.tsx src/app/utils/sanitize.ts src/app/plugins/react-custom-html-parser.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx`
- `git diff --check`