### PR TITLE
feat: send attachments before the caption text

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -6986,3 +6986,19 @@ uploads it as the `cinny-android-debug-apk` workflow artifact (14-day retention)
   - `npm test` passes (`237/237` files, `1788/1788` tests)
   - `npm run lint` passes with the current warning-only baseline (`17` warnings, `0` errors)
   - `git diff --check` passes
+
+## CINNY-108 — Send attachments before the caption text (2026-06-12)
+
+- Inverted the room-input send-session ordering so attachments send first (selection order) and the caption text sends last, matching the MindRoom backend coalescing contract where a media batch forms one agent turn and the trailing text event closes it (mindroom PR #1255).
+- Removed the `auto-thread-text-root` send mode: text plus attachments in the main timeline now uses the upload-root shape (first attachment is the room-level root, remaining attachments and the caption thread under it), the same structure attachment-only bursts already used.
+- The caption joins the thread opened by the upload root via a plain thread relation; reply-draft metadata stays on the root upload as before.
+- A caption no longer waits forever on a failed non-root upload awaiting manual retry; it sends once every active upload is settled, mirroring the existing relaxed non-root retry ordering.
+- The composer now resets when the send session snapshots the caption (session start) instead of when the text event goes out, since the text can now wait behind slow uploads; a failed caption stays in the session and retries via the existing Send-again resume path.
+- `RoomInput.test.ts` now also mocks `components/editor/utils` (the controller imports the reset helpers from there, not from the mocked editor barrel); at the old HEAD the controller's real `resetEditor` call crashed against the stubbed slate `Editor` and was silently swallowed by the send-step `catch`.
+- review:
+  - independent second self-review completed via a fresh `git diff` pass over the send-session policy, controller, and test changes; scope stayed limited to the room-input send path and this runbook update.
+- validation (2026-06-12):
+  - `npm test` passes (`302/302` files, `2249/2249` tests)
+  - `npm run typecheck` passes
+  - `npm run build` passes
+  - `npx eslint` on the changed files passes

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -6993,12 +6993,21 @@ uploads it as the `cinny-android-debug-apk` workflow artifact (14-day retention)
 - Removed the `auto-thread-text-root` send mode: text plus attachments in the main timeline now uses the upload-root shape (first attachment is the room-level root, remaining attachments and the caption thread under it), the same structure attachment-only bursts already used.
 - The caption joins the thread opened by the upload root via a plain thread relation; reply-draft metadata stays on the root upload as before.
 - A caption no longer waits forever on a failed non-root upload awaiting manual retry; it sends once every active upload is settled, mirroring the existing relaxed non-root retry ordering.
-- The composer now resets when the send session snapshots the caption (session start) instead of when the text event goes out, since the text can now wait behind slow uploads; a failed caption stays in the session and retries via the existing Send-again resume path.
+- The composer now resets when the send session snapshots the caption (session start) instead of when the text event goes out, since the text can now wait behind slow uploads; a failed caption is restored into the composer (see review fixes below).
 - `RoomInput.test.ts` now also mocks `components/editor/utils` (the controller imports the reset helpers from there, not from the mocked editor barrel); at the old HEAD the controller's real `resetEditor` call crashed against the stubbed slate `Editor` and was silently swallowed by the send-step `catch`.
 - review:
   - independent second self-review completed via a fresh `git diff` pass over the send-session policy, controller, and test changes; scope stayed limited to the room-input send path and this runbook update.
 - validation (2026-06-12):
   - `npm test` passes (`302/302` files, `2249/2249` tests)
+  - `npm run typecheck` passes
+  - `npm run build` passes
+  - `npx eslint` on the changed files passes
+- review fixes (2026-06-12, PR #40 review):
+  - Failed-caption recovery: with media-first ordering, the caption usually fails only after every upload has sent and left the board, so the board's Send-again affordance (the only way to resume a `blockedRoot` session) no longer exists — the caption was silently lost and the zombie session would flush the stale caption into a later unrelated send. The send-text failure path no longer sets `blockedRoot`; it restores the composer from a `structuredClone` snapshot of `editor.children` taken at session start (slate mutates `editor.children` in place) via the new `restoreEditorContent` helper in `components/editor/utils`, clears `textPending`, and lets the session finish. Upload retries stay resumable; a restored caption is never resent by the session. Manual resend of a restored caption goes through the normal submit path (in the auto-thread case it posts as a plain room message since the session root is gone — accepted trade-off).
+  - New controller tests cover caption-send failure: composer restore + session completion without stale resends, and upload-retry resume after a failed caption.
+  - Wrapped the over-`printWidth` lines this branch had introduced (send-step root condition, `resolveRoomInputSendStep` one-liners, two test titles); the touched modules other than `roomInputSendSession.ts`/`RoomInput.test.ts` pre-existing hunks are now prettier-clean.
+- validation (2026-06-12, after review fixes):
+  - `npm test` passes (`302/302` files, `2251/2251` tests)
   - `npm run typecheck` passes
   - `npm run build` passes
   - `npx eslint` on the changed files passes

--- a/src/app/components/editor/utils.ts
+++ b/src/app/components/editor/utils.ts
@@ -1,4 +1,14 @@
-import { BasePoint, BaseRange, Editor, Element, Point, Range, Text, Transforms } from 'slate';
+import {
+  BasePoint,
+  BaseRange,
+  Descendant,
+  Editor,
+  Element,
+  Point,
+  Range,
+  Text,
+  Transforms,
+} from 'slate';
 import { BlockType, MarkType } from './types';
 import {
   CommandElement,
@@ -259,6 +269,22 @@ export const isEmptyEditor = (editor: Editor): boolean => {
     return isEmpty;
   }
   return false;
+};
+
+export const restoreEditorContent = (editor: Editor, fragment: Descendant[]) => {
+  const wasEmpty = isEmptyEditor(editor);
+  Editor.withoutNormalizing(editor, () => {
+    Transforms.insertNodes(editor, fragment, { at: [0] });
+    // An empty editor holds a single empty paragraph; restoring before it would leave a
+    // trailing blank line. Anything the user typed since the snapshot stays, after the
+    // restored content.
+    if (wasEmpty) {
+      Transforms.removeNodes(editor, { at: [fragment.length] });
+    }
+  });
+  if (wasEmpty) {
+    Transforms.select(editor, Editor.end(editor, []));
+  }
 };
 
 export const getBeginCommand = (editor: Editor): string | undefined => {

--- a/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
+++ b/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
@@ -238,6 +238,14 @@ vi.mock('../../../components/editor', () => ({
   trimCustomHtml: (value: string) => value,
 }));
 
+// The send-session controller imports these helpers from the utils module directly, so the
+// editor barrel mock above does not cover its calls.
+vi.mock('../../../components/editor/utils', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  resetEditor: editorMocks.resetEditor,
+  resetEditorHistory: editorMocks.resetEditorHistory,
+}));
+
 vi.mock('../../../components/emoji-board', () => ({
   EmojiBoard: () => null,
   EmojiBoardTab: {},
@@ -1045,7 +1053,7 @@ describe('RoomInput', () => {
     renderer.unmount();
   });
 
-  it('keeps a paste upload claimed by send after the text-send editor reset clears the marker', async () => {
+  it('keeps a paste upload claimed by send after the session-start editor reset clears the marker', async () => {
     const { store, renderer } = await renderRoomInput();
     const pastedText = 'large paste\n'.repeat(6000);
 
@@ -1075,13 +1083,28 @@ describe('RoomInput', () => {
       await uploadBoardSend.props.onClick();
     });
 
-    expect(mxState.sendMessage).toHaveBeenCalledTimes(1);
+    // The caption sends after the paste upload; the session-start editor reset clears the
+    // marker but must not orphan-clean the claimed paste upload while it is still uploading.
+    expect(editorMocks.resetEditor).toHaveBeenCalled();
+    expect(mxState.sendMessage).not.toHaveBeenCalled();
     expect(store.get(roomIdToUploadItemsAtomFamily(ROOM_ID))).toHaveLength(1);
 
-    expect(mxState.sendMessage).toHaveBeenCalledTimes(1);
+    const pasteFile = store.get(roomIdToUploadItemsAtomFamily(ROOM_ID))[0].file;
+    await act(async () => {
+      store.set(roomUploadAtomFamily(pasteFile), { mxc: 'mxc://mindroom/paste' });
+    });
+
+    expect(mxState.sendMessage).toHaveBeenCalledTimes(2);
     expect(mxState.sendMessage.mock.calls[0][1]).toMatchObject({
+      url: 'mxc://mindroom/paste',
+    });
+    expect(mxState.sendMessage.mock.calls[1][1]).toMatchObject({
       msgtype: 'm.text',
       body: `${marker}\n\ntest testing`,
+      'm.relates_to': {
+        event_id: '$sent',
+        rel_type: 'm.thread',
+      },
     });
 
     renderer.unmount();

--- a/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
+++ b/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
@@ -38,6 +38,7 @@ const {
     moveCursor: vi.fn(),
     resetEditor: vi.fn(),
     resetEditorHistory: vi.fn(),
+    restoreEditorContent: vi.fn(),
   },
   customEditorState: {
     autocompleteQuery: undefined as { prefix: string; range: unknown; text: string } | undefined,
@@ -244,6 +245,7 @@ vi.mock('../../../components/editor/utils', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   resetEditor: editorMocks.resetEditor,
   resetEditorHistory: editorMocks.resetEditorHistory,
+  restoreEditorContent: editorMocks.restoreEditorContent,
 }));
 
 vi.mock('../../../components/emoji-board', () => ({
@@ -1053,7 +1055,7 @@ describe('RoomInput', () => {
     renderer.unmount();
   });
 
-  it('keeps a paste upload claimed by send after the session-start editor reset clears the marker', async () => {
+  it('keeps a paste upload claimed by send after the session-start editor reset', async () => {
     const { store, renderer } = await renderRoomInput();
     const pastedText = 'large paste\n'.repeat(6000);
 

--- a/src/app/mindroom/threads/roomInputSendSession.test.ts
+++ b/src/app/mindroom/threads/roomInputSendSession.test.ts
@@ -38,7 +38,7 @@ const plainReplyDraft = (eventId = '$reply'): IReplyDraft => ({
 });
 
 describe('roomInputSendSession', () => {
-  it('sends text first, then attachments in selection order for text plus attachments', () => {
+  it('sends attachments in selection order first and the caption last for text plus attachments', () => {
     const first = createFile('first.png');
     const second = createFile('second.png');
     const session = createRoomInputSendSessionState({
@@ -46,11 +46,7 @@ describe('roomInputSendSession', () => {
       hasText: true,
     });
 
-    expect(session.mode).toBe('auto-thread-text-root');
-    expect(resolveRoomInputSendStep(session, [], [first, second])).toEqual({ kind: 'send-text' });
-
-    session.textPending = false;
-    session.rootEventId = '$root';
+    expect(session.mode).toBe('auto-thread-upload-root');
 
     expect(
       resolveRoomInputSendStep(session, [loadingUpload(first), successUpload(second)], [first, second])
@@ -62,10 +58,11 @@ describe('roomInputSendSession', () => {
       kind: 'send-upload',
       file: first,
       mxc: 'mxc://mindroom/first.png',
-      isRoot: false,
+      isRoot: true,
     });
 
     session.sentFiles.add(first);
+    session.rootEventId = '$root';
 
     expect(
       resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
@@ -80,7 +77,41 @@ describe('roomInputSendSession', () => {
 
     expect(
       resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+    ).toEqual({ kind: 'send-text' });
+
+    session.textPending = false;
+
+    expect(
+      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
     ).toEqual({ kind: 'complete' });
+
+    expect(getTextRelationForSendSession(session)).toMatchObject({
+      event_id: '$root',
+      rel_type: RelationType.Thread,
+    });
+  });
+
+  it('auto-threads a single attachment with a caption under the upload root', () => {
+    const only = createFile('only.png');
+    const session = createRoomInputSendSessionState({
+      files: [only],
+      hasText: true,
+    });
+
+    expect(session.mode).toBe('auto-thread-upload-root');
+    expect(resolveRoomInputSendStep(session, [successUpload(only)], [only])).toEqual({
+      kind: 'send-upload',
+      file: only,
+      mxc: 'mxc://mindroom/only.png',
+      isRoot: true,
+    });
+
+    session.sentFiles.add(only);
+    session.rootEventId = '$root';
+
+    expect(resolveRoomInputSendStep(session, [successUpload(only)], [only])).toEqual({
+      kind: 'send-text',
+    });
   });
 
   it('uses the first attachment as the root and threads the rest for attachment-only sends', () => {
@@ -155,9 +186,7 @@ describe('roomInputSendSession', () => {
       is_falling_back: true,
     });
 
-    expect(resolveRoomInputSendStep(session, [], [first, second])).toEqual({ kind: 'send-text' });
-
-    session.textPending = false;
+    expect(resolveRoomInputSendStep(session, [], [first, second])).toEqual({ kind: 'wait' });
 
     expect(
       resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
@@ -167,6 +196,13 @@ describe('roomInputSendSession', () => {
       mxc: 'mxc://mindroom/first.png',
       isRoot: false,
     });
+
+    session.sentFiles.add(first);
+    session.sentFiles.add(second);
+
+    expect(
+      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+    ).toEqual({ kind: 'send-text' });
     expect(session.rootEventId).toBeUndefined();
   });
 
@@ -206,18 +242,27 @@ describe('roomInputSendSession', () => {
 
   it('keeps plain reply metadata on the root and threads later attachments under the new root', () => {
     const first = createFile('first.png');
-    const textSession = createRoomInputSendSessionState({
+    const captionedSession = createRoomInputSendSessionState({
       files: [first],
       hasText: true,
       replyDraft: plainReplyDraft(),
     });
 
     expect(
-      getTextRelationForSendSession({ ...textSession, replyDraft: plainReplyDraft() })
+      getUploadRelationForSendSession({ ...captionedSession, replyDraft: plainReplyDraft() }, true)
     ).toEqual({
       'm.in_reply_to': {
         event_id: '$reply',
       },
+    });
+
+    captionedSession.rootEventId = '$new-root';
+
+    expect(
+      getTextRelationForSendSession({ ...captionedSession, replyDraft: plainReplyDraft() })
+    ).toMatchObject({
+      event_id: '$new-root',
+      rel_type: RelationType.Thread,
     });
 
     const uploadSession = createRoomInputSendSessionState({
@@ -343,6 +388,29 @@ describe('roomInputSendSession', () => {
       mxc: 'mxc://mindroom/second.png',
       isRoot: false,
     });
+  });
+
+  it('sends the caption without waiting for a failed non-root upload awaiting manual retry', () => {
+    const first = createFile('first.png');
+    const second = createFile('second.png');
+    const session = createRoomInputSendSessionState({
+      files: [first, second],
+      hasText: true,
+    });
+
+    session.sentFiles.add(first);
+    session.rootEventId = '$root';
+    session.failedFiles.add(second);
+
+    expect(
+      resolveRoomInputSendStep(session, [successUpload(first), errorUpload(second)], [first, second])
+    ).toEqual({ kind: 'send-text' });
+
+    session.textPending = false;
+
+    expect(
+      resolveRoomInputSendStep(session, [successUpload(first), errorUpload(second)], [first, second])
+    ).toEqual({ kind: 'wait' });
   });
 
   it('only matches reply-draft clearing when the live send context still matches the session snapshot', () => {

--- a/src/app/mindroom/threads/roomInputSendSession.test.ts
+++ b/src/app/mindroom/threads/roomInputSendSession.test.ts
@@ -38,7 +38,7 @@ const plainReplyDraft = (eventId = '$reply'): IReplyDraft => ({
 });
 
 describe('roomInputSendSession', () => {
-  it('sends attachments in selection order first and the caption last for text plus attachments', () => {
+  it('sends attachments first and the caption last for text plus attachments', () => {
     const first = createFile('first.png');
     const second = createFile('second.png');
     const session = createRoomInputSendSessionState({
@@ -49,11 +49,19 @@ describe('roomInputSendSession', () => {
     expect(session.mode).toBe('auto-thread-upload-root');
 
     expect(
-      resolveRoomInputSendStep(session, [loadingUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [loadingUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({ kind: 'wait' });
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({
       kind: 'send-upload',
       file: first,
@@ -65,7 +73,11 @@ describe('roomInputSendSession', () => {
     session.rootEventId = '$root';
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({
       kind: 'send-upload',
       file: second,
@@ -76,13 +88,21 @@ describe('roomInputSendSession', () => {
     session.sentFiles.add(second);
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({ kind: 'send-text' });
 
     session.textPending = false;
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({ kind: 'complete' });
 
     expect(getTextRelationForSendSession(session)).toMatchObject({
@@ -189,7 +209,11 @@ describe('roomInputSendSession', () => {
     expect(resolveRoomInputSendStep(session, [], [first, second])).toEqual({ kind: 'wait' });
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({
       kind: 'send-upload',
       file: first,
@@ -201,7 +225,11 @@ describe('roomInputSendSession', () => {
     session.sentFiles.add(second);
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), successUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), successUpload(second)],
+        [first, second]
+      )
     ).toEqual({ kind: 'send-text' });
     expect(session.rootEventId).toBeUndefined();
   });
@@ -403,13 +431,21 @@ describe('roomInputSendSession', () => {
     session.failedFiles.add(second);
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), errorUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), errorUpload(second)],
+        [first, second]
+      )
     ).toEqual({ kind: 'send-text' });
 
     session.textPending = false;
 
     expect(
-      resolveRoomInputSendStep(session, [successUpload(first), errorUpload(second)], [first, second])
+      resolveRoomInputSendStep(
+        session,
+        [successUpload(first), errorUpload(second)],
+        [first, second]
+      )
     ).toEqual({ kind: 'wait' });
   });
 

--- a/src/app/mindroom/threads/roomInputSendSession.ts
+++ b/src/app/mindroom/threads/roomInputSendSession.ts
@@ -4,11 +4,7 @@ import { Upload, UploadStatus } from '../../state/upload';
 import { TUploadContent } from '../../utils/matrix';
 import { getMessageRelation } from './composeMessageRelation';
 
-export type RoomInputSendMode =
-  | 'room'
-  | 'existing-thread'
-  | 'auto-thread-text-root'
-  | 'auto-thread-upload-root';
+export type RoomInputSendMode = 'room' | 'existing-thread' | 'auto-thread-upload-root';
 
 export type RoomInputSendSessionState = {
   mode: RoomInputSendMode;
@@ -99,10 +95,7 @@ export const getRoomInputSendMode = ({
     return 'existing-thread';
   }
   if (!threadingEnabled) return 'room';
-  if (hasText) {
-    return 'auto-thread-text-root';
-  }
-  if (attachmentCount > 1) {
+  if (attachmentCount > 1 || (hasText && attachmentCount > 0)) {
     return 'auto-thread-upload-root';
   }
   return 'room';
@@ -160,18 +153,10 @@ export const resolveRoomInputSendStep = (
     return { kind: 'wait' };
   }
 
-  if (session.textPending) {
-    return { kind: 'send-text' };
-  }
-
   const pendingFiles = getPendingFiles(session, activeFiles);
-  if (pendingFiles.length === 0) {
-    return { kind: 'complete' };
-  }
-
   const uploadMap = new Map(uploads.map((upload) => [upload.file, upload]));
 
-  if (session.mode === 'auto-thread-upload-root' && !session.rootEventId) {
+  if (session.mode === 'auto-thread-upload-root' && !session.rootEventId && pendingFiles.length > 0) {
     const rootFile = pendingFiles[0];
     const upload = uploadMap.get(rootFile);
 
@@ -200,6 +185,17 @@ export const resolveRoomInputSendStep = (
     return { kind: 'send-upload', file, mxc: upload.mxc, isRoot: false };
   }
 
+  // Attachments go out first and the caption goes last: MindRoom coalesces a media batch into
+  // one agent turn and closes it on the trailing text event. Files awaiting a manual retry do
+  // not hold the caption back.
+  if (session.textPending) {
+    return { kind: 'send-text' };
+  }
+
+  if (pendingFiles.length === 0) {
+    return { kind: 'complete' };
+  }
+
   return { kind: 'wait' };
 };
 
@@ -223,6 +219,11 @@ export const getTextRelationForSendSession = (session: RelationSession) => {
       session.threadId,
       { allowThreadRelation: allowThreadRelation(session) }
     );
+  }
+  if (session.mode === 'auto-thread-upload-root' && session.rootEventId) {
+    // The root upload already carried the reply metadata; the trailing caption just joins the
+    // thread it opened.
+    return getMessageRelation(undefined, undefined, session.rootEventId);
   }
 
   return getMessageRelation(session.replyDraft?.eventId, session.replyDraft?.relation, undefined, {

--- a/src/app/mindroom/threads/roomInputSendSession.ts
+++ b/src/app/mindroom/threads/roomInputSendSession.ts
@@ -156,7 +156,11 @@ export const resolveRoomInputSendStep = (
   const pendingFiles = getPendingFiles(session, activeFiles);
   const uploadMap = new Map(uploads.map((upload) => [upload.file, upload]));
 
-  if (session.mode === 'auto-thread-upload-root' && !session.rootEventId && pendingFiles.length > 0) {
+  if (
+    session.mode === 'auto-thread-upload-root' &&
+    !session.rootEventId &&
+    pendingFiles.length > 0
+  ) {
     const rootFile = pendingFiles[0];
     const upload = uploadMap.get(rootFile);
 

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.test.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.test.ts
@@ -14,11 +14,13 @@ import {
 const mocks = vi.hoisted(() => ({
   resetEditor: vi.fn(),
   resetEditorHistory: vi.fn(),
+  restoreEditorContent: vi.fn(),
 }));
 
 vi.mock('../../components/editor/utils', () => ({
   resetEditor: mocks.resetEditor,
   resetEditorHistory: mocks.resetEditorHistory,
+  restoreEditorContent: mocks.restoreEditorContent,
 }));
 
 type HarnessApi = {
@@ -72,11 +74,13 @@ const prepErrorUpload = (file: File): Upload => ({
 const TestHarness = ({
   onReady,
   mx,
+  editor,
 }: {
   onReady: (api: HarnessApi) => void;
   mx: {
     sendMessage: ReturnType<typeof vi.fn>;
   };
+  editor: { children: unknown[] };
 }) => {
   const selectedFilesRef = useRef<TUploadItem[]>([]);
   const sendSessionFilesRef = useRef<TUploadContent[]>([]);
@@ -94,7 +98,7 @@ const TestHarness = ({
     threadId: undefined,
     replyDraft: undefined,
     setReplyDraft: vi.fn(),
-    editor: {} as never,
+    editor: editor as never,
     sendTypingStatus: vi.fn(),
     selectedFilesRef,
     sendSessionFilesRef,
@@ -142,12 +146,16 @@ const renderHarness = () => {
       return { event_id: eventId };
     }),
   };
+  const editor = {
+    children: [{ type: 'paragraph', children: [{ text: 'caption draft' }] }],
+  };
   let api!: HarnessApi;
 
   act(() => {
     create(
       React.createElement(TestHarness, {
         mx,
+        editor,
         onReady: (nextApi) => {
           api = nextApi;
         },
@@ -155,7 +163,7 @@ const renderHarness = () => {
     );
   });
 
-  return { api, mx };
+  return { api, mx, editor };
 };
 
 describe('useRoomInputSendSessionController prep-error uploads', () => {
@@ -293,5 +301,103 @@ describe('useRoomInputSendSessionController prep-error uploads', () => {
         is_falling_back: true,
       },
     });
+  });
+});
+
+describe('useRoomInputSendSessionController caption send failures', () => {
+  beforeEach(() => {
+    mocks.resetEditor.mockReset();
+    mocks.resetEditorHistory.mockReset();
+    mocks.restoreEditorContent.mockReset();
+  });
+
+  it('restores the caption to the composer and completes the session when the caption fails', async () => {
+    const { api, mx, editor } = renderHarness();
+    const image = createFile('image.png');
+
+    api.selectedFilesRef.current = [createUploadItem(image)];
+    api.uploadsRef.current = [successUpload(image)];
+
+    mx.sendMessage.mockImplementationOnce(async () => ({ event_id: '$root' }));
+    mx.sendMessage.mockImplementationOnce(async () => {
+      throw new Error('caption send failed');
+    });
+
+    await act(async () => {
+      await api.startSendSession({
+        textContent: { msgtype: 'm.text', body: 'caption draft' },
+      });
+    });
+
+    expect(mx.sendMessage).toHaveBeenCalledTimes(2);
+    expect(mx.sendMessage.mock.calls[0][1]).toMatchObject({
+      url: 'mxc://mindroom/image.png',
+    });
+    expect(mocks.resetEditor).toHaveBeenCalledWith(editor);
+    expect(mocks.restoreEditorContent).toHaveBeenCalledWith(editor, [
+      { type: 'paragraph', children: [{ text: 'caption draft' }] },
+    ]);
+
+    // The failed caption must not piggyback onto a later unrelated send.
+    const later = createFile('later.txt');
+    api.selectedFilesRef.current = [createUploadItem(later)];
+    api.uploadsRef.current = [successUpload(later)];
+
+    await act(async () => {
+      await api.startSendSession();
+    });
+
+    expect(mx.sendMessage).toHaveBeenCalledTimes(3);
+    expect(mx.sendMessage.mock.calls[2][1]).toMatchObject({
+      body: 'later.txt',
+      url: 'mxc://mindroom/later.txt',
+    });
+  });
+
+  it('keeps upload retries resumable after a failed caption without resending the caption', async () => {
+    const { api, mx } = renderHarness();
+    const first = createFile('first.png');
+    const second = createFile('second.png');
+
+    api.selectedFilesRef.current = [createUploadItem(first), createUploadItem(second)];
+    api.uploadsRef.current = [successUpload(first), successUpload(second)];
+
+    mx.sendMessage.mockImplementationOnce(async () => ({ event_id: '$root' }));
+    mx.sendMessage.mockImplementationOnce(async () => {
+      throw new Error('upload send failed');
+    });
+    mx.sendMessage.mockImplementationOnce(async () => {
+      throw new Error('caption send failed');
+    });
+
+    await act(async () => {
+      await api.startSendSession({
+        textContent: { msgtype: 'm.text', body: 'caption draft' },
+      });
+    });
+
+    // Root upload sent, the second upload send failed, then the caption failed and was
+    // restored to the composer.
+    expect(mx.sendMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.restoreEditorContent).toHaveBeenCalledTimes(1);
+
+    // Send-again resumes the failed upload but must not resend the restored caption.
+    await act(async () => {
+      await api.startSendSession();
+    });
+
+    expect(mx.sendMessage).toHaveBeenCalledTimes(4);
+    expect(mx.sendMessage.mock.calls[3][1]).toMatchObject({
+      body: 'second.png',
+      url: 'mxc://mindroom/second.png',
+      'm.relates_to': {
+        event_id: '$root',
+        rel_type: 'm.thread',
+      },
+    });
+    const textSends = mx.sendMessage.mock.calls.filter(
+      (call) => (call[1] as { msgtype?: string }).msgtype === 'm.text'
+    );
+    expect(textSends).toHaveLength(1);
   });
 });

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.ts
@@ -172,18 +172,12 @@ export const useRoomInputSendSessionController = ({
             'm.relates_to': relation,
           }
         : session.textContent;
-      const response = await mx.sendMessage(session.roomId, content as any);
+      await mx.sendMessage(session.roomId, content as any);
 
       session.textPending = false;
-      if (session.mode === 'auto-thread-text-root') {
-        session.rootEventId = response.event_id;
-      }
       clearReplyDraftForSession(session);
-      resetEditor(editor);
-      resetEditorHistory(editor);
-      sendTypingStatus(false);
     },
-    [mx, clearReplyDraftForSession, editor, sendTypingStatus]
+    [mx, clearReplyDraftForSession]
   );
 
   const sendSessionUpload = useCallback(
@@ -356,6 +350,13 @@ export const useRoomInputSendSessionController = ({
           threadingEnabled: sessionThreadingEnabled,
         }),
       };
+      if (textContent) {
+        // The caption sends last (after the uploads), so free the composer as soon as the
+        // session has snapshotted the text instead of when the text event goes out.
+        resetEditor(editor);
+        resetEditorHistory(editor);
+        sendTypingStatus(false);
+      }
       await processSendSession();
     },
     [
@@ -364,6 +365,8 @@ export const useRoomInputSendSessionController = ({
       replyDraft,
       threadingEnabled,
       room,
+      editor,
+      sendTypingStatus,
       selectedFilesRef,
       sendSessionFilesRef,
       sendSessionUploadItemsRef,

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.ts
@@ -1,8 +1,12 @@
 import { MutableRefObject, useCallback, useRef } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { IContent, MatrixClient, Room } from 'matrix-js-sdk';
-import { Editor } from 'slate';
-import { resetEditor, resetEditorHistory } from '../../components/editor/utils';
+import { Descendant, Editor } from 'slate';
+import {
+  resetEditor,
+  resetEditorHistory,
+  restoreEditorContent,
+} from '../../components/editor/utils';
 import { IReplyDraft, TUploadItem } from '../../state/room/roomInputDrafts';
 import { Upload } from '../../state/upload';
 import { TUploadContent } from '../../utils/matrix';
@@ -24,6 +28,7 @@ type SendSession = RoomInputSendSessionState & {
   replyDraft: IReplyDraft | undefined;
   threadingEnabled: boolean;
   textContent?: IContent;
+  composerFallback?: Descendant[];
   replyCleared: boolean;
   signalBridgedRoom: boolean;
 };
@@ -217,6 +222,21 @@ export const useRoomInputSendSessionController = ({
     ]
   );
 
+  const restoreComposerFallback = useCallback(
+    (session: SendSession) => {
+      // A failed caption goes back into the composer instead of parking in the session: by the
+      // time the caption sends, the uploads have left the board, so the board's Send-again
+      // affordance that resumes a blocked session no longer exists.
+      session.textPending = false;
+      const fragment = session.composerFallback;
+      session.composerFallback = undefined;
+      if (fragment && (mountedRef?.current ?? true)) {
+        restoreEditorContent(editor, fragment);
+      }
+    },
+    [editor, mountedRef]
+  );
+
   const processSendSession = useCallback(async () => {
     if (processingSendSessionRef.current) return;
 
@@ -257,8 +277,7 @@ export const useRoomInputSendSessionController = ({
           try {
             await sendSessionText(session);
           } catch (error) {
-            session.blockedRoot = true;
-            return;
+            restoreComposerFallback(session);
           }
           continue;
         }
@@ -286,6 +305,7 @@ export const useRoomInputSendSessionController = ({
     mountedRef,
     sendSessionText,
     sendSessionUpload,
+    restoreComposerFallback,
   ]);
 
   const startSendSession = useCallback(
@@ -352,7 +372,10 @@ export const useRoomInputSendSessionController = ({
       };
       if (textContent) {
         // The caption sends last (after the uploads), so free the composer as soon as the
-        // session has snapshotted the text instead of when the text event goes out.
+        // session has snapshotted the text instead of when the text event goes out. Keep a
+        // clone of the composer content so a failed caption can be restored (slate mutates
+        // editor.children in place).
+        sendSessionRef.current.composerFallback = structuredClone(editor.children);
         resetEditor(editor);
         resetEditorHistory(editor);
         sendTypingStatus(false);


### PR DESCRIPTION
## What

Inverts the room-input send-session ordering: attachments send first (in selection order) and the caption text sends last, in every send mode.

- **Existing thread / classic room mode**: same events, flipped order — uploads, then text.
- **Main timeline with text + attachments**: the `auto-thread-text-root` mode is removed. These sends now use the upload-root shape that attachment-only bursts already used: the first attachment is the room-level root, and the remaining attachments plus the caption thread under it. Reply-draft metadata stays on the root upload; the caption joins the thread with a plain thread relation.
- **Composer reset** moves from text-send time to session start (the session snapshots the caption), so the composer frees up immediately instead of staying frozen behind slow uploads.
- A caption no longer waits on a failed non-root upload awaiting manual retry — it sends once every active upload is settled, mirroring the existing relaxed non-root retry ordering.
- **Failed-caption recovery**: with media-first ordering the caption usually fails only after every upload has sent and left the board, so the board's Send-again affordance (the only way to resume a blocked session) no longer exists at that point. A failed caption is therefore restored into the composer from a snapshot taken at session start (anything typed since is kept, after the restored content), and the session finishes without it — no zombie session that could flush a stale caption into a later unrelated send. Upload retries stay resumable via Send-again; the session never resends a restored caption.

## Why

MindRoom's backend (mindroom-ai/mindroom#1255) coalesces a live message batch into one agent turn with a single rule: a batch ending in **text** is a complete utterance and dispatches immediately; a batch ending in **media** waits a debounce window for more attachments or the trailing caption, which closes the batch the moment it arrives.

This fork sent the events in the opposite order (CINNY-067 sent the text first so its event id could root the auto-thread). With text-first, the backend answers the caption **before the images arrive**, and the images land as a separate follow-up turn. Media-first + trailing caption makes image(s)+caption one combined turn that dispatches the instant the caption is sent.

## UX note

In the main timeline, an image-with-caption now renders as the image rooting the auto-thread with the caption as the first thread message (previously the caption text was the root). This follows necessarily from media-first ordering plus the existing auto-threading design.

## Test note

`RoomInput.test.ts` now also mocks `components/editor/utils`: the send-session controller imports the reset/restore helpers from there, not from the mocked editor barrel. At the old HEAD the controller's real `resetEditor` crashed against the stubbed slate `Editor` and the send-step `catch` silently swallowed it; moving the reset to session start surfaced that latent gap.

Controller tests cover the caption-failure path: composer restore + session completion without stale resends, and upload-retry resume after a failed caption.

## Validation

- `npm test`: 302/302 files, 2251/2251 tests
- `npm run typecheck` passes
- `npm run build` passes
- `npx eslint` on changed files passes
- changed hunks are prettier-clean (repo prettier 2.8.1, printWidth 100)
- Runbook updated (CINNY-108)
