### PR TITLE
Use WebGL background for splash screens

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -14,9 +14,42 @@
     error, missing browser feature error, and client startup error screens.
   - Preserved the optional `background` prop so callers can still supply an
     explicit custom background.
+  - Review follow-up: falsy `background` values now keep the fallback behavior
+    instead of silently removing both the visual background and particle content
+    wrapper.
+- Decisions:
+  - Treat `null` and `false` `background` values like the old fallback path,
+    because the previous dot-pattern implementation did not support disabling
+    the default background with falsy prop values.
+  - Keep `SplashScreen` responsible for selecting the default MindRoom particle
+    background while preserving custom background nodes supplied by callers.
+  - Do not add a second fallback component in `SplashScreen`; the particle
+    background already lowers particle counts for coarse/low-core devices and
+    keeps a CSS gradient visible when reduced-motion CSS hides the canvas.
+- Risks:
+  - `@basnijholt/particular-drift` is a WebGL2 renderer, so non-WebGL2 runtime
+    failures may still need a future library-level or component-level fallback
+    if they appear in real devices.
+  - Low-powered devices now see the particle background on generic splash
+    screens; the existing low-end particle count and reduced-motion CSS should
+    be watched in production-like device testing.
+  - Local dependency sync reports Node 20 engine warnings for packages requiring
+    Node 22 and npm audit findings; these are not introduced by the splash
+    fallback change but remain operational follow-up items.
+- Next steps:
+  - Track device/browser feedback for the new generic splash-screen background,
+    especially WebGL2 failures and reduced-motion behavior.
+  - Revisit a no-WebGL fallback if the particle renderer does not degrade
+    cleanly on supported deployment targets.
+  - Keep the architecture guard watching for accidental reintroduction of the
+    old dot-pattern stylesheet import.
 - Review:
   - Independent subagent review found no source issues; the reviewer noted the
     new splash-screen test needed to be tracked.
+  - PR review follow-up verified the `null`/`false` fallback concern against the
+    previous implementation, added custom-background and falsy-background unit
+    coverage, loosened brittle architecture source assertions, and added an
+    explicit guard against reintroducing `Patterns.css`.
 - Validation:
   - Red check:
     `npm test -- src/app/components/splash-screen/SplashScreen.test.ts`
@@ -43,6 +76,27 @@
   - Green: `npm run build` (existing Vite runtime-config, sourcemap, and
     chunk-size warnings only).
   - Green: `git diff --check`.
+  - Review red check:
+    `npm test -- src/app/components/splash-screen/SplashScreen.test.ts` failed
+    while `background={null}` did not render the default particle background.
+  - Review green check:
+    `npm test -- src/app/components/splash-screen/SplashScreen.test.ts` (4
+    tests).
+  - Review green focused check:
+    `npm test -- src/app/components/splash-screen/SplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (2 files, 97 tests).
+  - Review green check:
+    `npx prettier --check FORK_CHANGES.md src/app/components/splash-screen/SplashScreen.tsx src/app/components/splash-screen/SplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Review green check: `npm run typecheck`.
+  - Review green check: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Review green check: `npm test` (301 files, 2240 tests).
+  - Review green check: `npm run build` (existing Vite runtime-config,
+    sourcemap, localStorage, and chunk-size warnings only).
+  - Independent review green check: separate subagent review found no issues,
+    and independently ran the focused splash/architecture tests plus
+    `git diff --check`.
+  - Review green check: `git diff --check`.
 
 ### CINNY-130 - Point fork support links at MindRoom repository (2026-05-29)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,48 @@
 
 ## Runbook
 
