### PR TITLE
Add package dependency cleanup guard

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -326,6 +326,8 @@
 
 - Status:
   - Audit complete; no package or lockfile changes made.
+  - Follow-up complete: added a repeatable package dependency diff report for
+    clean-history staging and upstream rebase previews.
 - Scope checked:
   - Compared `package.json` direct dependencies against upstream `v4.11.1` base
     `6a05ff58`, current fork `HEAD`, and upstream `dev` / `v4.12.2`
@@ -333,6 +335,9 @@
   - Checked `package-lock.json` through the root manifest relationship, the
     `patches/**` hook, package-driven scripts, Vite/Vitest/Playwright config,
     and Android/iOS Capacitor generated package references.
+  - Added `scripts/report-package-dependency-diff.mjs` so future agents can
+    rerun the package ownership audit against `v4.11.1`, `v4.12.2`, or another
+    explicit base without touching `package.json` or `package-lock.json`.
 - Dependency ownership buckets:
   | Bucket | Dependencies / scripts | Ownership note |
   | --- | --- | --- |
@@ -365,6 +370,8 @@
   5. Test/tooling harness: keep Vitest, Playwright, jsdom, react-test-renderer,
      TypeScript, and ESLint changes with test/config additions.
 - Validation:
+  - Green: `node scripts/report-package-dependency-diff.mjs v4.11.1 HEAD`.
+  - Green: `node scripts/report-package-dependency-diff.mjs v4.12.2 HEAD`.
   - Green: `npm install --package-lock-only --ignore-scripts --no-audit --no-fund --dry-run`.
   - Green: `npx patch-package --error-on-fail` reapplied
     `matrix-js-sdk@38.2.0`.

--- a/docs/mindroom-soft-reset-recommit-plan.md
+++ b/docs/mindroom-soft-reset-recommit-plan.md
@@ -18,13 +18,18 @@ The current diff from `v4.11.1` to head contains 1,074 changed files: 460
 
 ## Pre-Reset Checks
 
-- Confirm the intended base before rewriting history. The current runbook recommends rebasing to
-  upstream `v4.12.2` before rewriting, because v4.12.2 already changes call, dependency, sanitizer,
-  and editor surfaces that overlap this fork.
+- Confirm the intended reset base before rewriting history. The current strategy is to finish
+  cleanup on the already-working fork state, save a safety ref, soft-reset/recommit against the
+  current fork point, and only then rebase the clean stack onto newer upstream.
+- Preview upstream `v4.12.2` conflicts before rewriting, but do not rebase to `v4.12.2` during the
+  cleanup/reset window. v4.12.2 already changes call, dependency, sanitizer, and editor surfaces
+  that overlap this fork, so it should inform commit boundaries without changing the pre-reset tree.
 - Save a safety ref before any reset: `git branch backup/mindroom-before-clean-history HEAD`.
 - Capture inventory:
   - `git diff --name-status v4.11.1..HEAD > /tmp/mindroom-clean-history-files.txt`
   - `node scripts/report-non-mindroom-source-diff.mjs v4.11.1 HEAD`
+  - `node scripts/report-package-dependency-diff.mjs v4.11.1 HEAD`
+  - `node scripts/report-package-dependency-diff.mjs v4.12.2 HEAD`
   - `git merge-tree --write-tree --messages --merge-base 6a05ff58 upstream/dev HEAD`
 - If this linked worktree resolves plain `git` commands to the git metadata directory, export the
   explicit worktree before running inventory commands:
@@ -45,6 +50,7 @@ later feature commits do not repeatedly carry lockfile/config churn.
 - `package.json`
 - `package-lock.json`
 - `patches/**`
+- `scripts/report-package-dependency-diff.mjs`
 - `.npmrc`
 - `.node-version`
 - `vite.config.js`
@@ -72,7 +78,7 @@ later feature commits do not repeatedly carry lockfile/config churn.
 
 **Expected validation command:**
 
-`npm run typecheck && npm test && npm run build`
+`node scripts/report-package-dependency-diff.mjs v4.11.1 HEAD && node scripts/report-package-dependency-diff.mjs v4.12.2 HEAD && npm run typecheck && npm test && npm run build`
 
 **Likely conflict risk:** High. `package.json`, `package-lock.json`, `config.json`, `Dockerfile`,
 and Vite/PWA settings overlap upstream v4.12.2 dependency and runtime changes. Resolve this group

