### PR TITLE
feat(mindroom): enable iOS push gateway

### DIFF
--- a/config.mindroom.json
+++ b/config.mindroom.json
@@ -5,9 +5,9 @@
 
   "push": {
     "ios": {
-      "enabled": false,
+      "enabled": true,
       "appId": "com.mindroom-ai.app.ios",
-      "gatewayUrl": "",
+      "gatewayUrl": "https://push.mindroom.chat/_matrix/push/v1/notify",
       "appDisplayName": "MindRoom iOS",
       "deviceDisplayName": "MindRoom iOS",
       "append": true,


### PR DESCRIPTION
Enables the MindRoom iOS push gateway in config.mindroom.json.

Gateway: https://push.mindroom.chat/_matrix/push/v1/notify
App ID: com.mindroom-ai.app.ios

Verification:
- npm run appstore:preflight
- Live chat.mindroom.chat config.json now advertises the gateway URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS push notifications are now enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