+### CINNY-131 - Default splash screens to WebGL background (2026-05-31)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Updated the shared `SplashScreen` fallback so generic client error and
+    feature-check screens use the MindRoom WebGL particle background instead of
+    the old dot-pattern background.
+  - Target surfaces include the homeserver connection error, client config
+    error, missing browser feature error, and client startup error screens.
+  - Preserved the optional `background` prop so callers can still supply an
+    explicit custom background.
+- Review:
+  - Independent subagent review found no source issues; the reviewer noted the
+    new splash-screen test needed to be tracked.
+- Validation:
+  - Red check:
+    `npm test -- src/app/components/splash-screen/SplashScreen.test.ts`
+    failed while `SplashScreen` did not render a default particle background.
+  - Green check:
+    `npm test -- src/app/components/splash-screen/SplashScreen.test.ts`.
+  - Red architecture check:
+    `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    failed on the old dot-pattern invariant before the guard was updated.
+  - Green focused check:
+    `npm test -- src/app/components/splash-screen/SplashScreen.test.ts src/app/components/splash-screen/MindRoomSplashScreen.test.ts src/app/pages/client/SpecVersions.test.ts`
+    (3 files, 10 tests).
+  - Green architecture check:
+    `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (93 tests).
+  - Dependency sync: `npm ci` refreshed stale local `node_modules`; npm reported
+    Node 20 engine warnings for packages requiring Node 22 and audit findings.
+  - Green:
+    `npx prettier --check FORK_CHANGES.md src/app/components/splash-screen/SplashScreen.tsx src/app/components/splash-screen/SplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Green: `npm test` (301 files, 2237 tests).
+  - Green: `npm run build` (existing Vite runtime-config, sourcemap, and
+    chunk-size warnings only).
+  - Green: `git diff --check`.
+
 ### CINNY-130 - Point fork support links at MindRoom repository (2026-05-29)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -17,12 +17,18 @@
   - Review follow-up: falsy `background` values now keep the fallback behavior
     instead of silently removing both the visual background and particle content
     wrapper.
+  - Simplification follow-up: `MindRoomSplashScreen` now relies on the shared
+    `SplashScreen` default particle background instead of passing the same
+    WebGL background explicitly.
 - Decisions:
   - Treat `null` and `false` `background` values like the old fallback path,
     because the previous dot-pattern implementation did not support disabling
     the default background with falsy prop values.
   - Keep `SplashScreen` responsible for selecting the default MindRoom particle
     background while preserving custom background nodes supplied by callers.
+  - Remove redundant default-background props only from `SplashScreen` callers;
+    keep direct particle backgrounds on non-`SplashScreen` surfaces such as the
+    auth layout.
   - Do not add a second fallback component in `SplashScreen`; the particle
     background already lowers particle counts for coarse/low-core devices and
     keeps a CSS gradient visible when reduced-motion CSS hides the canvas.
@@ -50,6 +56,9 @@
     previous implementation, added custom-background and falsy-background unit
     coverage, loosened brittle architecture source assertions, and added an
     explicit guard against reintroducing `Patterns.css`.
+  - Follow-up cleanup verified that `MindRoomSplashScreen` was the only
+    redundant explicit default-background caller; `AuthLayout` still renders its
+    own particle background because it does not use `SplashScreen`.
 - Validation:
   - Red check:
     `npm test -- src/app/components/splash-screen/SplashScreen.test.ts`
@@ -97,6 +106,24 @@
     and independently ran the focused splash/architecture tests plus
     `git diff --check`.
   - Review green check: `git diff --check`.
+  - Cleanup red check:
+    `npm test -- src/app/components/splash-screen/MindRoomSplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    failed while `MindRoomSplashScreen` still imported and passed the explicit
+    particle background.
+  - Cleanup green focused check:
+    `npm test -- src/app/components/splash-screen/MindRoomSplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (2 files, 98 tests).
+  - Cleanup green check:
+    `npx prettier --check FORK_CHANGES.md src/app/components/splash-screen/MindRoomSplashScreen.tsx src/app/components/splash-screen/MindRoomSplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Cleanup green check: `npm run typecheck`.
+  - Cleanup green check: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Cleanup green check: `npm test` (301 files, 2240 tests).
+  - Cleanup green check: `npm run build` (existing Vite runtime-config,
+    sourcemap, localStorage, and chunk-size warnings only).
+  - Cleanup independent review green check: separate subagent review found no
+    issues and confirmed no `SplashScreen` caller still passes the redundant
+    default particle background.
 
 ### CINNY-130 - Point fork support links at MindRoom repository (2026-05-29)
 