--- a/scripts/report-package-dependency-diff.mjs
+++ b/scripts/report-package-dependency-diff.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workTree = process.cwd();
+const gitFile = resolve(workTree, '.git');
+const env = { ...process.env };
+
+if (existsSync(gitFile) && statSync(gitFile).isFile()) {
+  const gitFileBody = readFileSync(gitFile, 'utf8').trim();
+  const gitdirPrefix = 'gitdir: ';
+  if (gitFileBody.startsWith(gitdirPrefix)) {
+    env.GIT_DIR = gitFileBody.slice(gitdirPrefix.length);
+    env.GIT_WORK_TREE = workTree;
+  }
+}
+
+const [base = 'v4.11.1', target = 'HEAD'] = process.argv.slice(2);
+
+const forkOwnedPackages = new Map(
+  [
+    [
+      'MindRoom product/runtime',
+      [
+        '@basnijholt/particular-drift',
+        '@dnd-kit/core',
+        '@dnd-kit/sortable',
+        '@dnd-kit/utilities',
+        '@tabler/icons-react',
+        'fuse.js',
+        'katex',
+        'workbox-precaching',
+        'workbox-routing',
+      ],
+    ],
+    [
+      'Native mobile',
+      [
+        '@capacitor/android',
+        '@capacitor/app',
+        '@capacitor/app-launcher',
+        '@capacitor/browser',
+        '@capacitor/cli',
+        '@capacitor/core',
+        '@capacitor/haptics',
+        '@capacitor/ios',
+        '@capacitor/keyboard',
+        '@capacitor/push-notifications',
+        '@capacitor/splash-screen',
+        '@capacitor/status-bar',
+      ],
+    ],
+    [
+      'Test/tooling',
+      [
+        '@playwright/test',
+        '@types/react-test-renderer',
+        '@typescript-eslint/eslint-plugin',
+        '@typescript-eslint/parser',
+        'eslint',
+        'jsdom',
+        'patch-package',
+        'react-test-renderer',
+        'typescript',
+        'vitest',
+      ],
+    ],
+  ].flatMap(([label, packages]) => packages.map((name) => [name, label]))
+);
+
+const upstreamAdoptionPackages = new Set([
+  '@element-hq/element-call-embedded',
+  '@types/sanitize-html',
+  'cz-conventional-changelog',
+  'husky',
+  'lint-staged',
+  'matrix-js-sdk',
+  'matrix-widget-api',
+  'sanitize-html',
+]);
+
+const showFile = (ref, path) =>
+  execFileSync('git', ['show', `${ref}:${path}`], {
+    cwd: workTree,
+    env,
+    encoding: 'utf8',
+  });
+
+const readPackageJson = (ref) => JSON.parse(showFile(ref, 'package.json'));
+
+const diffNameStatus = (pathspec) =>
+  execFileSync(
+    'git',
+    ['diff', '--name-status', '--find-renames', `${base}..${target}`, '--', pathspec],
+    {
+      cwd: workTree,
+      env,
+      encoding: 'utf8',
+    }
+  )
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+const basePackage = readPackageJson(base);
+const targetPackage = readPackageJson(target);
+
+const compareRecord = (baseRecord = {}, targetRecord = {}) => {
+  const names = new Set([...Object.keys(baseRecord), ...Object.keys(targetRecord)]);
+
+  return [...names].sort().flatMap((name) => {
+    const from = baseRecord[name];
+    const to = targetRecord[name];
+    if (from === to) return [];
+    if (from === undefined) return [{ name, from: '-', to, change: 'added' }];
+    if (to === undefined) return [{ name, from, to: '-', change: 'removed' }];
+    return [{ name, from, to, change: 'changed' }];
+  });
+};
+
+const classifyPackage = (name) => {
+  if (forkOwnedPackages.has(name)) return forkOwnedPackages.get(name);
+  if (upstreamAdoptionPackages.has(name)) return 'Upstream adoption/rebase';
+  return 'Unclassified';
+};
+
+const dependencyChanges = [
+  ...compareRecord(basePackage.dependencies, targetPackage.dependencies).map((row) => ({
+    ...row,
+    section: 'dependencies',
+  })),
+  ...compareRecord(basePackage.devDependencies, targetPackage.devDependencies).map((row) => ({
+    ...row,
+    section: 'devDependencies',
+  })),
+];
+
+const scriptChanges = compareRecord(basePackage.scripts, targetPackage.scripts);
+const lockRoot = JSON.parse(showFile(target, 'package-lock.json')).packages?.[''] ?? {};
+const lockRootDeps = {
+  ...(lockRoot.dependencies ?? {}),
+  ...(lockRoot.devDependencies ?? {}),
+};
+
+const printRows = (rows, format) => {
+  if (rows.length === 0) {
+    console.log('  none');
+    return;
+  }
+
+  for (const row of rows) console.log(`  ${format(row)}`);
+};
+
+console.log(`Package dependency diff in ${base}..${target}`);
+console.log('');
+
+console.log('Direct package changes:');
+printRows(
+  dependencyChanges,
+  ({ section, name, from, to, change }) =>
+    `${section} ${change}: ${name} ${from} -> ${to} [${classifyPackage(name)}]`
+);
+
+console.log('');
+console.log('Script changes:');
+printRows(scriptChanges, ({ name, from, to, change }) => `${change}: ${name} ${from} -> ${to}`);
+
+console.log('');
+console.log('Patch files:');
+printRows(diffNameStatus('patches'), (line) => line);
+
+const missingFromLockRoot = dependencyChanges
+  .filter(({ change }) => change !== 'removed')
+  .filter(({ name, to }) => lockRootDeps[name] !== to);
+
+console.log('');
+console.log('Target lockfile root manifest check:');
+if (missingFromLockRoot.length === 0) {
+  console.log('  package-lock.json root dependency entries match package.json');
+} else {
+  printRows(
+    missingFromLockRoot,
+    ({ name, to }) => `${name} expected ${to}, package-lock root has ${lockRootDeps[name] ?? '-'}`
+  );
+}
+
+const unclassified = dependencyChanges.filter(
+  ({ name }) => classifyPackage(name) === 'Unclassified'
+);
+if (unclassified.length > 0) {
+  console.log('');
+  console.log(
+    'Unclassified package changes need an ownership decision before clean-history staging.'
+  );
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a repeatable package dependency diff report for clean-history staging
- document package ownership audit reruns in the runbook
- correct the soft-reset plan sequencing: cleanup/reset first, upstream rebase later

## Validation
- node --check scripts/report-package-dependency-diff.mjs
- node scripts/report-package-dependency-diff.mjs v4.11.1 HEAD
- node scripts/report-package-dependency-diff.mjs v4.12.2 HEAD
- npx prettier --check docs/mindroom-soft-reset-recommit-plan.md scripts/report-package-dependency-diff.mjs
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated dependency audit tool to compare package versions and identify dependency ownership classifications across releases.

* **Documentation**
  * Updated runbook entries and process documentation with new validation procedures and dependency audit workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->