### PR TITLE
fix: avoid forwarding config retry click event

### DIFF
--- a/src/app/pages/ConfigConfig.test.tsx
+++ b/src/app/pages/ConfigConfig.test.tsx
@@ -4,20 +4,19 @@ import { describe, expect, it, vi } from 'vitest';
 import { ConfigConfigError } from './ConfigConfig';
 
 vi.mock('folds', () => ({
-  Box: ({ children, ...props }: { children?: React.ReactNode }) =>
-    React.createElement('div', props, children),
+  Box: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
   Button: ({
     children,
     onClick,
-    ...props
   }: {
     children?: React.ReactNode;
     onClick?: (event?: unknown) => void;
-  }) => React.createElement('button', { ...props, onClick }, children),
-  Dialog: ({ children, ...props }: { children?: React.ReactNode }) =>
-    React.createElement('div', props, children),
-  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
-    React.createElement('span', props, children),
+  }) => React.createElement('button', { onClick }, children),
+  Dialog: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  Text: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('span', null, children),
   color: {
     Critical: {
       Main: 'red',
@@ -42,19 +41,29 @@ const getButtonByText = (renderer: ReactTestRenderer, text: string) =>
     button.findAllByType('span').some((span) => span.children.includes(text))
   );
 
+const renderConfigError = ({
+  retry,
+  ignore,
+}: {
+  retry: () => void;
+  ignore: () => void;
+}) => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <ConfigConfigError error={new Error('config failed')} retry={retry} ignore={ignore} />
+    );
+  });
+  return renderer!;
+};
+
 describe('ConfigConfigError', () => {
   it('does not forward the click event into the retry callback', () => {
     const retry = vi.fn();
     const ignore = vi.fn();
+    const renderer = renderConfigError({ retry, ignore });
 
-    let renderer: ReactTestRenderer;
-    act(() => {
-      renderer = create(
-        <ConfigConfigError error={new Error('config failed')} retry={retry} ignore={ignore} />
-      );
-    });
-
-    const retryButton = getButtonByText(renderer!, 'Retry');
+    const retryButton = getButtonByText(renderer, 'Retry');
     expect(retryButton).toBeDefined();
 
     act(() => {
@@ -63,5 +72,21 @@ describe('ConfigConfigError', () => {
 
     expect(retry).toHaveBeenCalledTimes(1);
     expect(retry).toHaveBeenCalledWith();
+  });
+
+  it('does not forward the click event into the ignore callback', () => {
+    const retry = vi.fn();
+    const ignore = vi.fn();
+    const renderer = renderConfigError({ retry, ignore });
+
+    const continueButton = getButtonByText(renderer, 'Continue');
+    expect(continueButton).toBeDefined();
+
+    act(() => {
+      continueButton?.props.onClick({ type: 'click' });
+    });
+
+    expect(ignore).toHaveBeenCalledTimes(1);
+    expect(ignore).toHaveBeenCalledWith();
   });
 });

--- a/src/app/pages/ConfigConfig.test.tsx
+++ b/src/app/pages/ConfigConfig.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfigConfigError } from './ConfigConfig';
+
+vi.mock('folds', () => ({
+  Box: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: {
+    children?: React.ReactNode;
+    onClick?: (event?: unknown) => void;
+  }) => React.createElement('button', { ...props, onClick }, children),
+  Dialog: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
+  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('span', props, children),
+  color: {
+    Critical: {
+      Main: 'red',
+    },
+  },
+  config: {
+    space: {
+      S400: '16px',
+    },
+  },
+}));
+
+vi.mock('../components/splash-screen', () => ({
+  MindRoomSplashScreen: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  SplashScreen: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+
+const getButtonByText = (renderer: ReactTestRenderer, text: string) =>
+  renderer.root.findAllByType('button').find((button) =>
+    button.findAllByType('span').some((span) => span.children.includes(text))
+  );
+
+describe('ConfigConfigError', () => {
+  it('does not forward the click event into the retry callback', () => {
+    const retry = vi.fn();
+    const ignore = vi.fn();
+
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <ConfigConfigError error={new Error('config failed')} retry={retry} ignore={ignore} />
+      );
+    });
+
+    const retryButton = getButtonByText(renderer!, 'Retry');
+    expect(retryButton).toBeDefined();
+
+    act(() => {
+      retryButton?.props.onClick({ type: 'click' });
+    });
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(retry).toHaveBeenCalledWith();
+  });
+});

--- a/src/app/pages/ConfigConfig.tsx
+++ b/src/app/pages/ConfigConfig.tsx
@@ -28,12 +28,12 @@ export function ConfigConfigError({ error, retry, ignore }: ConfigConfigErrorPro
                   </Text>
                 )}
             </Box>
-            <Button variant="Critical" onClick={retry}>
+            <Button variant="Critical" onClick={() => retry()}>
               <Text as="span" size="B400">
                 Retry
               </Text>
             </Button>
-            <Button variant="Critical" onClick={ignore} fill="Soft">
+            <Button variant="Critical" onClick={() => ignore()} fill="Soft">
               <Text as="span" size="B400">
                 Continue
               </Text>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,13 +6,7 @@ export default defineConfig({
     setupFiles: ['./src/vitest.setup.ts'],
     include: [
       'src/**/*.test.ts',
-      'src/app/pages/ConfigConfig.test.tsx',
-      'src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx',
-      'src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx',
-      'src/app/components/message/content/AudioContent.test.tsx',
-      'src/app/components/message/content/ImageContent.test.tsx',
-      'src/app/features/room-nav/SortableRoomNavItem.test.tsx',
-      'src/app/mindroom/native/useEdgeSwipeBack.test.tsx',
+      'src/**/*.test.tsx',
     ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     setupFiles: ['./src/vitest.setup.ts'],
     include: [
       'src/**/*.test.ts',
+      'src/app/pages/ConfigConfig.test.tsx',
       'src/app/components/invite-user-prompt/InviteUserAutocomplete.test.tsx',
       'src/app/components/invite-user-prompt/InviteUserPrompt.test.tsx',
       'src/app/components/message/content/AudioContent.test.tsx',


### PR DESCRIPTION
## Summary
- wrap the config error dialog button handlers so React click events are not passed into config loading callbacks
- add a regression test for retry click handling

## Test
- npm test -- src/app/pages/ConfigConfig.test.tsx
- npx eslint src/app/pages/ConfigConfig.tsx src/app/pages/ConfigConfig.test.tsx
- npm run typecheck