--- a/src/app/components/splash-screen/MindRoomSplashScreen.test.ts
+++ b/src/app/components/splash-screen/MindRoomSplashScreen.test.ts
@@ -31,10 +31,6 @@ vi.mock('folds', async () => {
   };
 });
 
-vi.mock('../particle-background', () => ({
-  MindRoomParticleBackground: () => React.createElement('div', null, 'particle background'),
-}));
-
 vi.mock('./SplashScreen', () => ({
   SplashScreen: ({
     children,
@@ -87,7 +83,7 @@ describe('MindRoomSplashScreen', () => {
       );
     });
 
-    expect(renderer!.root.findByProps({ 'data-has-background': true })).toBeDefined();
+    expect(renderer!.root.findByProps({ 'data-has-background': false })).toBeDefined();
     expect(
       renderer!.root.findAll(
         (node) => typeof node.type === 'string' && node.children.includes('Alpha')

--- a/src/app/components/splash-screen/MindRoomSplashScreen.tsx
+++ b/src/app/components/splash-screen/MindRoomSplashScreen.tsx
@@ -1,7 +1,6 @@
 import { Box, Spinner, Text } from 'folds';
 import React, { ReactNode, useMemo } from 'react';
 import { useNativeSplashOverlay } from '../../mindroom/native/useNativeSplashOverlay';
-import { MindRoomParticleBackground } from '../particle-background';
 import { SplashScreen } from './SplashScreen';
 
 export const DEFAULT_MINDROOM_SPLASH_MESSAGES = ['Loading MindRoom'] as const;
@@ -44,7 +43,7 @@ export function MindRoomSplashScreen({
   );
 
   return (
-    <SplashScreen background={<MindRoomParticleBackground position="fixed" />}>
+    <SplashScreen>
       <Box direction="Column" grow="Yes" alignItems="Center" justifyContent="Center" gap="400">
         <Spinner variant="Secondary" size="600" />
         <Text>{selectedMessage}</Text>

--- a/src/app/components/splash-screen/SplashScreen.test.ts
+++ b/src/app/components/splash-screen/SplashScreen.test.ts
@@ -42,4 +42,48 @@ describe('SplashScreen', () => {
       })
     ).toBeDefined();
   });
+
+  it('renders a custom background instead of the particle background', () => {
+    const customBackground = React.createElement('div', {
+      'data-custom-background': true,
+    });
+
+    const renderer = create(
+      React.createElement(
+        SplashScreen,
+        { background: customBackground },
+        React.createElement('span', null, 'Content')
+      )
+    );
+
+    expect(renderer.root.findByProps({ 'data-custom-background': true })).toBeDefined();
+    expect(
+      renderer.root.findAllByProps({ 'data-mindroom-particle-background': true })
+    ).toHaveLength(0);
+  });
+
+  it.each([null, false])(
+    'falls back to the MindRoom particle background when background is %s',
+    (background) => {
+      const renderer = create(
+        React.createElement(
+          SplashScreen,
+          { background },
+          React.createElement('span', null, 'Content')
+        )
+      );
+
+      expect(
+        renderer.root.findByProps({
+          'data-mindroom-particle-background': true,
+          'data-position': 'fixed',
+        })
+      ).toBeDefined();
+      expect(
+        renderer.root.findAll(
+          (node) => node.type === 'div' && node.props.className === 'splash-screen-content'
+        )
+      ).toHaveLength(1);
+    }
+  );
 });

--- a/src/app/components/splash-screen/SplashScreen.test.ts
+++ b/src/app/components/splash-screen/SplashScreen.test.ts
@@ -1,0 +1,45 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { SplashScreen } from './SplashScreen';
+
+vi.mock('folds', async () => {
+  const reactModule = await import('react');
+
+  return {
+    Box: ({ children, className }: { children?: React.ReactNode; className?: string }) =>
+      reactModule.createElement('div', { className }, children),
+    Text: ({ children }: { children?: React.ReactNode }) =>
+      reactModule.createElement('span', null, children),
+  };
+});
+
+vi.mock('../particle-background', () => ({
+  MindRoomParticleBackground: ({ position }: { position?: string }) =>
+    React.createElement('div', {
+      'data-mindroom-particle-background': true,
+      'data-position': position,
+    }),
+}));
+
+vi.mock('./SplashScreen.css', () => ({
+  SplashScreen: 'splash-screen',
+  SplashScreenContent: 'splash-screen-content',
+  SplashScreenFooter: 'splash-screen-footer',
+  SplashScreenParticle: 'splash-screen-particle',
+}));
+
+describe('SplashScreen', () => {
+  it('uses the MindRoom particle background by default', () => {
+    const renderer = create(
+      React.createElement(SplashScreen, null, React.createElement('span', null, 'Content'))
+    );
+
+    expect(
+      renderer.root.findByProps({
+        'data-mindroom-particle-background': true,
+        'data-position': 'fixed',
+      })
+    ).toBeDefined();
+  });
+});

--- a/src/app/components/splash-screen/SplashScreen.tsx
+++ b/src/app/components/splash-screen/SplashScreen.tsx
@@ -1,9 +1,9 @@
 import { Box, Text } from 'folds';
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
-import * as patternsCSS from '../../styles/Patterns.css';
 import * as css from './SplashScreen.css';
 import { MINDROOM_CLIENT_BRANDING } from '../../mindroom/branding/clientBranding';
+import { MindRoomParticleBackground } from '../particle-background';
 
 type SplashScreenProps = {
   children: ReactNode;
@@ -11,16 +11,16 @@ type SplashScreenProps = {
 };
 
 export function SplashScreen({ children, background }: SplashScreenProps) {
+  const resolvedBackground =
+    background === undefined ? <MindRoomParticleBackground position="fixed" /> : background;
+
   return (
     <Box
-      className={classNames(
-        css.SplashScreen,
-        background ? css.SplashScreenParticle : patternsCSS.BackgroundDotPattern
-      )}
+      className={classNames(css.SplashScreen, resolvedBackground && css.SplashScreenParticle)}
       direction="Column"
     >
-      {background}
-      {background ? (
+      {resolvedBackground}
+      {resolvedBackground ? (
         <Box className={css.SplashScreenContent} direction="Column" grow="Yes">
           {children}
         </Box>

--- a/src/app/components/splash-screen/SplashScreen.tsx
+++ b/src/app/components/splash-screen/SplashScreen.tsx
@@ -11,8 +11,7 @@ type SplashScreenProps = {
 };
 
 export function SplashScreen({ children, background }: SplashScreenProps) {
-  const resolvedBackground =
-    background === undefined ? <MindRoomParticleBackground position="fixed" /> : background;
+  const resolvedBackground = background || <MindRoomParticleBackground position="fixed" />;
 
   return (
     <Box

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -1899,9 +1899,11 @@ describe('RoomTimeline architecture', () => {
     expect(welcomePageSource).toContain("from '../../mindroom/branding/clientBranding'");
     expect(welcomePageSource).not.toContain("from '../../mindroom/branding/branding'");
     expect(splashScreenSource).toContain("from '../../mindroom/branding/clientBranding'");
+    expect(splashScreenSource).toContain("from '../particle-background'");
     expect(splashScreenSource).toContain('background?: ReactNode');
-    expect(splashScreenSource).toContain('background ? css.SplashScreenParticle');
-    expect(splashScreenSource).toContain('patternsCSS.BackgroundDotPattern');
+    expect(splashScreenSource).toContain('const resolvedBackground =');
+    expect(splashScreenSource).toContain('<MindRoomParticleBackground position="fixed" />');
+    expect(splashScreenSource).not.toContain('patternsCSS.BackgroundDotPattern');
     expect(splashScreenSource).not.toContain("from '../../pages/auth/AuthParticleBackground'");
     expect(mindRoomSplashScreenSource).toContain("from '../particle-background'");
     expect(mindRoomSplashScreenSource).toContain(

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -1902,8 +1902,11 @@ describe('RoomTimeline architecture', () => {
     expect(splashScreenSource).toContain("from '../particle-background'");
     expect(splashScreenSource).toContain('background?: ReactNode');
     expect(splashScreenSource).toContain('const resolvedBackground =');
-    expect(splashScreenSource).toContain('<MindRoomParticleBackground position="fixed" />');
+    expect(splashScreenSource).toContain('MindRoomParticleBackground');
+    expect(splashScreenSource).toContain('position="fixed"');
     expect(splashScreenSource).not.toContain('patternsCSS.BackgroundDotPattern');
+    expect(splashScreenSource).not.toContain("'../../styles/Patterns.css'");
+    expect(splashScreenSource).not.toContain('"../../styles/Patterns.css"');
     expect(splashScreenSource).not.toContain("from '../../pages/auth/AuthParticleBackground'");
     expect(mindRoomSplashScreenSource).toContain("from '../particle-background'");
     expect(mindRoomSplashScreenSource).toContain(

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -1908,10 +1908,10 @@ describe('RoomTimeline architecture', () => {
     expect(splashScreenSource).not.toContain("'../../styles/Patterns.css'");
     expect(splashScreenSource).not.toContain('"../../styles/Patterns.css"');
     expect(splashScreenSource).not.toContain("from '../../pages/auth/AuthParticleBackground'");
-    expect(mindRoomSplashScreenSource).toContain("from '../particle-background'");
-    expect(mindRoomSplashScreenSource).toContain(
-      '<SplashScreen background={<MindRoomParticleBackground position="fixed" />}>'
-    );
+    expect(mindRoomSplashScreenSource).not.toContain("from '../particle-background'");
+    expect(mindRoomSplashScreenSource).not.toContain('MindRoomParticleBackground');
+    expect(mindRoomSplashScreenSource).not.toContain('background={<');
+    expect(mindRoomSplashScreenSource).toContain('<SplashScreen>');
     expect(clientRootSource).toContain('MindRoomSplashScreen');
     expect(configConfigSource).toContain('MindRoomSplashScreen');
     expect(specVersionsSource).toContain('MindRoomSplashScreen');


### PR DESCRIPTION
## Summary
- Default shared splash screens to the MindRoom WebGL particle background.
- Move the homeserver connection error and other generic splash/error screens off the old dot-pattern background.
- Add a regression test and update the architecture guard/runbook entry.

## Test Plan
- [x] npm test
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] npx prettier --check FORK_CHANGES.md src/app/components/splash-screen/SplashScreen.tsx src/app/components/splash-screen/SplashScreen.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
- [x] git diff --check

## Summary by Sourcery

Default shared splash screens to use the MindRoom WebGL particle background instead of the legacy dot-pattern background while preserving support for custom backgrounds.

Enhancements:
- Switch shared SplashScreen to resolve a default MindRoom WebGL particle background when no custom background is provided.
- Remove dependency on the legacy dot-pattern background from generic splash and error screens.
- Tighten RoomTimeline architecture constraints to require the SplashScreen to use the client branding and particle background modules.

Documentation:
- Add a new runbook entry documenting the splash-screen background change, its validation steps, and related guardrail updates in FORK_CHANGES.md.

Tests:
- Add a dedicated SplashScreen test suite to verify the default particle background behavior and related rendering.
- Update the RoomTimeline architecture test expectations to reflect the new SplashScreen background implementation and imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Splash screens (client errors, feature checks, startup screens) now display an animated WebGL particle background by default instead of the previous dot-pattern design. Custom backgrounds remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->