### PR TITLE
fix(mindroom): align iOS push app id

### DIFF
--- a/.docs/ios-build.md
+++ b/.docs/ios-build.md
@@ -62,7 +62,7 @@ This project includes native iOS push registration via Capacitor and Matrix push
   "push": {
     "ios": {
       "enabled": true,
-      "appId": "com.mindroom-ai.app.ios",
+      "appId": "chat.mindroom.app",
       "gatewayUrl": "https://YOUR-PUSH-GATEWAY/_matrix/push/v1/notify",
       "appDisplayName": "MindRoom iOS",
       "deviceDisplayName": "MindRoom iOS",

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ registration). To turn it on for a deployment:
   "push": {
     "ios": {
       "enabled": true,
-      "appId": "com.mindroom-ai.app.ios",
+      "appId": "chat.mindroom.app",
       "gatewayUrl": "https://YOUR-PUSH-GATEWAY/_matrix/push/v1/notify",
       "appDisplayName": "MindRoom iOS",
       "deviceDisplayName": "MindRoom iOS",

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,7 +1,7 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.mindroom-ai.app',
+  appId: 'chat.mindroom.app',
   appName: 'MindRoom',
   webDir: 'dist',
   server: {

--- a/config.mindroom.json
+++ b/config.mindroom.json
@@ -6,7 +6,7 @@
   "push": {
     "ios": {
       "enabled": true,
-      "appId": "com.mindroom-ai.app.ios",
+      "appId": "chat.mindroom.app",
       "gatewayUrl": "https://push.mindroom.chat/_matrix/push/v1/notify",
       "appDisplayName": "MindRoom iOS",
       "deviceDisplayName": "MindRoom iOS",

--- a/scripts/appstore-preflight.mjs
+++ b/scripts/appstore-preflight.mjs
@@ -11,6 +11,7 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const configFileName = 'config.mindroom.json';
 const configPath = path.join(repoRoot, configFileName);
+const capacitorConfigPath = path.join(repoRoot, 'capacitor.config.ts');
 const xcodeProjectPath = path.join(repoRoot, 'ios', 'App', 'App.xcodeproj', 'project.pbxproj');
 const infoPlistPath = path.join(repoRoot, 'ios', 'App', 'App', 'Info.plist');
 const entitlementsPath = path.join(repoRoot, 'ios', 'App', 'App', 'App.entitlements');
@@ -34,6 +35,7 @@ const check = (condition, message) => {
 };
 
 const config = JSON.parse(readText(configPath));
+const capacitorConfig = readText(capacitorConfigPath);
 const xcodeProject = readText(xcodeProjectPath);
 const infoPlist = readText(infoPlistPath);
 const entitlements = fs.existsSync(entitlementsPath) ? readText(entitlementsPath) : '';
@@ -52,12 +54,14 @@ const isHttpsUrl = (value) => {
     return false;
   }
 };
+const capacitorAppIdMatch = capacitorConfig.match(/appId:\s*['"]([^'"]+)['"]/);
 const hasPlistKey = (plist, key) =>
   new RegExp(`<key>\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*</key>`).test(plist);
 const hasSingleValue = (values) => new Set(values).size === 1;
 
 let marketingVersions = [];
 let buildNumbers = [];
+let bundleIdentifiers = [];
 
 try {
   marketingVersions = getAppTargetBuildSettingValues(xcodeProject, 'MARKETING_VERSION').map(
@@ -66,6 +70,10 @@ try {
   buildNumbers = getAppTargetBuildSettingValues(xcodeProject, 'CURRENT_PROJECT_VERSION').map(
     (record) => record.value
   );
+  bundleIdentifiers = getAppTargetBuildSettingValues(
+    xcodeProject,
+    'PRODUCT_BUNDLE_IDENTIFIER'
+  ).map((record) => record.value);
 } catch (error) {
   check(false, `Xcode project: ${error.message}`);
 }
@@ -113,6 +121,14 @@ check(
   'Xcode project: App target CURRENT_PROJECT_VERSION values must match across build configurations.'
 );
 check(
+  bundleIdentifiers.length > 0,
+  'Xcode project: missing App target PRODUCT_BUNDLE_IDENTIFIER entries.'
+);
+check(
+  hasSingleValue(bundleIdentifiers),
+  'Xcode project: App target PRODUCT_BUNDLE_IDENTIFIER values must match across build configurations.'
+);
+check(
   xcodeProject.includes('com.apple.SignInWithApple'),
   'Xcode project: missing Sign in with Apple capability.'
 );
@@ -129,6 +145,15 @@ if (iosPushConfig.enabled === true) {
   check(
     isHttpsUrl(iosPushConfig.gatewayUrl),
     `${configFileName}: push.ios.gatewayUrl must be a HTTPS URL when push.ios.enabled is true.`
+  );
+  check(
+    capacitorAppIdMatch?.[1] === iosPushConfig.appId,
+    `capacitor.config.ts: appId must match ${configFileName} push.ios.appId when iOS push is enabled.`
+  );
+  check(
+    bundleIdentifiers.length > 0 &&
+      bundleIdentifiers.every((value) => value === iosPushConfig.appId),
+    `Xcode project: PRODUCT_BUNDLE_IDENTIFIER must match ${configFileName} push.ios.appId when iOS push is enabled.`
   );
   check(
     fs.existsSync(entitlementsPath),

--- a/src/app/utils/runtimeConfig.test.ts
+++ b/src/app/utils/runtimeConfig.test.ts
@@ -58,7 +58,7 @@ describe('MindRoom runtime client config defaults', () => {
     expect(mindroomConfig.welcome?.title).toBe('Welcome to MindRoom');
     expect(mindroomConfig.splash?.loadingMessages).toContain('Loading MindRoom');
     expect(mindroomConfig.mindroom?.thinkingPlaceholderMessages).toContain('Thinking');
-    expect(mindroomConfig.push?.ios?.appId).toBe('com.mindroom-ai.app.ios');
+    expect(mindroomConfig.push?.ios?.appId).toBe('chat.mindroom.app');
 
     expect(copyFiles.targets).toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- align the hosted MindRoom iOS push config with the actual iOS bundle id: `chat.mindroom.app`
- update the README push configuration example to use the same app id

## Verification
- `npm run appstore:preflight`
- `npm test -- src/app/mindroom/native/iosPush.test.ts src/app/mindroom/native/IOSPushNotification.test.ts src/app/mindroom/notifications/SystemNotificationMindroomExtensions.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS push notification configuration identifier

* **Documentation**
  * Updated iOS push notification setup example in README

* **Tests**
  * Updated configuration validation tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom-cinny/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->