### PR TITLE
docs: point fork support links at MindRoom repo

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -1,13 +1,13 @@
-labels: ["needs-confirmation"]
+labels: ['needs-confirmation']
 body:
   - type: markdown #add faqs in future
     attributes:
       value: |
         > [!IMPORTANT]
-        > Please read through [the Discussion rules](https://github.com/cinnyapp/cinny/discussions/2653) and check for both existing [Discussions](https://github.com/cinnyapp/cinny/discussions?discussions_q=) and [Issues](https://github.com/cinnyapp/cinny/issues?q=sort%3Areactions-desc) prior to opening a new Discussion.
+        > Please check for both existing [Discussions](https://github.com/mindroom-ai/mindroom-cinny/discussions?discussions_q=) and [Issues](https://github.com/mindroom-ai/mindroom-cinny/issues?q=sort%3Areactions-desc) prior to opening a new Discussion.
   - type: markdown
     attributes:
-      value: "# Issue Details"
+      value: '# Issue Details'
   - type: textarea
     attributes:
       label: Issue Description
@@ -64,7 +64,7 @@ body:
         - Browser: 
         - Cinny Web Version: (app.cinny.in or self hosted)
         - Cinny desktop Version: (appimage or deb or flatpak)
-        - Matrix Homeserver: 
+        - Matrix Homeserver:
       placeholder: |
         - OS: Windows 11
         - Browser: Chrome 120.0.6099.109
@@ -80,12 +80,12 @@ body:
       label: Relevant Logs
       description: |
         If applicable, add browser console logs to help explain your problem.
-        
+
         **To get browser console logs:**
         - Chrome/Edge: Press F12 → Console tab
         - Firefox: Press F12 → Console tab  
         - Safari: Develop → Show Web Inspector → Console
-        
+
         Please wrap large log outputs in code blocks with triple backticks (```).
       placeholder: |
         ```
@@ -98,7 +98,7 @@ body:
       render: shell
     validations:
       required: false
-  - type: textarea 
+  - type: textarea
     attributes:
       label: Additional context
       description: |
@@ -116,12 +116,12 @@ body:
       value: |
         # User Acknowledgements
         > [!TIP]
-        > Use these links to review the existing Cinny [Discussions](https://github.com/cinnyapp/cinny/discussions?discussions_q=) and [Issues](https://github.com/cinnyapp/cinny/issues?q=sort%3Areactions-desc).
+        > Use these links to review the existing MindRoom Cinny [Discussions](https://github.com/mindroom-ai/mindroom-cinny/discussions?discussions_q=) and [Issues](https://github.com/mindroom-ai/mindroom-cinny/issues?q=sort%3Areactions-desc).
   - type: checkboxes #add faqs in future
     attributes:
-      label: "I acknowledge that:"
+      label: 'I acknowledge that:'
       options:
-        - label: I have searched the Cinny repository (both open and closed Discussions and Issues) and confirm this is not a duplicate of an existing issue or discussion.
+        - label: I have searched the MindRoom Cinny repository (both open and closed Discussions and Issues) and confirm this is not a duplicate of an existing issue or discussion.
           required: true
         - label: I have checked the "Preview" tab on all text fields to ensure that everything looks right, and have wrapped all configuration and code in code blocks with a group of three backticks (` ``` `) on separate lines.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Features, Bug Reports, Questions
-    url: https://github.com/cinnyapp/cinny/discussions/new/choose
+    url: https://github.com/mindroom-ai/mindroom-cinny/discussions/new/choose
     about: Our preferred starting point if you have any questions or suggestions about features or behavior.

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,62 @@
 
 ## Runbook
 
+### CINNY-130 - Point fork support links at MindRoom repository (2026-05-29)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Updated GitHub issue/discussion template links from the upstream Cinny
+    repository to `mindroom-ai/mindroom-cinny` so fork users are routed to the
+    MindRoom fork instead of upstream support surfaces.
+  - Updated MindRoom source-code links in the About panel and README to point at
+    the MindRoom Cinny fork repository.
+  - Kept upstream Cinny attribution, but changed powered-by attribution links to
+    the Cinny website instead of the upstream GitHub issue tracker.
+- Decisions:
+  - Keep upstream-owned GitHub templates present for rebaseability, but route
+    their visible support links to the MindRoom fork.
+  - Keep attribution to upstream Cinny while using `cinny.in` for powered-by
+    attribution instead of upstream GitHub support surfaces.
+- Risks:
+  - Future upstream template or README syncs may reintroduce upstream support
+    repository links.
+  - Fork users may still see upstream Cinny terminology in retained templates
+    where broader rewrites would increase rebase churn.
+- Next steps:
+  - Monitor future upstream syncs for support links that should point at
+    `mindroom-ai/mindroom-cinny`.
+  - Keep durable attribution policy documented in this runbook when related
+    branding or support links change.
+- Validation:
+  - Green: hidden-file grep for the old upstream repository URL returned no
+    matches.
+  - Green: `npm run typecheck`.
+  - Green:
+    `npx prettier --check FORK_CHANGES.md README.md config.mindroom.json .github/DISCUSSION_TEMPLATE/issue-triage.yml .github/ISSUE_TEMPLATE/config.yml src/app/features/settings/about/About.tsx src/app/mindroom/branding/branding.ts`.
+  - Green: `git diff --check`.
+  - Rebase green check: rebased onto `origin/dev` at `a95e1076`.
+  - Rebase green check: hidden-file grep for the old upstream repository URL
+    returned no matches.
+  - Rebase green check:
+    `npx prettier --check FORK_CHANGES.md README.md config.mindroom.json .github/DISCUSSION_TEMPLATE/issue-triage.yml .github/ISSUE_TEMPLATE/config.yml src/app/features/settings/about/About.tsx src/app/mindroom/branding/branding.ts`.
+  - Rebase green check: `npm run typecheck`.
+  - Rebase green check: `git diff --check`.
+  - Review green check: hidden-file grep for the old upstream repository URL
+    and stale checkbox label returned no matches.
+  - Review green check:
+    `npx prettier --check FORK_CHANGES.md README.md config.mindroom.json .github/DISCUSSION_TEMPLATE/issue-triage.yml .github/ISSUE_TEMPLATE/config.yml src/app/features/settings/about/About.tsx src/app/mindroom/branding/branding.ts`.
+  - Review green check: `npm run typecheck`.
+  - Review green check: `git diff --check`.
+  - Rebase green check: rebased onto `origin/dev` at `2ad704e1` after the
+    Android keyboard viewport fix landed.
+  - Rebase green check: hidden-file grep for the old upstream repository URL
+    and stale checkbox label returned no matches.
+  - Rebase green check:
+    `npx prettier --check FORK_CHANGES.md README.md config.mindroom.json .github/DISCUSSION_TEMPLATE/issue-triage.yml .github/ISSUE_TEMPLATE/config.yml src/app/features/settings/about/About.tsx src/app/mindroom/branding/branding.ts`.
+  - Rebase green check: `npm run typecheck`.
+  - Rebase green check: `git diff --check`.
+
 ### CINNY-129 - Android keyboard viewport restore (2026-05-29)
 
 - Status:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MindRoom
 
 MindRoom is a Matrix client focused on AI-agent workflows.
-This repository is a fork of [Cinny](https://github.com/cinnyapp/cinny), with product and UX changes for MindRoom use cases.
+This repository is the [MindRoom Cinny fork](https://github.com/mindroom-ai/mindroom-cinny), with product and UX changes for MindRoom use cases.
 
 ## What MindRoom Is
 
@@ -226,7 +226,8 @@ npm run release:next-tag
 
 This project is built on top of Cinny and Matrix ecosystem libraries.
 
-- Upstream Cinny: <https://github.com/cinnyapp/cinny>
+- MindRoom Cinny fork: <https://github.com/mindroom-ai/mindroom-cinny>
+- Original Cinny project: <https://cinny.in>
 - Matrix: <https://matrix.org>
 
 ## License

--- a/config.mindroom.json
+++ b/config.mindroom.json
@@ -113,7 +113,7 @@
       },
       {
         "label": "Cinny",
-        "url": "https://github.com/cinnyapp/cinny"
+        "url": "https://cinny.in"
       },
       {
         "label": "MindRoom Cinny Fork",

--- a/src/app/features/settings/about/About.tsx
+++ b/src/app/features/settings/about/About.tsx
@@ -73,7 +73,7 @@ export function About({ requestClose }: AboutProps) {
                   <Box gap="200" wrap="Wrap">
                     <Button
                       as="a"
-                      href="https://github.com/cinnyapp/cinny"
+                      href="https://github.com/mindroom-ai/mindroom-cinny"
                       rel="noreferrer noopener"
                       target="_blank"
                       variant="Secondary"

--- a/src/app/mindroom/branding/branding.ts
+++ b/src/app/mindroom/branding/branding.ts
@@ -21,6 +21,6 @@ export type MindroomPoweredByLink = {
 export const MINDROOM_DEFAULT_POWERED_BY: MindroomPoweredByLink[] = [
   { label: MINDROOM_APP_NAME, url: MINDROOM_SOURCE_URL },
   { label: 'Matrix', url: 'https://matrix.org' },
-  { label: 'Cinny', url: 'https://github.com/cinnyapp/cinny' },
+  { label: 'Cinny', url: 'https://cinny.in' },
   { label: 'MindRoom Cinny Fork', url: MINDROOM_CINNY_SOURCE_URL },
 ];


### PR DESCRIPTION
## Summary
- Route GitHub issue/discussion template links to mindroom-ai/mindroom-cinny.
- Point the About source button and README fork references at the MindRoom Cinny repo.
- Keep Cinny attribution while avoiding upstream GitHub support links.

## Validation
- rg --hidden -n "github.com/cinnyapp/cinny" . -g '!.git' || true
- npm run typecheck
- npx prettier --check FORK_CHANGES.md README.md config.mindroom.json .github/DISCUSSION_TEMPLATE/issue-triage.yml .github/ISSUE_TEMPLATE/config.yml src/app/features/settings/about/About.tsx src/app/mindroom/branding/branding.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository links and attribution throughout the application to reference the MindRoom Cinny fork.
  * Updated "Source Code" and "Powered by" links to direct to correct fork and upstream project locations.
  * Updated GitHub issue and discussion template links to reference the MindRoom Cinny fork.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->