### PR TITLE
feat: add pending send indicator

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -28,6 +28,9 @@
     in the `Sending to this thread` context while `sendMessage` is unresolved.
     Pending thread reply local echoes emitted with `liveEvent: false` are also
     retained for the open thread timeline as supplemental events.
+  - PR review follow-up: removed the unreachable cross-room guard from the
+    local-echo refresh hook and added the all-three suffix composition test for
+    custom suffix, edited marker, and pending indicator order.
 - Design:
   - Spec: `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
   - Plan: `docs/superpowers/plans/2026-06-13-pending-send-indicator.md`.
@@ -41,6 +44,11 @@
     focused renderer tests, compact card/model tests, active-thread composer
     tests, status helper tests, a local-echo refresh hook test, a targeted
     pending thread local-echo controller test, and source architecture guards.
+  - PR review triage: skipped the suggested nullable-room guard because
+    `useRoomLocalEchoRefresh` and its only production caller require a concrete
+    `Room`; skipped the one-off i18n migration because current MindRoom/status
+    UI strings in this fork are not localized and the locale files contain only
+    a minimal legacy key.
 - Files changed:
   - `src/app/mindroom/messages/pendingLocalEcho.ts`
   - `src/app/mindroom/messages/pendingSendIndicator.tsx`
@@ -152,6 +160,18 @@
   - PR follow-up manual real-app verification: captured actual app screenshots
     for a pending compact root card and an unresolved open-thread composer send
     against the local Matrix fixture.
+  - PR review green focused check:
+    `npm test -- src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts`
+    (2 files, 7 tests).
+  - PR review green: `npm run typecheck`.
+  - PR review green: `npm test` (306 files, 2278 tests).
+  - PR review green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - PR review green: `npm run build` (existing Vite runtime-config, sourcemap,
+    and chunk-size warnings only).
+  - PR review green:
+    `npx prettier --check FORK_CHANGES.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts`
+    and `git diff --check`.
 
 ### CINNY-131 - Default splash screens to WebGL background (2026-05-31)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,26 @@
 
 ## Runbook
 
+### CINNY-132 - Pending local echo send indicator (2026-06-13)
+
+- Status:
+  - In progress.
+- Summary:
+  - Designing and implementing a subtle indicator for messages that are still
+    Matrix local echoes and have not yet been accepted/remote-echoed by the
+    server.
+  - Approved UX: a small muted inline clock at the end of the message body,
+    using Matrix local echo status rather than custom message metadata.
+- Design:
+  - Spec: `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
+- Validation:
+  - Green: independent spec review approved
+    `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`
+    with advisory notes on suffix composition and media scope folded into the
+    spec.
+  - Green:
+    `npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
+
 ### CINNY-131 - Default splash screens to WebGL background (2026-05-31)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -21,6 +21,13 @@
   - Added a room local-echo refresh hook so `RoomEvent.LocalEchoUpdated`
     triggers a cheap room/thread timeline re-render when SDK status or local ID
     replacement changes.
+  - PR follow-up: compact MindRoom overview cards now carry `hasPendingSend`
+    from loaded thread root/reply events, including pending replacement edits,
+    and render the same subtle clock beside the compact preview text.
+  - PR follow-up: open thread composer sends now render the same pending clock
+    in the `Sending to this thread` context while `sendMessage` is unresolved.
+    Pending thread reply local echoes emitted with `liveEvent: false` are also
+    retained for the open thread timeline as supplemental events.
 - Design:
   - Spec: `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
   - Plan: `docs/superpowers/plans/2026-06-13-pending-send-indicator.md`.
@@ -30,9 +37,10 @@
     an Important release blocker; it is included in the final close-out commit.
   - Residual risk: there is no full behavioral room/thread timeline test that
     renders a pending local echo, emits `RoomEvent.LocalEchoUpdated`, and
-    verifies the clock disappears across both surfaces. Coverage is split
-    across focused renderer tests, status helper tests, a local-echo refresh
-    hook test, and source architecture guards.
+    verifies the clock disappears across every surface. Coverage is split across
+    focused renderer tests, compact card/model tests, active-thread composer
+    tests, status helper tests, a local-echo refresh hook test, a targeted
+    pending thread local-echo controller test, and source architecture guards.
 - Files changed:
   - `src/app/mindroom/messages/pendingLocalEcho.ts`
   - `src/app/mindroom/messages/pendingSendIndicator.tsx`
@@ -40,7 +48,14 @@
   - `src/app/mindroom/messages/messageStateSuffix.tsx`
   - `src/app/components/RenderMessageContent.tsx`
   - `src/app/mindroom/messages/renderMindroomMessageContent.tsx`
+  - `src/app/mindroom/room-input/MindroomRoomInput.tsx`
+  - `src/app/mindroom/room-input/RoomInputMindroomExtensions.tsx`
   - `src/app/mindroom/threads/MindroomRoomTimeline.tsx`
+  - `src/app/mindroom/threads/CompactRoomView.css.ts`
+  - `src/app/mindroom/threads/CompactThreadCard.tsx`
+  - `src/app/mindroom/threads/compactThreadCardViewModel.ts`
+  - `src/app/mindroom/threads/threadRecord.ts`
+  - `src/app/mindroom/threads/types.ts`
   - `src/app/mindroom/threads/roomLocalEchoRefresh.ts`
   - `src/app/mindroom/threads/roomLiveEventController.ts`
   - Focused tests under the same message/thread areas.
@@ -86,6 +101,57 @@
   - Green:
     `npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md src/app/mindroom/messages/pendingLocalEcho.ts src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/messageStateSuffix.tsx src/app/mindroom/messages/pendingSendIndicator.test.ts src/app/mindroom/messages/messageStateSuffix.test.ts src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/MindroomRoomTimeline.tsx src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/roomLiveEventController.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
   - Green: `git diff --check`.
+  - PR follow-up red compact check:
+    `npm test -- src/app/mindroom/threads/CompactThreadCard.test.tsx src/app/mindroom/threads/compactThreadCardViewModel.test.ts`
+    failed while compact cards omitted the pending indicator and compact view
+    models did not expose `hasPendingSend`.
+  - PR follow-up green compact check:
+    `npm test -- src/app/mindroom/threads/CompactThreadCard.test.tsx src/app/mindroom/threads/compactThreadCardViewModel.test.ts`
+    (2 files, 7 tests).
+  - PR follow-up red active-thread composer check:
+    `npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts -t "pending send indicator for unresolved thread composer sends"`
+    failed while unresolved thread sends did not expose a pending indicator in
+    the composer context.
+  - PR follow-up green active-thread composer check:
+    `npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts -t "pending send indicator for unresolved thread composer sends"`
+    (1 file, 1 test).
+  - PR follow-up red active-thread controller check:
+    `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts -t "adds pending local-echo replies"`
+    failed while pending thread reply local echoes emitted with
+    `liveEvent: false` were dropped before the open thread timeline could retain
+    them.
+  - PR follow-up green active-thread controller check:
+    `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts -t "adds pending local-echo replies"`
+    (1 file, 1 test).
+  - PR follow-up focused regression check:
+    `npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts src/app/mindroom/threads/CompactThreadCard.test.tsx src/app/mindroom/threads/compactThreadCardViewModel.test.ts src/app/mindroom/messages/pendingSendIndicator.test.ts src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (10 files, 260 tests).
+  - PR follow-up red full-suite check: `npm test` failed because
+    `RoomInputMindroomExtensions.test.ts` directly imports the extension module,
+    and the new `PendingSendIndicator` import pulled vanilla-extract CSS into a
+    non-CSS test file scope.
+  - Fix after red check: added the missing
+    `../messages/PendingSendIndicator.css` mock in
+    `RoomInputMindroomExtensions.test.ts`, matching the existing CSS-module
+    test pattern.
+  - PR follow-up green direct extension check:
+    `npm test -- src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts`
+    (1 file, 6 tests).
+  - PR follow-up green: `npm run typecheck`.
+  - PR follow-up green: `npm test` (306 files, 2278 tests).
+  - PR follow-up green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - PR follow-up green: `npm run build` (existing Vite runtime-config,
+    sourcemap, and chunk-size warnings only).
+  - PR follow-up green:
+    `npx prettier --check FORK_CHANGES.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md src/app/mindroom/threads/CompactRoomView.css.ts src/app/mindroom/threads/CompactThreadCard.tsx src/app/mindroom/threads/CompactThreadCard.test.tsx src/app/mindroom/threads/compactThreadCardViewModel.test.ts src/app/mindroom/threads/compactThreadCardViewModel.ts src/app/mindroom/threads/roomLiveEventController.ts src/app/mindroom/threads/threadRecord.ts src/app/mindroom/threads/types.ts`.
+  - PR follow-up note: skipped Prettier on legacy-format room-input test/source
+    files to avoid unrelated formatter churn; lint, typecheck, and tests still
+    cover them.
+  - PR follow-up green: `git diff --check`.
+  - PR follow-up manual real-app verification: captured actual app screenshots
+    for a pending compact root card and an unresolved open-thread composer send
+    against the local Matrix fixture.
 
 ### CINNY-131 - Default splash screens to WebGL background (2026-05-31)
 
@@ -329,6 +395,7 @@
     failed with the iOS focus-transfer and pending-RAF cleanup regression tests.
   - Review green check: `npm test -- src/app/hooks/useMobileKeyboardViewportFix.test.ts`
     (3 tests).
+
 ### CINNY-118 - Voice message compression and speech capture constraints (2026-05-18)
 
 - Status:
@@ -368,6 +435,7 @@
   - Independent review before recovery: second self-review checked the final
     diff for stale fallback paths, literal contract coverage, runbook status,
     and half-refactor traces.
+
 ### Safe SVG in message extras HTML (2026-05-11)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -14,13 +14,20 @@
     using Matrix local echo status rather than custom message metadata.
 - Design:
   - Spec: `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
+  - Plan: `docs/superpowers/plans/2026-06-13-pending-send-indicator.md`.
 - Validation:
   - Green: independent spec review approved
     `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`
     with advisory notes on suffix composition and media scope folded into the
     spec.
+  - Green: independent plan review approved
+    `docs/superpowers/plans/2026-06-13-pending-send-indicator.md` after the
+    plan was updated to derive pending state from both base events and pending
+    edit replacement events.
   - Green:
     `npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
+  - Green:
+    `npx prettier --check docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md`.
 
 ### CINNY-131 - Default splash screens to WebGL background (2026-05-31)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -5,16 +5,45 @@
 ### CINNY-132 - Pending local echo send indicator (2026-06-13)
 
 - Status:
-  - In progress.
+  - Complete locally.
 - Summary:
-  - Designing and implementing a subtle indicator for messages that are still
+  - Added a subtle muted inline clock indicator for messages that are still
     Matrix local echoes and have not yet been accepted/remote-echoed by the
     server.
-  - Approved UX: a small muted inline clock at the end of the message body,
-    using Matrix local echo status rather than custom message metadata.
+  - Pending state is derived from SDK local-echo status:
+    `ENCRYPTING`, `SENDING`, `QUEUED`, and `SENT` render the indicator;
+    `NOT_SENT`, `CANCELLED`, and absent status do not.
+  - Message suffix rendering now composes streaming, edited, and pending-send
+    markers without duplicating the existing edited marker behavior.
+  - Pending state is derived from both the base event and a pending replacement
+    edit event so edited local echoes show the indicator until the server
+    accepts the edit.
+  - Added a room local-echo refresh hook so `RoomEvent.LocalEchoUpdated`
+    triggers a cheap room/thread timeline re-render when SDK status or local ID
+    replacement changes.
 - Design:
   - Spec: `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
   - Plan: `docs/superpowers/plans/2026-06-13-pending-send-indicator.md`.
+- Review:
+  - Independent review found no Critical issues and no implementation logic
+    issues. The reviewer flagged the untracked `pendingLocalEcho.ts` helper as
+    an Important release blocker; it is included in the final close-out commit.
+  - Residual risk: there is no full behavioral room/thread timeline test that
+    renders a pending local echo, emits `RoomEvent.LocalEchoUpdated`, and
+    verifies the clock disappears across both surfaces. Coverage is split
+    across focused renderer tests, status helper tests, a local-echo refresh
+    hook test, and source architecture guards.
+- Files changed:
+  - `src/app/mindroom/messages/pendingLocalEcho.ts`
+  - `src/app/mindroom/messages/pendingSendIndicator.tsx`
+  - `src/app/mindroom/messages/PendingSendIndicator.css.ts`
+  - `src/app/mindroom/messages/messageStateSuffix.tsx`
+  - `src/app/components/RenderMessageContent.tsx`
+  - `src/app/mindroom/messages/renderMindroomMessageContent.tsx`
+  - `src/app/mindroom/threads/MindroomRoomTimeline.tsx`
+  - `src/app/mindroom/threads/roomLocalEchoRefresh.ts`
+  - `src/app/mindroom/threads/roomLiveEventController.ts`
+  - Focused tests under the same message/thread areas.
 - Validation:
   - Green: independent spec review approved
     `docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`
@@ -28,6 +57,35 @@
     `npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md`.
   - Green:
     `npx prettier --check docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md`.
+  - Green focused check:
+    `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.ts`.
+  - Green focused check:
+    `npm test -- src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts`.
+  - Green architecture check:
+    `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Green local-echo refresh check:
+    `npm test -- src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Red full-suite check: `npm test` initially failed in room timeline suites
+    because `MindroomRoomTimeline.tsx` imported the pure pending-status helper
+    from the React indicator module, which also imported vanilla-extract CSS.
+  - Fix after red check: split pending-status logic into
+    `src/app/mindroom/messages/pendingLocalEcho.ts` so timeline code depends on
+    a CSS-free helper module.
+  - Green regression check:
+    `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.navigation.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.permalink-refresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.filter-query.test.ts src/app/mindroom/threads/__tests__/RoomTimelineCollapsible.test.ts`
+    (5 files, 143 tests).
+  - Green focused check:
+    `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.ts src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (6 files, 137 tests).
+  - Green: `npm test` (304 files, 2259 tests).
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Green: `npm run build` (existing Vite runtime-config, sourcemap, and
+    chunk-size warnings only).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md src/app/mindroom/messages/pendingLocalEcho.ts src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/messageStateSuffix.tsx src/app/mindroom/messages/pendingSendIndicator.test.ts src/app/mindroom/messages/messageStateSuffix.test.ts src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/MindroomRoomTimeline.tsx src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/roomLiveEventController.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`.
+  - Green: `git diff --check`.
 
 ### CINNY-131 - Default splash screens to WebGL background (2026-05-31)
 

--- a/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
+++ b/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
@@ -1,0 +1,271 @@
+# Pending Send Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a subtle inline clock indicator while a Matrix message is still a pending local echo.
+
+**Architecture:** Add a fork-owned pending-send helper/component under `src/app/mindroom/messages/`, compose it with the existing message state suffix path, and pass a `pendingSend` boolean from `MindroomRoomTimeline` using Matrix local echo status. Add a focused room local-echo refresh hook so `RoomEvent.LocalEchoUpdated` forces the timeline surfaces to re-render when the SDK mutates local echo status or replaces local IDs.
+
+**Tech Stack:** React, TypeScript, Folds icons, matrix-js-sdk `EventStatus`, Vitest/react-test-renderer, vanilla-extract.
+
+---
+
+### Task 1: Pending Send Helper And Indicator
+
+**Files:**
+
+- Create: `src/app/mindroom/messages/pendingSendIndicator.tsx`
+- Create: `src/app/mindroom/messages/PendingSendIndicator.css.ts`
+- Test: `src/app/mindroom/messages/pendingSendIndicator.test.tsx`
+
+- [ ] **Step 1: Write the failing helper/component tests**
+
+```tsx
+it.each([EventStatus.ENCRYPTING, EventStatus.SENDING, EventStatus.QUEUED, EventStatus.SENT])(
+  'treats %s as pending',
+  (status) => {
+    expect(isPendingLocalEchoStatus(status)).toBe(true);
+  }
+);
+
+it.each([undefined, null, EventStatus.NOT_SENT, EventStatus.CANCELLED])(
+  'does not treat %s as pending',
+  (status) => {
+    expect(isPendingLocalEchoStatus(status)).toBe(false);
+  }
+);
+
+it('renders an accessible muted clock indicator', () => {
+  const renderer = create(<PendingSendIndicator />);
+  expect(JSON.stringify(renderer.toJSON())).toContain('Message sending');
+  expect(JSON.stringify(renderer.toJSON())).toContain('Waiting for server');
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.tsx`
+
+Expected: FAIL because the helper/component files do not exist yet.
+
+- [ ] **Step 3: Implement the helper and indicator**
+
+Implement:
+
+- `isPendingLocalEchoStatus(status: unknown): boolean`
+- `isPendingLocalEchoEvent(event?: Pick<MatrixEvent, 'status'> | null): boolean`
+- `PendingSendIndicator`
+- `renderPendingSendIndicator`
+
+Use Folds `Icons.Clock`, a low-priority `Text` wrapper, `role="status"`,
+`aria-label="Message sending"`, and `title="Waiting for server"`.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/pendingSendIndicator.test.tsx
+git commit -m "feat: add pending send indicator"
+```
+
+### Task 2: Compose Message State Suffixes
+
+**Files:**
+
+- Create: `src/app/mindroom/messages/messageStateSuffix.tsx`
+- Test: `src/app/mindroom/messages/messageStateSuffix.test.tsx`
+- Modify: `src/app/components/RenderMessageContent.tsx`
+- Modify: `src/app/mindroom/messages/renderMindroomMessageContent.tsx`
+- Test: `src/app/mindroom/messages/renderMindroomMessageContent.test.ts`
+
+- [ ] **Step 1: Write failing suffix composition tests**
+
+Cover:
+
+- no custom suffix and no pending returns `undefined`, preserving existing edited behavior,
+- pending returns a suffix renderer,
+- custom streaming suffix plus pending renders both,
+- edited plus pending renders both edited and pending.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+`npm test -- src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts`
+
+Expected: FAIL because the suffix helper does not exist and pending state is not passed.
+
+- [ ] **Step 3: Implement suffix composition**
+
+Create `getMindroomMessageStateSuffixRenderer({ edited, pendingSend, renderStateSuffix })`.
+
+Rules:
+
+- return `undefined` when only `edited` is true, so current generic edited rendering remains unchanged,
+- when a custom suffix or pending indicator exists, return a function that renders the custom suffix, then edited marker if needed, then pending indicator if needed,
+- do not duplicate edited marker.
+
+- [ ] **Step 4: Add `pendingSend?: boolean` to `RenderMessageContent`**
+
+Pass `pendingSend` through to `renderMindroomMessageContent`.
+
+For local caption rendering in `RenderMessageContent`, pass a composed
+`renderStateSuffix` to `MText` when `pendingSend` is true.
+
+- [ ] **Step 5: Add `pendingSend?: boolean` to `renderMindroomMessageContent`**
+
+Use the composed suffix helper for text, notice, emote, and MindRoom long-text
+rendering. Keep media-only and sticker rendering out of scope.
+
+- [ ] **Step 6: Run focused tests and verify they pass**
+
+Run:
+`npm test -- src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/mindroom/messages/messageStateSuffix.tsx src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts
+git commit -m "feat: compose pending message suffix"
+```
+
+### Task 3: Wire Pending State From Timeline Events
+
+**Files:**
+
+- Modify: `src/app/mindroom/threads/MindroomRoomTimeline.tsx`
+- Test: `src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+
+- [ ] **Step 1: Write a failing rendering test**
+
+Add a focused source-architecture guard that requires `MindroomRoomTimeline.tsx`
+to import `isPendingLocalEchoEvent`, derive pending state from both `mEvent` and
+`editedEvent`, and pass that derived value to message content renderers.
+Behavioral coverage for pending vs accepted/failed states lives in the focused
+message renderer tests from Tasks 1 and 2.
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+`npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+
+Expected: FAIL because `MindroomRoomTimeline.tsx` is not passing
+`pendingSend`.
+
+- [ ] **Step 3: Wire the pending state**
+
+Import `isPendingLocalEchoEvent` in `MindroomRoomTimeline.tsx` and derive:
+
+```tsx
+const pendingSend = isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent);
+```
+
+Pass `pendingSend={pendingSend}` to `RenderMessageContent` call sites that render standard room messages,
+encrypted room-message content after decryption, and MindRoom approval/text
+content where the suffix path is used.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+`npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/mindroom/threads/MindroomRoomTimeline.tsx src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+git commit -m "feat: show pending indicator for local echoes"
+```
+
+### Task 4: Refresh On Local Echo Status Updates
+
+**Files:**
+
+- Create: `src/app/mindroom/threads/roomLocalEchoRefresh.ts`
+- Test: `src/app/mindroom/threads/roomLocalEchoRefresh.test.ts`
+- Modify: `src/app/mindroom/threads/roomLiveEventController.ts`
+
+- [ ] **Step 1: Write failing hook tests**
+
+Test that `useRoomLocalEchoRefresh(room, callback)` subscribes to
+`RoomEvent.LocalEchoUpdated`, calls the callback for the same room, ignores
+other rooms, and removes the listener on unmount.
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `npm test -- src/app/mindroom/threads/roomLocalEchoRefresh.test.ts`
+
+Expected: FAIL because the hook does not exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Use `useEffect`, `RoomEvent.LocalEchoUpdated`, and
+`RoomEventHandlerMap[RoomEvent.LocalEchoUpdated]`.
+
+- [ ] **Step 4: Use the hook in `useRoomLiveEventController`**
+
+Call the hook with a memoized callback that does:
+
+```ts
+setTimeline((current) => ({ ...current }));
+```
+
+This is intentionally broad and cheap; local echo updates are low volume and
+status/id replacement must refresh both room and thread surfaces.
+
+- [ ] **Step 5: Run focused tests and verify they pass**
+
+Run:
+`npm test -- src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/roomLiveEventController.ts
+git commit -m "fix: refresh room timeline on local echo updates"
+```
+
+### Task 5: Final Validation And Runbook
+
+**Files:**
+
+- Modify: `FORK_CHANGES.md`
+
+- [ ] **Step 1: Update runbook status and files/validation notes**
+
+Record changed files, design decisions, focused test results, and final
+validation commands under `CINNY-132`.
+
+- [ ] **Step 2: Run focused validation**
+
+Run:
+
+```bash
+npm test -- src/app/mindroom/messages/pendingSendIndicator.test.tsx src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+npm run typecheck
+npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/messageStateSuffix.tsx src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLiveEventController.ts
+git diff --check
+```
+
+- [ ] **Step 3: Run broader validation**
+
+Run `npm test`, `npm run lint`, and `npm run build`. Treat `npm test` as
+required by `AGENTS.md` unless the environment prevents completion; if blocked,
+record the concrete reason in `FORK_CHANGES.md`. Record any existing
+warning-only baselines.
+
+- [ ] **Step 4: Commit runbook and plan**
+
+```bash
+git add FORK_CHANGES.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md
+git commit -m "docs: record pending send indicator validation"
+```

--- a/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
+++ b/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
@@ -236,6 +236,109 @@ git add src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/thread
 git commit -m "fix: refresh room timeline on local echo updates"
 ```
 
+### PR Follow-Up: Compact Overview Cards
+
+**Files:**
+
+- Modify: `src/app/mindroom/threads/threadRecord.ts`
+- Modify: `src/app/mindroom/threads/compactThreadCardViewModel.ts`
+- Modify: `src/app/mindroom/threads/types.ts`
+- Modify: `src/app/mindroom/threads/CompactThreadCard.tsx`
+- Modify: `src/app/mindroom/threads/CompactRoomView.css.ts`
+- Test: `src/app/mindroom/threads/compactThreadCardViewModel.test.ts`
+- Test: `src/app/mindroom/threads/CompactThreadCard.test.tsx`
+
+- [x] **Step 1: Write failing compact view tests**
+
+Cover:
+
+- zero-reply thread root local echoes set `hasPendingSend`,
+- pending visible reply local echoes set `hasPendingSend`,
+- compact cards render the pending indicator beside preview text.
+
+- [x] **Step 2: Run the compact tests and verify they fail**
+
+Run:
+`npm test -- src/app/mindroom/threads/CompactThreadCard.test.tsx src/app/mindroom/threads/compactThreadCardViewModel.test.ts`
+
+Expected: FAIL because compact models do not expose pending send state and the
+card does not render the indicator.
+
+- [x] **Step 3: Implement compact pending state**
+
+In `threadRecord.ts`, derive `hasPendingSend` from the resolved thread root and
+loaded visible replies, checking both each event and its pending replacement
+event with `isPendingLocalEchoEvent`.
+
+In `compactThreadCardViewModel.ts`, map the thread-record status flag into the
+compact card view model.
+
+- [x] **Step 4: Render the indicator in compact cards**
+
+Import `PendingSendIndicator` into `CompactThreadCard.tsx`, include
+`Message sending` in the card aria label when pending, and render the clock next
+to preview text inside a stable flex wrapper.
+
+- [x] **Step 5: Run the compact tests and verify they pass**
+
+Run:
+`npm test -- src/app/mindroom/threads/CompactThreadCard.test.tsx src/app/mindroom/threads/compactThreadCardViewModel.test.ts`
+
+Expected: PASS.
+
+### PR Follow-Up: Open Thread Sends
+
+**Files:**
+
+- Modify: `src/app/mindroom/room-input/MindroomRoomInput.tsx`
+- Modify: `src/app/mindroom/room-input/RoomInputMindroomExtensions.tsx`
+- Modify: `src/app/mindroom/threads/roomLiveEventController.ts`
+- Test: `src/app/mindroom/room-input/__tests__/RoomInput.test.ts`
+- Test: `src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts`
+
+- [x] **Step 1: Write failing active-thread send tests**
+
+Cover:
+
+- the thread composer shows `Message sending` while an unresolved
+  `sendMessage` promise is in flight,
+- a pending thread reply local echo emitted with `liveEvent: false` is retained
+  as a supplemental event for the open thread timeline.
+
+- [x] **Step 2: Run the active-thread tests and verify they fail**
+
+Run:
+`npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts -t "pending send indicator for unresolved thread composer sends"`
+
+Run:
+`npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts -t "adds pending local-echo replies"`
+
+Expected: FAIL while the composer context has no pending send state and the
+live-event controller drops pending thread local echoes with `liveEvent: false`.
+
+- [x] **Step 3: Implement active-thread pending state**
+
+Track a narrow `submitPending` state around unresolved text-message
+`mx.sendMessage` calls in `MindroomRoomInput.tsx`. Pass it to
+`MindroomRoomInputReplyContext` only when composing inside an open thread.
+
+In `RoomInputMindroomExtensions.tsx`, render `PendingSendIndicator` beside the
+`Sending to this thread` context when `pendingSend` is true.
+
+In `roomLiveEventController.ts`, keep pending thread reply local echoes emitted
+with `liveEvent: false` as supplemental thread events instead of dropping them
+before the open thread can render them.
+
+- [x] **Step 4: Run the active-thread tests and verify they pass**
+
+Run:
+`npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts -t "pending send indicator for unresolved thread composer sends"`
+
+Run:
+`npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts -t "adds pending local-echo replies"`
+
+Expected: PASS.
+
 ### Task 5: Final Validation And Runbook
 
 **Files:**

--- a/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
+++ b/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
@@ -92,6 +92,7 @@ Cover:
 - pending returns a suffix renderer,
 - custom streaming suffix plus pending renders both,
 - edited plus pending renders both edited and pending.
+- custom suffix plus edited plus pending renders all three in order.
 
 - [x] **Step 2: Run the focused tests and verify they fail**
 

--- a/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
+++ b/docs/superpowers/plans/2026-06-13-pending-send-indicator.md
@@ -4,7 +4,7 @@
 
 **Goal:** Show a subtle inline clock indicator while a Matrix message is still a pending local echo.
 
-**Architecture:** Add a fork-owned pending-send helper/component under `src/app/mindroom/messages/`, compose it with the existing message state suffix path, and pass a `pendingSend` boolean from `MindroomRoomTimeline` using Matrix local echo status. Add a focused room local-echo refresh hook so `RoomEvent.LocalEchoUpdated` forces the timeline surfaces to re-render when the SDK mutates local echo status or replaces local IDs.
+**Architecture:** Add a fork-owned pending-send helper/component under `src/app/mindroom/messages/`, compose it with the existing message state suffix path, and pass a `pendingSend` boolean from `MindroomRoomTimeline` using Matrix local echo status. Keep the status helper in a CSS-free module so timeline code does not import the React indicator styles. Add a focused room local-echo refresh hook so `RoomEvent.LocalEchoUpdated` forces the timeline surfaces to re-render when the SDK mutates local echo status or replaces local IDs.
 
 **Tech Stack:** React, TypeScript, Folds icons, matrix-js-sdk `EventStatus`, Vitest/react-test-renderer, vanilla-extract.
 
@@ -15,10 +15,11 @@
 **Files:**
 
 - Create: `src/app/mindroom/messages/pendingSendIndicator.tsx`
+- Create: `src/app/mindroom/messages/pendingLocalEcho.ts`
 - Create: `src/app/mindroom/messages/PendingSendIndicator.css.ts`
-- Test: `src/app/mindroom/messages/pendingSendIndicator.test.tsx`
+- Test: `src/app/mindroom/messages/pendingSendIndicator.test.ts`
 
-- [ ] **Step 1: Write the failing helper/component tests**
+- [x] **Step 1: Write the failing helper/component tests**
 
 ```tsx
 it.each([EventStatus.ENCRYPTING, EventStatus.SENDING, EventStatus.QUEUED, EventStatus.SENT])(
@@ -42,13 +43,13 @@ it('renders an accessible muted clock indicator', () => {
 });
 ```
 
-- [ ] **Step 2: Run the focused test and verify it fails**
+- [x] **Step 2: Run the focused test and verify it fails**
 
-Run: `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.tsx`
+Run: `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.ts`
 
 Expected: FAIL because the helper/component files do not exist yet.
 
-- [ ] **Step 3: Implement the helper and indicator**
+- [x] **Step 3: Implement the helper and indicator**
 
 Implement:
 
@@ -60,16 +61,16 @@ Implement:
 Use Folds `Icons.Clock`, a low-priority `Text` wrapper, `role="status"`,
 `aria-label="Message sending"`, and `title="Waiting for server"`.
 
-- [ ] **Step 4: Run the focused test and verify it passes**
+- [x] **Step 4: Run the focused test and verify it passes**
 
-Run: `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.tsx`
+Run: `npm test -- src/app/mindroom/messages/pendingSendIndicator.test.ts`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
-git add src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/pendingSendIndicator.test.tsx
+git add src/app/mindroom/messages/pendingLocalEcho.ts src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/pendingSendIndicator.test.ts
 git commit -m "feat: add pending send indicator"
 ```
 
@@ -78,12 +79,12 @@ git commit -m "feat: add pending send indicator"
 **Files:**
 
 - Create: `src/app/mindroom/messages/messageStateSuffix.tsx`
-- Test: `src/app/mindroom/messages/messageStateSuffix.test.tsx`
+- Test: `src/app/mindroom/messages/messageStateSuffix.test.ts`
 - Modify: `src/app/components/RenderMessageContent.tsx`
 - Modify: `src/app/mindroom/messages/renderMindroomMessageContent.tsx`
 - Test: `src/app/mindroom/messages/renderMindroomMessageContent.test.ts`
 
-- [ ] **Step 1: Write failing suffix composition tests**
+- [x] **Step 1: Write failing suffix composition tests**
 
 Cover:
 
@@ -92,14 +93,14 @@ Cover:
 - custom streaming suffix plus pending renders both,
 - edited plus pending renders both edited and pending.
 
-- [ ] **Step 2: Run the focused tests and verify they fail**
+- [x] **Step 2: Run the focused tests and verify they fail**
 
 Run:
-`npm test -- src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts`
+`npm test -- src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts`
 
 Expected: FAIL because the suffix helper does not exist and pending state is not passed.
 
-- [ ] **Step 3: Implement suffix composition**
+- [x] **Step 3: Implement suffix composition**
 
 Create `getMindroomMessageStateSuffixRenderer({ edited, pendingSend, renderStateSuffix })`.
 
@@ -109,29 +110,29 @@ Rules:
 - when a custom suffix or pending indicator exists, return a function that renders the custom suffix, then edited marker if needed, then pending indicator if needed,
 - do not duplicate edited marker.
 
-- [ ] **Step 4: Add `pendingSend?: boolean` to `RenderMessageContent`**
+- [x] **Step 4: Add `pendingSend?: boolean` to `RenderMessageContent`**
 
 Pass `pendingSend` through to `renderMindroomMessageContent`.
 
 For local caption rendering in `RenderMessageContent`, pass a composed
 `renderStateSuffix` to `MText` when `pendingSend` is true.
 
-- [ ] **Step 5: Add `pendingSend?: boolean` to `renderMindroomMessageContent`**
+- [x] **Step 5: Add `pendingSend?: boolean` to `renderMindroomMessageContent`**
 
 Use the composed suffix helper for text, notice, emote, and MindRoom long-text
 rendering. Keep media-only and sticker rendering out of scope.
 
-- [ ] **Step 6: Run focused tests and verify they pass**
+- [x] **Step 6: Run focused tests and verify they pass**
 
 Run:
-`npm test -- src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts`
+`npm test -- src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
-git add src/app/mindroom/messages/messageStateSuffix.tsx src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts
+git add src/app/mindroom/messages/messageStateSuffix.tsx src/app/mindroom/messages/messageStateSuffix.test.ts src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts
 git commit -m "feat: compose pending message suffix"
 ```
 
@@ -142,7 +143,7 @@ git commit -m "feat: compose pending message suffix"
 - Modify: `src/app/mindroom/threads/MindroomRoomTimeline.tsx`
 - Test: `src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
 
-- [ ] **Step 1: Write a failing rendering test**
+- [x] **Step 1: Write a failing rendering test**
 
 Add a focused source-architecture guard that requires `MindroomRoomTimeline.tsx`
 to import `isPendingLocalEchoEvent`, derive pending state from both `mEvent` and
@@ -150,7 +151,7 @@ to import `isPendingLocalEchoEvent`, derive pending state from both `mEvent` and
 Behavioral coverage for pending vs accepted/failed states lives in the focused
 message renderer tests from Tasks 1 and 2.
 
-- [ ] **Step 2: Run the focused test and verify it fails**
+- [x] **Step 2: Run the focused test and verify it fails**
 
 Run:
 `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
@@ -158,9 +159,10 @@ Run:
 Expected: FAIL because `MindroomRoomTimeline.tsx` is not passing
 `pendingSend`.
 
-- [ ] **Step 3: Wire the pending state**
+- [x] **Step 3: Wire the pending state**
 
-Import `isPendingLocalEchoEvent` in `MindroomRoomTimeline.tsx` and derive:
+Import `isPendingLocalEchoEvent` from the CSS-free pending local echo helper in
+`MindroomRoomTimeline.tsx` and derive:
 
 ```tsx
 const pendingSend = isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent);
@@ -170,14 +172,14 @@ Pass `pendingSend={pendingSend}` to `RenderMessageContent` call sites that rende
 encrypted room-message content after decryption, and MindRoom approval/text
 content where the suffix path is used.
 
-- [ ] **Step 4: Run the focused test and verify it passes**
+- [x] **Step 4: Run the focused test and verify it passes**
 
 Run:
 `npm test -- src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/app/mindroom/threads/MindroomRoomTimeline.tsx src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -192,24 +194,24 @@ git commit -m "feat: show pending indicator for local echoes"
 - Test: `src/app/mindroom/threads/roomLocalEchoRefresh.test.ts`
 - Modify: `src/app/mindroom/threads/roomLiveEventController.ts`
 
-- [ ] **Step 1: Write failing hook tests**
+- [x] **Step 1: Write failing hook tests**
 
 Test that `useRoomLocalEchoRefresh(room, callback)` subscribes to
 `RoomEvent.LocalEchoUpdated`, calls the callback for the same room, ignores
 other rooms, and removes the listener on unmount.
 
-- [ ] **Step 2: Run the focused test and verify it fails**
+- [x] **Step 2: Run the focused test and verify it fails**
 
 Run: `npm test -- src/app/mindroom/threads/roomLocalEchoRefresh.test.ts`
 
 Expected: FAIL because the hook does not exist.
 
-- [ ] **Step 3: Implement the hook**
+- [x] **Step 3: Implement the hook**
 
 Use `useEffect`, `RoomEvent.LocalEchoUpdated`, and
 `RoomEventHandlerMap[RoomEvent.LocalEchoUpdated]`.
 
-- [ ] **Step 4: Use the hook in `useRoomLiveEventController`**
+- [x] **Step 4: Use the hook in `useRoomLiveEventController`**
 
 Call the hook with a memoized callback that does:
 
@@ -220,14 +222,14 @@ setTimeline((current) => ({ ...current }));
 This is intentionally broad and cheap; local echo updates are low volume and
 status/id replacement must refresh both room and thread surfaces.
 
-- [ ] **Step 5: Run focused tests and verify they pass**
+- [x] **Step 5: Run focused tests and verify they pass**
 
 Run:
 `npm test -- src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/roomLiveEventController.ts
@@ -240,30 +242,30 @@ git commit -m "fix: refresh room timeline on local echo updates"
 
 - Modify: `FORK_CHANGES.md`
 
-- [ ] **Step 1: Update runbook status and files/validation notes**
+- [x] **Step 1: Update runbook status and files/validation notes**
 
 Record changed files, design decisions, focused test results, and final
 validation commands under `CINNY-132`.
 
-- [ ] **Step 2: Run focused validation**
+- [x] **Step 2: Run focused validation**
 
 Run:
 
 ```bash
-npm test -- src/app/mindroom/messages/pendingSendIndicator.test.tsx src/app/mindroom/messages/messageStateSuffix.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+npm test -- src/app/mindroom/messages/pendingSendIndicator.test.ts src/app/mindroom/messages/messageStateSuffix.test.ts src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts src/app/mindroom/threads/roomLocalEchoRefresh.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
 npm run typecheck
-npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/messageStateSuffix.tsx src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLiveEventController.ts
+npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md src/app/mindroom/messages/pendingLocalEcho.ts src/app/mindroom/messages/pendingSendIndicator.tsx src/app/mindroom/messages/PendingSendIndicator.css.ts src/app/mindroom/messages/messageStateSuffix.tsx src/app/components/RenderMessageContent.tsx src/app/mindroom/messages/renderMindroomMessageContent.tsx src/app/mindroom/threads/roomLocalEchoRefresh.ts src/app/mindroom/threads/roomLiveEventController.ts
 git diff --check
 ```
 
-- [ ] **Step 3: Run broader validation**
+- [x] **Step 3: Run broader validation**
 
 Run `npm test`, `npm run lint`, and `npm run build`. Treat `npm test` as
 required by `AGENTS.md` unless the environment prevents completion; if blocked,
 record the concrete reason in `FORK_CHANGES.md`. Record any existing
 warning-only baselines.
 
-- [ ] **Step 4: Commit runbook and plan**
+- [x] **Step 4: Commit runbook and plan**
 
 ```bash
 git add FORK_CHANGES.md docs/superpowers/plans/2026-06-13-pending-send-indicator.md

--- a/docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md
@@ -51,6 +51,21 @@ edited markers and MindRoom streaming indicators. This keeps the mark aligned
 with text, emote, notice, long-text, and standard MindRoom message rendering
 without changing the surrounding message layout.
 
+Compact MindRoom overview cards do not render through the message body suffix
+path. For those cards, derive a compact `hasPendingSend` flag from the loaded
+thread root and visible reply events, including pending replacement edits, and
+render the same quiet clock beside the compact preview text. This keeps the
+overview signal aligned with the opened thread timeline without widening the
+card metadata area.
+
+When a user sends a new reply from an already-open thread, the observed SDK/UI
+path keeps the unresolved text in the thread composer until `sendMessage`
+resolves. Show the same quiet clock in the composer thread context while the
+thread reply send is in flight. If the SDK also emits a pending
+`Room.timeline` event for that thread with `liveEvent: false`, preserve it as a
+supplemental thread event so timeline surfaces can render the row-level
+indicator.
+
 Suffixes should compose rather than replace each other. If a message is both
 edited and pending, render both the pending indicator and the edited marker. If
 MindRoom AI streaming and local-echo pending are both present, keep the streaming
@@ -74,7 +89,13 @@ Add focused unit coverage for:
 - helper returns pending for encrypting/sending/queued/sent states,
 - helper returns false for no status/not_sent/cancelled,
 - message rendering includes the pending indicator for a pending local echo,
-- message rendering omits it for accepted or failed/cancelled states.
+- message rendering omits it for accepted or failed/cancelled states,
+- compact card view models mark pending root and reply local echoes,
+- compact cards render the pending indicator beside preview text.
+- thread composer sends show the pending indicator while the unresolved
+  `sendMessage` promise is in flight,
+- pending thread local echoes emitted with `liveEvent: false` are retained for
+  the open thread timeline.
 
 Prefer focused message-rendering or helper tests over expanding broad room
 timeline tests unless local echo refresh behavior requires a targeted timeline

--- a/docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md
@@ -35,6 +35,11 @@ Do not show the pending indicator for `EventStatus.NOT_SENT` or
 sent to the server but not yet remotely echoed. Once the remote echo is handled,
 the SDK clears/replaces the local echo and the indicator should disappear.
 
+When rendering edited message content, derive pending state from both the
+original event and the resolved replacement event. This covers pending
+`m.replace` local echoes so an edited message can show both the edited marker
+and the pending clock while the edit is still waiting for server acceptance.
+
 ## Architecture
 
 Add a fork-owned MindRoom pending-send helper/component near the existing

--- a/docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-13-pending-send-indicator-design.md
@@ -1,0 +1,82 @@
+# Pending Send Indicator Design
+
+## Goal
+
+Show a subtle, clear indicator when a message is a Matrix local echo that has
+not yet been fully accepted and echoed by the server.
+
+## User Experience
+
+Messages in pending send states show a small muted clock indicator inline at
+the end of the rendered message body. The indicator uses accessible text
+(`Message sending`) and a tooltip/title such as `Waiting for server`.
+
+The indicator is intentionally quiet:
+
+- no bubble-wide dimming,
+- no extra row below the message,
+- no animation that could be confused with MindRoom AI streaming,
+- no indicator after the message reaches a terminal failure state.
+
+## Pending State Definition
+
+Use Matrix local echo status rather than custom message metadata. A message is
+pending when its `MatrixEvent.status` is one of:
+
+- `EventStatus.ENCRYPTING`
+- `EventStatus.SENDING`
+- `EventStatus.QUEUED`
+- `EventStatus.SENT`
+
+Do not show the pending indicator for `EventStatus.NOT_SENT` or
+`EventStatus.CANCELLED`.
+
+`EventStatus.SENT` remains pending for this UI because the SDK documents it as
+sent to the server but not yet remotely echoed. Once the remote echo is handled,
+the SDK clears/replaces the local echo and the indicator should disappear.
+
+## Architecture
+
+Add a fork-owned MindRoom pending-send helper/component near the existing
+message rendering code. The component should render a small Folds `Clock` icon
+with low-priority/muted styling.
+
+Route the component through the existing message state-suffix path used by
+edited markers and MindRoom streaming indicators. This keeps the mark aligned
+with text, emote, notice, long-text, and standard MindRoom message rendering
+without changing the surrounding message layout.
+
+Suffixes should compose rather than replace each other. If a message is both
+edited and pending, render both the pending indicator and the edited marker. If
+MindRoom AI streaming and local-echo pending are both present, keep the streaming
+indicator visible and add the pending clock after it.
+
+The first implementation targets message types that already render through the
+inline message-body suffix path: text, notice, emote, file captions, and
+MindRoom long-text variants. Media-only bodies and stickers are intentionally
+out of scope for this pass because they do not have the same inline text suffix
+surface.
+
+If necessary, extend local echo update handling so `RoomEvent.LocalEchoUpdated`
+causes the affected timeline surface to re-render when status changes or when
+the local event ID is replaced. This prevents the indicator from getting stuck
+after server acceptance.
+
+## Testing
+
+Add focused unit coverage for:
+
+- helper returns pending for encrypting/sending/queued/sent states,
+- helper returns false for no status/not_sent/cancelled,
+- message rendering includes the pending indicator for a pending local echo,
+- message rendering omits it for accepted or failed/cancelled states.
+
+Prefer focused message-rendering or helper tests over expanding broad room
+timeline tests unless local echo refresh behavior requires a targeted timeline
+test.
+
+## Validation
+
+Run focused tests first, then `npm run typecheck`. Before finalizing, run the
+repo-required validation that is feasible in this environment and record the
+results in `FORK_CHANGES.md`.

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -30,6 +30,7 @@ import { TextViewer } from './text-viewer';
 import { testMatrixTo } from '../plugins/matrix-to';
 import { IImageContent } from '../../types/matrix/common';
 import { renderMindroomMessageContent } from '../mindroom/messages/renderMindroomMessageContent';
+import { getMindroomMessageStateSuffixRenderer } from '../mindroom/messages/messageStateSuffix';
 
 type RenderMessageContentProps = {
   displayName: string;
@@ -50,6 +51,7 @@ type RenderMessageContentProps = {
   outlineAttachment?: boolean;
   hydrateLongText?: boolean;
   onLongTextHydratedMessageExtrasRendered?: () => void;
+  pendingSend?: boolean;
 };
 export function RenderMessageContent({
   displayName,
@@ -70,6 +72,7 @@ export function RenderMessageContent({
   outlineAttachment,
   hydrateLongText = true,
   onLongTextHydratedMessageExtrasRendered,
+  pendingSend,
 }: RenderMessageContentProps) {
   const renderUrlsPreview = (urls: string[]) => {
     const filteredUrls = urls.filter((url) => !testMatrixTo(url));
@@ -90,6 +93,10 @@ export function RenderMessageContent({
         <MText
           style={{ marginTop: config.space.S200 }}
           edited={edited}
+          renderStateSuffix={getMindroomMessageStateSuffixRenderer({
+            edited,
+            pendingSend,
+          })}
           content={content}
           renderBody={(props) => (
             <RenderBody
@@ -152,6 +159,7 @@ export function RenderMessageContent({
     msgType,
     edited,
     content,
+    pendingSend,
     renderUrlsPreview: urlPreview ? renderUrlsPreview : undefined,
     highlightRegex,
     htmlReactParserOptions,

--- a/src/app/mindroom/messages/PendingSendIndicator.css.ts
+++ b/src/app/mindroom/messages/PendingSendIndicator.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+import { toRem } from 'folds';
+
+export const Container = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  marginLeft: toRem(4),
+  verticalAlign: 'text-bottom',
+});

--- a/src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts
+++ b/src/app/mindroom/messages/__tests__/RenderMessageContent.test.ts
@@ -6,7 +6,27 @@ const toolApprovalCardMock = vi.hoisted(() => vi.fn());
 const renderMindroomMessageContentMock = vi.hoisted(() => vi.fn());
 
 vi.mock('folds', () => ({
+  Box: ({ children, as: asElement = 'div', ...props }: any) =>
+    React.createElement(asElement, props, children),
+  Icon: ({ src }: { src?: string }) => React.createElement('span', null, src ?? 'icon'),
+  Icons: {
+    Clock: 'Clock',
+    Delete: 'Delete',
+    Lock: 'Lock',
+    Warning: 'Warning',
+  },
+  Text: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('span', props, children),
+  as: (render: (props: Record<string, unknown>, ref: React.Ref<unknown>) => React.ReactNode) =>
+    React.forwardRef(render),
+  color: {
+    Critical: { Main: '#f00' },
+    Warning: { Main: '#fc0' },
+  },
   config: {
+    opacity: {
+      P300: '0.6',
+    },
     space: {
       S200: '8px',
     },
@@ -27,7 +47,13 @@ vi.mock('../../../components/message', () => ({
   MNotice: () => React.createElement('div', { 'data-renderer': 'notice' }),
   MindroomThreadSummaryCard: ({ summaryInfo }: { summaryInfo: { summaryText?: string } }) =>
     React.createElement('div', { 'data-renderer': 'summary-card' }, summaryInfo.summaryText),
-  MText: () => React.createElement('div', { 'data-renderer': 'text' }),
+  MText: ({ content, renderStateSuffix }: any) =>
+    React.createElement(
+      'div',
+      { 'data-renderer': 'text' },
+      typeof content.body === 'string' ? content.body : '',
+      renderStateSuffix?.()
+    ),
   MVideo: () => null,
   ReadPdfFile: () => null,
   ReadTextFile: () => null,
@@ -67,6 +93,10 @@ vi.mock('../../../plugins/matrix-to', () => ({
 
 vi.mock('../renderMindroomMessageContent', () => ({
   renderMindroomMessageContent: renderMindroomMessageContentMock,
+}));
+
+vi.mock('../PendingSendIndicator.css', () => ({
+  Container: 'PendingSendIndicator',
 }));
 
 vi.mock('../longText', () => ({
@@ -278,6 +308,36 @@ describe('RenderMessageContent', () => {
         }),
       })
     );
+
+    renderer.unmount();
+  });
+
+  it('renders the pending send suffix on image captions', async () => {
+    const { RenderMessageContent } = await import('../../../components/RenderMessageContent');
+    renderMindroomMessageContentMock.mockReset();
+    renderMindroomMessageContentMock.mockReturnValue(undefined);
+
+    const renderer = create(
+      React.createElement(RenderMessageContent, {
+        displayName: 'MindRoom',
+        msgType: 'm.image',
+        ts: 0,
+        pendingSend: true,
+        getContent: (() => ({
+          msgtype: 'm.image',
+          body: 'Caption text',
+          filename: 'image.png',
+          url: 'mxc://example/image',
+        })) as <T>() => T,
+        htmlReactParserOptions: {} as never,
+        linkifyOpts: {} as never,
+      })
+    );
+
+    const rendered = JSON.stringify(renderer.toJSON());
+
+    expect(rendered).toContain('Caption text');
+    expect(rendered).toContain('Message sending');
 
     renderer.unmount();
   });

--- a/src/app/mindroom/messages/messageStateSuffix.test.ts
+++ b/src/app/mindroom/messages/messageStateSuffix.test.ts
@@ -1,0 +1,61 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { getMindroomMessageStateSuffixRenderer } from './messageStateSuffix';
+
+vi.mock('./PendingSendIndicator.css', () => ({
+  Container: 'PendingSendIndicator',
+}));
+
+const renderSuffix = (renderSuffixFn: (() => React.ReactNode) | undefined): string => {
+  const renderer = create(React.createElement(React.Fragment, null, renderSuffixFn?.()));
+  const rendered = JSON.stringify(renderer.toJSON());
+  renderer.unmount();
+  return rendered;
+};
+
+describe('getMindroomMessageStateSuffixRenderer', () => {
+  it('preserves generic edited rendering when no custom suffix or pending indicator is needed', () => {
+    expect(
+      getMindroomMessageStateSuffixRenderer({
+        edited: true,
+        pendingSend: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it('renders the pending send indicator when a message is pending', () => {
+    const rendered = renderSuffix(
+      getMindroomMessageStateSuffixRenderer({
+        pendingSend: true,
+      })
+    );
+
+    expect(rendered).toContain('Message sending');
+    expect(rendered).toContain('Waiting for server');
+  });
+
+  it('composes custom suffixes with the pending send indicator', () => {
+    const rendered = renderSuffix(
+      getMindroomMessageStateSuffixRenderer({
+        pendingSend: true,
+        renderStateSuffix: () => React.createElement('span', { 'data-renderer': 'streaming' }),
+      })
+    );
+
+    expect(rendered).toContain('streaming');
+    expect(rendered).toContain('Message sending');
+  });
+
+  it('composes edited markers with the pending send indicator', () => {
+    const rendered = renderSuffix(
+      getMindroomMessageStateSuffixRenderer({
+        edited: true,
+        pendingSend: true,
+      })
+    );
+
+    expect(rendered).toContain('(edited)');
+    expect(rendered).toContain('Message sending');
+  });
+});

--- a/src/app/mindroom/messages/messageStateSuffix.test.ts
+++ b/src/app/mindroom/messages/messageStateSuffix.test.ts
@@ -58,4 +58,23 @@ describe('getMindroomMessageStateSuffixRenderer', () => {
     expect(rendered).toContain('(edited)');
     expect(rendered).toContain('Message sending');
   });
+
+  it('composes custom suffixes, edited markers, and pending send indicators in order', () => {
+    const rendered = renderSuffix(
+      getMindroomMessageStateSuffixRenderer({
+        edited: true,
+        pendingSend: true,
+        renderStateSuffix: () => React.createElement('span', { 'data-renderer': 'streaming' }),
+      })
+    );
+
+    const customSuffixIndex = rendered.indexOf('streaming');
+    const editedIndex = rendered.indexOf('(edited)');
+    const pendingIndex = rendered.indexOf('Message sending');
+
+    expect(customSuffixIndex).toBeGreaterThanOrEqual(0);
+    expect(editedIndex).toBeGreaterThan(customSuffixIndex);
+    expect(pendingIndex).toBeGreaterThan(editedIndex);
+    expect(rendered).toContain('Waiting for server');
+  });
 });

--- a/src/app/mindroom/messages/messageStateSuffix.tsx
+++ b/src/app/mindroom/messages/messageStateSuffix.tsx
@@ -1,0 +1,27 @@
+import React, { type ReactNode } from 'react';
+import { MessageEditedContent } from '../../components/message/content/FallbackContent';
+import { renderPendingSendIndicator } from './pendingSendIndicator';
+
+export type MindroomMessageStateSuffixOptions = {
+  edited?: boolean;
+  pendingSend?: boolean;
+  renderStateSuffix?: () => ReactNode;
+};
+
+export const getMindroomMessageStateSuffixRenderer = ({
+  edited,
+  pendingSend,
+  renderStateSuffix,
+}: MindroomMessageStateSuffixOptions): (() => ReactNode) | undefined => {
+  if (!renderStateSuffix && !pendingSend) {
+    return undefined;
+  }
+
+  return () => (
+    <>
+      {renderStateSuffix?.()}
+      {edited && <MessageEditedContent />}
+      {pendingSend && renderPendingSendIndicator()}
+    </>
+  );
+};

--- a/src/app/mindroom/messages/pendingLocalEcho.ts
+++ b/src/app/mindroom/messages/pendingLocalEcho.ts
@@ -1,0 +1,14 @@
+import { EventStatus, type MatrixEvent } from 'matrix-js-sdk';
+
+const PENDING_LOCAL_ECHO_STATUSES = new Set<unknown>([
+  EventStatus.ENCRYPTING,
+  EventStatus.SENDING,
+  EventStatus.QUEUED,
+  EventStatus.SENT,
+]);
+
+export const isPendingLocalEchoStatus = (status: unknown): boolean =>
+  PENDING_LOCAL_ECHO_STATUSES.has(status);
+
+export const isPendingLocalEchoEvent = (event?: Pick<MatrixEvent, 'status'> | null): boolean =>
+  isPendingLocalEchoStatus(event?.status);

--- a/src/app/mindroom/messages/pendingSendIndicator.test.ts
+++ b/src/app/mindroom/messages/pendingSendIndicator.test.ts
@@ -2,11 +2,8 @@ import React from 'react';
 import { create } from 'react-test-renderer';
 import { EventStatus } from 'matrix-js-sdk';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  PendingSendIndicator,
-  isPendingLocalEchoEvent,
-  isPendingLocalEchoStatus,
-} from './pendingSendIndicator';
+import { PendingSendIndicator } from './pendingSendIndicator';
+import { isPendingLocalEchoEvent, isPendingLocalEchoStatus } from './pendingLocalEcho';
 
 vi.mock('./PendingSendIndicator.css', () => ({
   Container: 'PendingSendIndicator',

--- a/src/app/mindroom/messages/pendingSendIndicator.test.ts
+++ b/src/app/mindroom/messages/pendingSendIndicator.test.ts
@@ -1,0 +1,47 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+import { EventStatus } from 'matrix-js-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PendingSendIndicator,
+  isPendingLocalEchoEvent,
+  isPendingLocalEchoStatus,
+} from './pendingSendIndicator';
+
+vi.mock('./PendingSendIndicator.css', () => ({
+  Container: 'PendingSendIndicator',
+}));
+
+describe('pending send indicator', () => {
+  it.each([EventStatus.ENCRYPTING, EventStatus.SENDING, EventStatus.QUEUED, EventStatus.SENT])(
+    'treats %s as pending',
+    (status) => {
+      expect(isPendingLocalEchoStatus(status)).toBe(true);
+    }
+  );
+
+  it.each([undefined, null, EventStatus.NOT_SENT, EventStatus.CANCELLED])(
+    'does not treat %s as pending',
+    (status) => {
+      expect(isPendingLocalEchoStatus(status)).toBe(false);
+    }
+  );
+
+  it('derives pending state from nullable Matrix events', () => {
+    expect(isPendingLocalEchoEvent({ status: EventStatus.SENDING })).toBe(true);
+    expect(isPendingLocalEchoEvent({ status: EventStatus.NOT_SENT })).toBe(false);
+    expect(isPendingLocalEchoEvent(null)).toBe(false);
+    expect(isPendingLocalEchoEvent(undefined)).toBe(false);
+  });
+
+  it('renders an accessible muted clock indicator', () => {
+    const renderer = create(React.createElement(PendingSendIndicator));
+    const rendered = JSON.stringify(renderer.toJSON());
+
+    expect(rendered).toContain('Message sending');
+    expect(rendered).toContain('Waiting for server');
+    expect(rendered).toContain('Clock');
+
+    renderer.unmount();
+  });
+});

--- a/src/app/mindroom/messages/pendingSendIndicator.tsx
+++ b/src/app/mindroom/messages/pendingSendIndicator.tsx
@@ -1,20 +1,6 @@
 import React from 'react';
-import { EventStatus, type MatrixEvent } from 'matrix-js-sdk';
 import { Icon, Icons, Text } from 'folds';
 import * as css from './PendingSendIndicator.css';
-
-const PENDING_LOCAL_ECHO_STATUSES = new Set<unknown>([
-  EventStatus.ENCRYPTING,
-  EventStatus.SENDING,
-  EventStatus.QUEUED,
-  EventStatus.SENT,
-]);
-
-export const isPendingLocalEchoStatus = (status: unknown): boolean =>
-  PENDING_LOCAL_ECHO_STATUSES.has(status);
-
-export const isPendingLocalEchoEvent = (event?: Pick<MatrixEvent, 'status'> | null): boolean =>
-  isPendingLocalEchoStatus(event?.status);
 
 export function PendingSendIndicator() {
   return (

--- a/src/app/mindroom/messages/pendingSendIndicator.tsx
+++ b/src/app/mindroom/messages/pendingSendIndicator.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { EventStatus, type MatrixEvent } from 'matrix-js-sdk';
+import { Icon, Icons, Text } from 'folds';
+import * as css from './PendingSendIndicator.css';
+
+const PENDING_LOCAL_ECHO_STATUSES = new Set<unknown>([
+  EventStatus.ENCRYPTING,
+  EventStatus.SENDING,
+  EventStatus.QUEUED,
+  EventStatus.SENT,
+]);
+
+export const isPendingLocalEchoStatus = (status: unknown): boolean =>
+  PENDING_LOCAL_ECHO_STATUSES.has(status);
+
+export const isPendingLocalEchoEvent = (event?: Pick<MatrixEvent, 'status'> | null): boolean =>
+  isPendingLocalEchoStatus(event?.status);
+
+export function PendingSendIndicator() {
+  return (
+    <Text
+      as="span"
+      size="T200"
+      priority="300"
+      className={css.Container}
+      role="status"
+      aria-label="Message sending"
+      title="Waiting for server"
+    >
+      <Icon data-pending-send-icon="Clock" src={Icons.Clock} size="50" aria-hidden="true" />
+    </Text>
+  );
+}
+
+export const renderPendingSendIndicator = () => <PendingSendIndicator />;

--- a/src/app/mindroom/messages/renderMindroomMessageContent.test.ts
+++ b/src/app/mindroom/messages/renderMindroomMessageContent.test.ts
@@ -93,6 +93,10 @@ vi.mock('./StreamingIndicator', () => ({
     React.createElement('span', { 'data-renderer': 'streaming' }),
 }));
 
+vi.mock('./PendingSendIndicator.css', () => ({
+  Container: 'PendingSendIndicator',
+}));
+
 vi.mock('./MindroomThinkingPlaceholder', () => ({
   MindroomThinkingPlaceholder: () =>
     React.createElement('span', { 'data-renderer': 'thinking-placeholder' }, 'Making progress'),
@@ -202,6 +206,63 @@ describe('renderMindroomMessageContent', () => {
     expect(rendered).toContain('The actual answer has started');
     expect(rendered).toContain('streaming');
     expect(rendered).not.toContain('thinking-placeholder');
+
+    renderer.unmount();
+  });
+
+  it('renders a pending send suffix for pending local echo text', async () => {
+    const renderer = await renderNode({
+      msgType: 'm.text',
+      pendingSend: true,
+      content: {
+        msgtype: 'm.text',
+        body: 'Uploading message',
+      },
+    });
+
+    const rendered = JSON.stringify(renderer.toJSON());
+
+    expect(rendered).toContain('Uploading message');
+    expect(rendered).toContain('Message sending');
+
+    renderer.unmount();
+  });
+
+  it('composes streaming and pending send suffixes', async () => {
+    const renderer = await renderNode({
+      msgType: 'm.text',
+      pendingSend: true,
+      content: {
+        msgtype: 'm.text',
+        body: 'The actual answer has started',
+        'io.mindroom.stream_status': 'streaming',
+      },
+    });
+
+    const rendered = JSON.stringify(renderer.toJSON());
+
+    expect(rendered).toContain('streaming');
+    expect(rendered).toContain('Message sending');
+
+    renderer.unmount();
+  });
+
+  it('composes edited and pending send suffixes', async () => {
+    const renderer = await renderNode({
+      msgType: 'm.text',
+      edited: true,
+      pendingSend: true,
+      content: {
+        msgtype: 'm.text',
+        body: 'Edited local echo',
+      },
+    });
+
+    const rendered = JSON.stringify(renderer.toJSON());
+
+    expect(rendered).toContain('Edited local echo');
+    expect(rendered).toContain('(edited)');
+    expect(rendered).toContain('Message sending');
 
     renderer.unmount();
   });

--- a/src/app/mindroom/messages/renderMindroomMessageContent.tsx
+++ b/src/app/mindroom/messages/renderMindroomMessageContent.tsx
@@ -19,6 +19,7 @@ import { isMindroomThinkingPlaceholderBody } from './thinkingPlaceholder';
 import { getMindroomPasteAttachmentFile } from './pasteAttachmentMarker';
 import { MINDROOM_TOOL_APPROVAL_EVENT, parseToolApprovalContent } from './toolApproval';
 import { getMindroomThreadSummaryInfo } from './threadSummary';
+import { getMindroomMessageStateSuffixRenderer } from './messageStateSuffix';
 
 export type RenderMindroomMessageContentOptions = {
   displayName: string;
@@ -29,6 +30,7 @@ export type RenderMindroomMessageContentOptions = {
   msgType: string;
   edited?: boolean;
   content: Record<string, unknown>;
+  pendingSend?: boolean;
   renderUrlsPreview?: (urls: string[]) => ReactNode;
   highlightRegex?: RegExp;
   htmlReactParserOptions: HTMLReactParserOptions;
@@ -63,6 +65,7 @@ export const renderMindroomMessageContent = ({
   msgType,
   edited,
   content,
+  pendingSend,
   renderUrlsPreview,
   highlightRegex,
   htmlReactParserOptions,
@@ -166,6 +169,13 @@ export const renderMindroomMessageContent = ({
     }
   };
 
+  const getMessageStateSuffix = (renderStateSuffix?: () => ReactNode) =>
+    getMindroomMessageStateSuffixRenderer({
+      edited,
+      pendingSend,
+      renderStateSuffix,
+    });
+
   const threadSummaryInfo = getMindroomThreadSummaryInfo(content);
   if (threadSummaryInfo) {
     return (
@@ -197,6 +207,7 @@ export const renderMindroomMessageContent = ({
       return (
         <MText
           content={content}
+          renderStateSuffix={getMessageStateSuffix()}
           renderBody={() => <MindroomThinkingPlaceholder />}
           renderAfterBody={renderMessageExtras(content)}
         />
@@ -209,7 +220,9 @@ export const renderMindroomMessageContent = ({
         <MindroomLongTextText
           kind={MindroomLongTextKind.Text}
           edited={edited}
-          renderStateSuffix={isStreaming ? renderMindroomStreamingIndicator : undefined}
+          renderStateSuffix={getMessageStateSuffix(
+            isStreaming ? renderMindroomStreamingIndicator : undefined
+          )}
           content={longTextSource.previewContent}
           longTextSource={longTextSource}
           hydrate={hydrateLongText}
@@ -245,7 +258,9 @@ export const renderMindroomMessageContent = ({
       return (
         <MText
           edited={edited}
-          renderStateSuffix={isStreaming ? renderMindroomStreamingIndicator : undefined}
+          renderStateSuffix={getMessageStateSuffix(
+            isStreaming ? renderMindroomStreamingIndicator : undefined
+          )}
           content={renderableContent}
           renderBody={renderBody(renderableContent)}
           renderAfterBody={renderMessageExtras(renderableContent, [content])}
@@ -264,7 +279,9 @@ export const renderMindroomMessageContent = ({
           kind={MindroomLongTextKind.Emote}
           displayName={displayName}
           edited={edited}
-          renderStateSuffix={isStreaming ? renderMindroomStreamingIndicator : undefined}
+          renderStateSuffix={getMessageStateSuffix(
+            isStreaming ? renderMindroomStreamingIndicator : undefined
+          )}
           content={longTextSource.previewContent}
           longTextSource={longTextSource}
           hydrate={hydrateLongText}
@@ -293,7 +310,9 @@ export const renderMindroomMessageContent = ({
       <MEmote
         displayName={displayName}
         edited={edited}
-        renderStateSuffix={isStreaming ? renderMindroomStreamingIndicator : undefined}
+        renderStateSuffix={getMessageStateSuffix(
+          isStreaming ? renderMindroomStreamingIndicator : undefined
+        )}
         content={renderableContent}
         renderBody={renderBody(renderableContent)}
         renderAfterBody={renderMessageExtras(renderableContent, [content])}
@@ -310,7 +329,9 @@ export const renderMindroomMessageContent = ({
         <MindroomLongTextText
           kind={MindroomLongTextKind.Notice}
           edited={edited}
-          renderStateSuffix={isStreaming ? renderMindroomStreamingIndicator : undefined}
+          renderStateSuffix={getMessageStateSuffix(
+            isStreaming ? renderMindroomStreamingIndicator : undefined
+          )}
           content={longTextSource.previewContent}
           longTextSource={longTextSource}
           hydrate={hydrateLongText}
@@ -338,7 +359,9 @@ export const renderMindroomMessageContent = ({
     return (
       <MNotice
         edited={edited}
-        renderStateSuffix={isStreaming ? renderMindroomStreamingIndicator : undefined}
+        renderStateSuffix={getMessageStateSuffix(
+          isStreaming ? renderMindroomStreamingIndicator : undefined
+        )}
         content={renderableContent}
         renderBody={renderBody(renderableContent)}
         renderAfterBody={renderMessageExtras(renderableContent, [content])}

--- a/src/app/mindroom/room-input/MindroomRoomInput.tsx
+++ b/src/app/mindroom/room-input/MindroomRoomInput.tsx
@@ -279,6 +279,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const [autocompleteQuery, setAutocompleteQuery] =
       useState<AutocompleteQuery<RoomInputAutocompletePrefix>>();
     const [voiceRecorderOpen, setVoiceRecorderOpen] = useState(false);
+    const [submitPending, setSubmitPending] = useState(false);
     const voiceAutoSendPending = useAtomValue(voiceAutoSendPendingAtom);
     const pendingVoiceSendDraft = useAtomValue(pendingVoiceSendDraftAtom);
     const setPendingVoiceSendDraft = useSetAtom(pendingVoiceSendDraftAtom);
@@ -920,6 +921,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const submit = useCallback(async () => {
       if (submitInFlightRef.current) return;
       submitInFlightRef.current = true;
+      let submitPendingStarted = false;
 
       try {
         if (store.get(voiceAutoSendPendingAtom)) return;
@@ -1009,12 +1011,17 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         if (relation) {
           content['m.relates_to'] = relation;
         }
+        submitPendingStarted = true;
+        setSubmitPending(true);
         await mx.sendMessage(roomId, content as any);
         resetEditor(editor);
         resetEditorHistory(editor);
         setReplyDraft(undefined);
         sendTypingStatus(false);
       } finally {
+        if (submitPendingStarted) {
+          setSubmitPending(false);
+        }
         submitInFlightRef.current = false;
       }
     }, [
@@ -1235,6 +1242,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                   <MindroomRoomInputReplyContext
                     room={room}
                     relation={replyDraft?.relation}
+                    pendingSend={!!threadId && submitPending}
                     threadId={threadId}
                     leading={
                       replyDraft && (

--- a/src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts
+++ b/src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts
@@ -24,6 +24,10 @@ vi.mock('../threads/ThreadIndicator', () => ({
   ThreadIndicator: () => null,
 }));
 
+vi.mock('../messages/PendingSendIndicator.css', () => ({
+  Container: 'PendingSendIndicator',
+}));
+
 vi.mock('../voice/VoiceRecorderDialog', () => ({
   VoiceRecorderComposer: () => null,
 }));

--- a/src/app/mindroom/room-input/RoomInputMindroomExtensions.tsx
+++ b/src/app/mindroom/room-input/RoomInputMindroomExtensions.tsx
@@ -12,6 +12,7 @@ import type {
 } from '../../state/room/roomInputDrafts';
 import { MindroomCommandAutocomplete } from '../commands/MindroomCommandAutocomplete';
 import { getMindroomCommandQuery, MINDROOM_COMMAND_PREFIX } from '../commands/mindroomCommandQuery';
+import { PendingSendIndicator } from '../messages/pendingSendIndicator';
 import { getMessageRelation } from '../threads/composeMessageRelation';
 import { ThreadIndicator } from '../threads/ThreadIndicator';
 import { VoiceRecorderComposer } from '../voice/VoiceRecorderDialog';
@@ -51,6 +52,7 @@ export type MindroomVoiceSendContext = PendingVoiceSendContext;
 type MindroomRoomInputReplyContextProps = {
   children?: React.ReactNode;
   leading?: React.ReactNode;
+  pendingSend?: boolean;
   relation: IReplyDraft['relation'] | undefined;
   room: Room;
   threadId?: string;
@@ -226,6 +228,7 @@ export function MindroomRoomInputThreadIndicator({
 export function MindroomRoomInputReplyContext({
   children,
   leading,
+  pendingSend,
   relation,
   room,
   threadId,
@@ -246,6 +249,7 @@ export function MindroomRoomInputReplyContext({
             Sending to this thread
           </Text>
         )}
+        {pendingSend && <PendingSendIndicator />}
       </Box>
     </Box>
   );

--- a/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
+++ b/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
@@ -553,8 +553,28 @@ vi.mock('../RoomInputMindroomExtensions', async () => {
       ),
     isMindroomRoomInputAutocompleteQuery: (query?: { prefix?: string }) => query?.prefix === '!',
     MindroomRoomInputAutocomplete: () => null,
-    MindroomRoomInputReplyContext: ({ children }: { children?: React.ReactNode }) =>
-      React.createElement('div', null, children),
+    MindroomRoomInputReplyContext: ({
+      children,
+      pendingSend,
+    }: {
+      children?: React.ReactNode;
+      pendingSend?: boolean;
+    }) =>
+      React.createElement(
+        'div',
+        null,
+        children ?? 'Sending to this thread',
+        pendingSend
+          ? React.createElement(
+              'span',
+              {
+                role: 'status',
+                title: 'Waiting for server',
+              },
+              'Message sending'
+            )
+          : null
+      ),
     MindroomVoiceRecorderComposer: ({
       onSendRecording,
       getSendContext,
@@ -1145,6 +1165,33 @@ describe('RoomInput', () => {
       send.resolve({ event_id: '$sent' });
       await Promise.resolve();
     });
+
+    renderer.unmount();
+  });
+
+  it('shows the pending send indicator for unresolved thread composer sends', async () => {
+    const { renderer } = await renderRoomInput(createStore(), { threadId: '$thread' });
+    const send = createDeferred<{ event_id: string }>();
+    mxState.sendMessage.mockReturnValueOnce(send.promise);
+
+    editorOutputState.plainText = 'Thread reply still sending';
+    editorOutputState.customHtml = 'Thread reply still sending';
+    editorOutputState.htmlEqualsPlainText = true;
+
+    await act(async () => {
+      customEditorState.props!.onKeyDown?.({ key: 'Enter', preventDefault: vi.fn() });
+      await Promise.resolve();
+    });
+
+    expect(JSON.stringify(renderer.toJSON())).toContain('Message sending');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Waiting for server');
+
+    await act(async () => {
+      send.resolve({ event_id: '$sent' });
+      await Promise.resolve();
+    });
+
+    expect(JSON.stringify(renderer.toJSON())).not.toContain('Message sending');
 
     renderer.unmount();
   });

--- a/src/app/mindroom/threads/CompactRoomView.css.ts
+++ b/src/app/mindroom/threads/CompactRoomView.css.ts
@@ -92,6 +92,13 @@ export const MessageRow = style({
   justifyContent: 'space-between',
 });
 
+export const MessagePreview = style({
+  display: 'flex',
+  alignItems: 'center',
+  minWidth: 0,
+  flex: 1,
+});
+
 export const MessageText = style({
   minWidth: 0,
   flex: 1,

--- a/src/app/mindroom/threads/CompactThreadCard.test.tsx
+++ b/src/app/mindroom/threads/CompactThreadCard.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { CompactThreadCard } from './CompactThreadCard';
+import type { CompactThreadCardViewModel } from './types';
+
+vi.mock('./CompactRoomView.css', () => ({
+  AttentionDot: vi.fn(() => 'AttentionDot'),
+  Card: 'Card',
+  CardResolved: 'CardResolved',
+  MessagePreview: 'MessagePreview',
+  MessageRow: 'MessageRow',
+  MessageText: 'MessageText',
+  MetadataRow: 'MetadataRow',
+  ParticipantAvatar: 'ParticipantAvatar',
+  Participants: 'Participants',
+  ScheduledIndicator: 'ScheduledIndicator',
+  ScreenReaderText: 'ScreenReaderText',
+  StatBadge: 'StatBadge',
+  Stats: 'Stats',
+  StatusChip: 'StatusChip',
+  TimeText: 'TimeText',
+  TitleLead: 'TitleLead',
+  TitleRow: 'TitleRow',
+  TitleText: 'TitleText',
+  UnreadDot: 'UnreadDot',
+  UnreadWrap: 'UnreadWrap',
+}));
+
+vi.mock('./ThreadIndicator.css', () => ({
+  ThreadParticipant: 'ThreadParticipant',
+  ThreadScheduledIcon: 'ThreadScheduledIcon',
+  ThreadScheduledIndicator: 'ThreadScheduledIndicator',
+  ThreadStreamingDot: 'ThreadStreamingDot',
+  ThreadUnreadDot: 'ThreadUnreadDot',
+}));
+
+vi.mock('../messages/PendingSendIndicator.css', () => ({
+  Container: 'PendingSendIndicator',
+}));
+
+vi.mock('../../hooks/useRelativeTime', () => ({
+  useRelativeTime: () => '',
+}));
+
+vi.mock('../../components/user-avatar', () => ({
+  UserAvatar: ({ renderFallback }: { renderFallback?: () => React.ReactNode }) =>
+    renderFallback?.() ?? null,
+}));
+
+const makeViewModel = (
+  overrides: Partial<CompactThreadCardViewModel> = {}
+): CompactThreadCardViewModel => ({
+  id: {
+    roomId: '!room:server',
+    threadRootId: '$thread',
+  },
+  titleText: 'Thread title',
+  displayTitleText: 'Thread title',
+  previewText: 'Me: Pending reply body',
+  messageCount: 1,
+  messageCountLabel: '1 msg',
+  attentionState: 'waiting',
+  attentionStatusText: 'Waiting on response',
+  participants: [],
+  tags: [],
+  isResolved: false,
+  isUnread: false,
+  isStreaming: false,
+  ...overrides,
+});
+
+describe('CompactThreadCard', () => {
+  it('renders the pending send indicator beside compact preview text', () => {
+    const renderer = create(
+      <CompactThreadCard viewModel={makeViewModel({ hasPendingSend: true })} onClick={vi.fn()} />
+    );
+
+    const rendered = JSON.stringify(renderer.toJSON());
+
+    expect(rendered).toContain('Me: Pending reply body');
+    expect(rendered).toContain('Message sending');
+    expect(rendered).toContain('Waiting for server');
+    expect(rendered).toContain('data-pending-send-icon');
+
+    renderer.unmount();
+  });
+});

--- a/src/app/mindroom/threads/CompactThreadCard.tsx
+++ b/src/app/mindroom/threads/CompactThreadCard.tsx
@@ -6,6 +6,7 @@ import { UserAvatar } from '../../components/user-avatar';
 import { useRelativeTime } from '../../hooks/useRelativeTime';
 import type { CompactThreadCardViewModel } from './types';
 import * as css from './CompactRoomView.css';
+import { PendingSendIndicator } from '../messages/pendingSendIndicator';
 
 const tagColor = (tagName: string): string => {
   let hash = 0;
@@ -36,6 +37,7 @@ export function CompactThreadCard({ viewModel, onClick }: CompactThreadCardProps
     isResolved,
     isUnread,
     isStreaming,
+    hasPendingSend,
     scheduledDisplayText,
     scheduledTaskLabel,
     lastActivityTs,
@@ -51,6 +53,7 @@ export function CompactThreadCard({ viewModel, onClick }: CompactThreadCardProps
     isResolved ? 'Resolved thread' : 'Unresolved thread',
     isUnread ? 'Unread messages' : undefined,
     isStreaming ? 'Agent streaming' : undefined,
+    hasPendingSend ? 'Message sending' : undefined,
     scheduledTaskLabel,
     relativeTime ? `Last activity ${relativeTime}` : undefined,
   ]
@@ -92,9 +95,12 @@ export function CompactThreadCard({ viewModel, onClick }: CompactThreadCardProps
       </Box>
 
       <Box className={css.MessageRow}>
-        <Text className={css.MessageText} size="T200" priority="300" truncate>
-          {previewText}
-        </Text>
+        <Box className={css.MessagePreview} alignItems="Center">
+          <Text className={css.MessageText} size="T200" priority="300" truncate>
+            {previewText}
+          </Text>
+          {hasPendingSend && <PendingSendIndicator />}
+        </Box>
         <Box className={css.Stats}>
           <Badge className={css.StatBadge} variant="Secondary" fill="Soft" radii="Pill">
             <Text as="span" size="T200">

--- a/src/app/mindroom/threads/MindroomRoomTimeline.tsx
+++ b/src/app/mindroom/threads/MindroomRoomTimeline.tsx
@@ -120,6 +120,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
 import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { Event, Message } from '../messages/MindroomMessage';
+import { isPendingLocalEchoEvent } from '../messages/pendingSendIndicator';
 import type { MindroomThreadSummaryInfo } from './threadSummaryStore';
 import {
   consumeLiveExpandOnceId,
@@ -1541,6 +1542,7 @@ export function RoomTimeline({
         const highlighted = focusItem?.index === item && focusItem.highlight;
 
         const editedEvent = getEditedEvent(mEventId, mEvent, timelineSet);
+        const pendingSend = isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent);
         const resolvedContent = getLatestMessageContent(mEvent, editedEvent);
         const getContent = (() => resolvedContent) as GetContentCallback;
         const collapseMode = getCollapsibleMessageMode(
@@ -1660,6 +1662,7 @@ export function RoomTimeline({
                   msgType={msgType ?? ''}
                   ts={mEvent.getTs()}
                   edited={!!editedEvent}
+                  pendingSend={pendingSend}
                   getContent={getContent}
                   mediaAutoLoad={mediaAutoLoad}
                   urlPreview={showUrlPreview}
@@ -1706,6 +1709,8 @@ export function RoomTimeline({
           const { replyEventId, threadRootId } = mEvent;
           const highlighted = focusItem?.index === item && focusItem.highlight;
           const editedEvent = getEditedEvent(mEventId, mEvent, timelineSet);
+          const pendingSend =
+            isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent);
           const approvalContent =
             getMindroomRoomTimelineApprovalContentIfSupported(mEvent, editedEvent) ??
             mEvent.getContent();
@@ -1805,6 +1810,7 @@ export function RoomTimeline({
                   }
                   ts={mEvent.getTs()}
                   edited={!!editedEvent}
+                  pendingSend={pendingSend}
                   getContent={getContent}
                   mediaAutoLoad={mediaAutoLoad}
                   urlPreview={showUrlPreview}
@@ -1823,6 +1829,7 @@ export function RoomTimeline({
         const { replyEventId, threadRootId } = mEvent;
         const highlighted = focusItem?.index === item && focusItem.highlight;
         const editedEvent = getEditedEvent(mEventId, mEvent, timelineSet);
+        const pendingSend = isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent);
         const resolvedContent = getLatestMessageContent(mEvent, editedEvent);
         const threadSummary = showThreadBadgesInRoom
           ? renderMindroomRoomTimelineThreadBadge({
@@ -1943,6 +1950,7 @@ export function RoomTimeline({
                       }
                       ts={mEvent.getTs()}
                       edited={!!editedEvent}
+                      pendingSend={pendingSend}
                       getContent={getContent}
                       mediaAutoLoad={mediaAutoLoad}
                       urlPreview={showUrlPreview}
@@ -1988,6 +1996,7 @@ export function RoomTimeline({
                       msgType={mEvent.getContent().msgtype ?? ''}
                       ts={mEvent.getTs()}
                       edited={!!editedEvent}
+                      pendingSend={pendingSend}
                       getContent={getContent}
                       mediaAutoLoad={mediaAutoLoad}
                       urlPreview={showUrlPreview}

--- a/src/app/mindroom/threads/MindroomRoomTimeline.tsx
+++ b/src/app/mindroom/threads/MindroomRoomTimeline.tsx
@@ -120,7 +120,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
 import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { Event, Message } from '../messages/MindroomMessage';
-import { isPendingLocalEchoEvent } from '../messages/pendingSendIndicator';
+import { isPendingLocalEchoEvent } from '../messages/pendingLocalEcho';
 import type { MindroomThreadSummaryInfo } from './threadSummaryStore';
 import {
   consumeLiveExpandOnceId,

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -134,6 +134,16 @@ describe('RoomTimeline architecture', () => {
     expect(timelineMessageSource).toContain('renderMindroomRoomTimelineThreadBadge');
   });
 
+  it('passes pending local echo state from base and edited events into message content', () => {
+    const source = readRoomTimelineSource();
+
+    expect(source).toContain("from '../messages/pendingSendIndicator'");
+    expect(source).toContain(
+      'isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent)'
+    );
+    expect(source).toContain('pendingSend={pendingSend}');
+  });
+
   it('keeps reply/start-thread draft policy in MindRoom threads', () => {
     const source = readRoomTimelineSource();
     const implementationSource = readFileSync(

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -2339,6 +2339,8 @@ describe('RoomTimeline architecture', () => {
     expect(source).not.toContain('room-thread-cache-persist-paginated');
     expect(controllerSource).toContain('useRoomLiveEventController');
     expect(controllerSource).toContain('useLiveEventArrive');
+    expect(controllerSource).toContain("from './roomLocalEchoRefresh'");
+    expect(controllerSource).toContain('useRoomLocalEchoRefresh');
     expect(controllerSource).toContain('getLiveCollapsibleMessageExpandId');
     expect(controllerSource).toContain('room-thread-cache-persist-paginated');
     expect(subscriptionSource).toContain('useLiveEventArrive');

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -137,7 +137,7 @@ describe('RoomTimeline architecture', () => {
   it('passes pending local echo state from base and edited events into message content', () => {
     const source = readRoomTimelineSource();
 
-    expect(source).toContain("from '../messages/pendingSendIndicator'");
+    expect(source).toContain("from '../messages/pendingLocalEcho'");
     expect(source).toContain(
       'isPendingLocalEchoEvent(mEvent) || isPendingLocalEchoEvent(editedEvent)'
     );

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts
@@ -1257,6 +1257,72 @@ describe('RoomTimeline', () => {
     }
   });
 
+  it('adds pending local-echo replies to an open thread after liveEvent:false dispatch', async () => {
+    const { RoomTimeline } = await import('../../../features/room/RoomTimeline');
+    const threadId = '$thread-root';
+    const rootEvent = makeEvent(threadId, {
+      isThreadRoot: true,
+      ts: 100,
+    });
+    const threadTimeline = makeTimeline([rootEvent]);
+    const room = makeRoom({
+      liveEvents: [rootEvent],
+      threads: [
+        {
+          id: threadId,
+          rootEvent,
+          events: [],
+          timeline: [],
+          getUnfilteredTimelineSet: () => ({
+            getLiveTimeline: () => threadTimeline,
+          }),
+        },
+      ],
+    });
+    const ControlledRoomTimeline = createControlledRoomTimelineHarness(RoomTimeline as never);
+    let renderer: ReturnType<typeof create> | undefined;
+
+    try {
+      await act(async () => {
+        renderer = create(
+          React.createElement(ControlledRoomTimeline, {
+            room,
+            threadId,
+          })
+        );
+        await flushAsyncWork(2);
+      });
+
+      threadRenderStateMock.setSupplementalThreadEvents.mockClear();
+      const pendingReply = makeEvent('~pending-reply', {
+        content: {
+          body: 'Pending thread reply',
+          msgtype: 'm.text',
+        },
+        isSending: true,
+        relation: {
+          event_id: threadId,
+          rel_type: 'm.thread',
+        },
+        threadRootId: threadId,
+        ts: 200,
+      });
+
+      await act(async () => {
+        room.__listeners.get(RoomEvent.Timeline)?.(pendingReply, room, false, false, {
+          liveEvent: false,
+        });
+        await flushAsyncWork(2);
+      });
+
+      expect(threadRenderStateMock.setSupplementalThreadEvents).toHaveBeenCalledWith(threadId, [
+        pendingReply,
+      ]);
+    } finally {
+      renderer?.unmount();
+    }
+  });
+
   it('preserves zero replies for recent standalone roots in the regular timeline thread badge logic', async () => {
     const { getThreadReplyCount, shouldRenderZeroReplyThreadBadge } = await import(
       '../threadBadgeViewModel'

--- a/src/app/mindroom/threads/compactThreadCardViewModel.test.ts
+++ b/src/app/mindroom/threads/compactThreadCardViewModel.test.ts
@@ -1,4 +1,4 @@
-import type { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+import { EventStatus, type MatrixClient, type MatrixEvent } from 'matrix-js-sdk';
 import type { Room } from 'matrix-js-sdk/lib/models/room';
 import { describe, expect, it, vi } from 'vitest';
 import { buildCompactThreadCardViewModelFromRecord } from './compactThreadCardViewModel';
@@ -10,6 +10,7 @@ const makeEvent = ({
   sender,
   body,
   content,
+  status,
   ts = 1000,
 }: {
   eventId: string;
@@ -17,6 +18,7 @@ const makeEvent = ({
   sender?: string;
   body?: string;
   content?: Record<string, unknown>;
+  status?: EventStatus;
   ts?: number;
 }): MatrixEvent =>
   ({
@@ -32,6 +34,7 @@ const makeEvent = ({
     getUnsigned: () => undefined,
     isRedacted: () => false,
     isRedaction: () => false,
+    status,
   } as unknown as MatrixEvent);
 
 const makeRoom = ({
@@ -244,5 +247,71 @@ describe('buildCompactThreadCardViewModelFromRecord', () => {
     expect(model.isResolved).toBe(true);
     expect(model.tags).toEqual(['triage']);
     expect(model.attentionState).toBe('resolved');
+  });
+
+  it('marks compact models pending while a zero-reply root local echo is sending', () => {
+    const rootEvent = makeEvent({
+      eventId: '~root',
+      sender: '@me:server',
+      body: 'Pending root body',
+      status: EventStatus.SENDING,
+    });
+    const room = makeRoom({ rootEvent });
+
+    const model = buildModel(room, {
+      threadRootId: '~root',
+      threadRootEvent: rootEvent,
+      fallbackMessageCount: 0,
+    });
+
+    expect((model as { hasPendingSend?: boolean }).hasPendingSend).toBe(true);
+  });
+
+  it('marks compact models pending while the latest visible reply local echo is sending', () => {
+    const rootEvent = makeEvent({
+      eventId: '$root',
+      sender: '@me:server',
+      body: 'Root body',
+      ts: 1000,
+    });
+    const reply = makeEvent({
+      eventId: '~reply',
+      threadRootId: '$root',
+      sender: '@me:server',
+      body: 'Pending reply body',
+      status: EventStatus.SENDING,
+      ts: 2000,
+    });
+    const thread = {
+      id: '$root',
+      rootEvent,
+      events: [reply],
+      timeline: [reply],
+      lastReply: () => reply,
+      replyToEvent: undefined,
+      getUnfilteredTimelineSet: () => ({
+        getLiveTimeline: () => ({
+          getEvents: () => [rootEvent, reply],
+          getNeighbouringTimeline: () => undefined,
+        }),
+        relations: {
+          getChildEventsForEvent: () => undefined,
+        },
+      }),
+    } as unknown as ReturnType<Room['getThread']>;
+    const room = makeRoom({
+      rootEvent,
+      thread,
+      memberNames: {
+        '@me:server': 'Me',
+      },
+    });
+
+    const model = buildModel(room, {
+      threadRootEvent: rootEvent,
+    });
+
+    expect(model.previewText).toBe('Me: Pending reply body');
+    expect((model as { hasPendingSend?: boolean }).hasPendingSend).toBe(true);
   });
 });

--- a/src/app/mindroom/threads/compactThreadCardViewModel.ts
+++ b/src/app/mindroom/threads/compactThreadCardViewModel.ts
@@ -164,6 +164,7 @@ export const buildCompactThreadCardViewModelFromRecord = ({
     isResolved: status.isResolved,
     isUnread: status.isUnread,
     isStreaming: status.isStreaming,
+    hasPendingSend: status.hasPendingSend === true,
     scheduledDisplayText,
     scheduledTaskLabel,
     lastActivityTs: status.lastActivityTs,

--- a/src/app/mindroom/threads/roomLiveEventController.ts
+++ b/src/app/mindroom/threads/roomLiveEventController.ts
@@ -144,6 +144,14 @@ export const useRoomLiveEventController = ({
         }
 
         if (!timelineMeta.liveEvent) {
+          if (threadId && mEvt.isSending() && isVisibleThreadActivity) {
+            if (relation?.rel_type !== RelationType.Replace) {
+              setSupplementalThreadEvents(threadId, [mEvt]);
+            }
+            setThreadTimelineTick((val) => val + 1);
+            return;
+          }
+
           if (!threadId && threadCacheTargetId) {
             queueRoomThreadCachePersist(mEvt);
             logTimelineDebug(roomDebugTraceId, 'room-thread-cache-persist-paginated', {

--- a/src/app/mindroom/threads/roomLiveEventController.ts
+++ b/src/app/mindroom/threads/roomLiveEventController.ts
@@ -33,6 +33,7 @@ import type {
   ThreadCachePersistenceController,
 } from './threadCachePersistenceController';
 import type { PersistRoomEventCache } from './roomCacheLifecycleController';
+import { useRoomLocalEchoRefresh } from './roomLocalEchoRefresh';
 
 type ScrollToBottomState = {
   count: number;
@@ -84,10 +85,7 @@ export const useRoomLiveEventController = ({
   liveExpandOnceIds: MutableRefObject<Set<string>>;
   mx: MatrixClient;
   normalThreadRecordMap: ReadonlyMap<string, ThreadRecord>;
-  onStoreThreadSummary: (
-    threadRootId: string,
-    info: MindroomThreadSummaryInfo | undefined
-  ) => void;
+  onStoreThreadSummary: (threadRootId: string, info: MindroomThreadSummaryInfo | undefined) => void;
   persistRoomEventCache: PersistRoomEventCache;
   persistThreadCacheFromRoomEvents: ThreadCachePersistenceController['persistThreadCacheFromRoomEvents'];
   persistThreadEventCache: PersistThreadEventCache;
@@ -109,6 +107,13 @@ export const useRoomLiveEventController = ({
   timelineAtLiveEnd: boolean;
   unreadInfo: RoomUnreadInfo;
 }) => {
+  useRoomLocalEchoRefresh(
+    room,
+    useCallback(() => {
+      setTimeline((current) => ({ ...current }));
+    }, [setTimeline])
+  );
+
   useLiveEventArrive(
     room,
     useCallback(
@@ -155,11 +160,7 @@ export const useRoomLiveEventController = ({
           // "0 replies" card never appears until the second arrival. Scoped
           // narrowly to sent-but-not-yet-confirmed standalone roots in the room
           // view, so paginated history and thread-only arrivals are unaffected.
-          if (
-            !threadId &&
-            mEvt.isSending() &&
-            isZeroReplyStandaloneThreadRootEvent(mEvt)
-          ) {
+          if (!threadId && mEvt.isSending() && isZeroReplyStandaloneThreadRootEvent(mEvt)) {
             setTimeline((ct) => ({ ...ct }));
           }
           return;

--- a/src/app/mindroom/threads/roomLocalEchoRefresh.test.ts
+++ b/src/app/mindroom/threads/roomLocalEchoRefresh.test.ts
@@ -1,0 +1,89 @@
+import React from 'react';
+import { RoomEvent, type Room } from 'matrix-js-sdk';
+import { act, create } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { useRoomLocalEchoRefresh } from './roomLocalEchoRefresh';
+
+type MockRoom = {
+  roomId: string;
+  on: (eventName: string, listener: (...args: unknown[]) => void) => void;
+  removeListener: (eventName: string, listener: (...args: unknown[]) => void) => void;
+  emit: (eventName: string, ...args: unknown[]) => void;
+  listenerCount: (eventName: string) => number;
+};
+
+const makeRoom = (roomId = '!room:example.org'): MockRoom => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  return {
+    roomId,
+    on: (eventName: string, listener: (...args: unknown[]) => void) => {
+      const eventListeners = listeners.get(eventName) ?? new Set();
+      eventListeners.add(listener);
+      listeners.set(eventName, eventListeners);
+    },
+    removeListener: (eventName: string, listener: (...args: unknown[]) => void) => {
+      listeners.get(eventName)?.delete(listener);
+    },
+    emit: (eventName: string, ...args: unknown[]) => {
+      listeners.get(eventName)?.forEach((listener) => listener(...args));
+    },
+    listenerCount: (eventName: string) => listeners.get(eventName)?.size ?? 0,
+  };
+};
+
+const LocalEchoHarness = ({ onRefresh, room }: { onRefresh: () => void; room: MockRoom }) => {
+  useRoomLocalEchoRefresh(room as unknown as Room, onRefresh);
+  return null;
+};
+
+describe('useRoomLocalEchoRefresh', () => {
+  it('refreshes when a local echo update belongs to the room', async () => {
+    const room = makeRoom();
+    const onRefresh = vi.fn();
+
+    await act(async () => {
+      create(React.createElement(LocalEchoHarness, { room, onRefresh }));
+    });
+    await act(async () => {
+      room.emit(RoomEvent.LocalEchoUpdated, {}, room);
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores local echo updates for other rooms', async () => {
+    const room = makeRoom('!room:example.org');
+    const otherRoom = makeRoom('!other:example.org');
+    const onRefresh = vi.fn();
+
+    await act(async () => {
+      create(React.createElement(LocalEchoHarness, { room, onRefresh }));
+    });
+    await act(async () => {
+      room.emit(RoomEvent.LocalEchoUpdated, {}, otherRoom);
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('removes the local echo listener on unmount', async () => {
+    const room = makeRoom();
+    const onRefresh = vi.fn();
+    let renderer: ReturnType<typeof create> | undefined;
+
+    await act(async () => {
+      renderer = create(React.createElement(LocalEchoHarness, { room, onRefresh }));
+    });
+    expect(room.listenerCount(RoomEvent.LocalEchoUpdated)).toBe(1);
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+    expect(room.listenerCount(RoomEvent.LocalEchoUpdated)).toBe(0);
+
+    await act(async () => {
+      room.emit(RoomEvent.LocalEchoUpdated, {}, room);
+    });
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/mindroom/threads/roomLocalEchoRefresh.test.ts
+++ b/src/app/mindroom/threads/roomLocalEchoRefresh.test.ts
@@ -51,21 +51,6 @@ describe('useRoomLocalEchoRefresh', () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores local echo updates for other rooms', async () => {
-    const room = makeRoom('!room:example.org');
-    const otherRoom = makeRoom('!other:example.org');
-    const onRefresh = vi.fn();
-
-    await act(async () => {
-      create(React.createElement(LocalEchoHarness, { room, onRefresh }));
-    });
-    await act(async () => {
-      room.emit(RoomEvent.LocalEchoUpdated, {}, otherRoom);
-    });
-
-    expect(onRefresh).not.toHaveBeenCalled();
-  });
-
   it('removes the local echo listener on unmount', async () => {
     const room = makeRoom();
     const onRefresh = vi.fn();

--- a/src/app/mindroom/threads/roomLocalEchoRefresh.ts
+++ b/src/app/mindroom/threads/roomLocalEchoRefresh.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { Room, RoomEvent, RoomEventHandlerMap } from 'matrix-js-sdk';
+
+export const useRoomLocalEchoRefresh = (room: Room, onRefresh: () => void) => {
+  useEffect(() => {
+    const handleLocalEcho: RoomEventHandlerMap[RoomEvent.LocalEchoUpdated] = (
+      _event,
+      eventRoom
+    ) => {
+      if (eventRoom.roomId !== room.roomId) return;
+      onRefresh();
+    };
+
+    room.on(RoomEvent.LocalEchoUpdated, handleLocalEcho);
+    return () => {
+      room.removeListener(RoomEvent.LocalEchoUpdated, handleLocalEcho);
+    };
+  }, [room, onRefresh]);
+};

--- a/src/app/mindroom/threads/roomLocalEchoRefresh.ts
+++ b/src/app/mindroom/threads/roomLocalEchoRefresh.ts
@@ -3,11 +3,7 @@ import { Room, RoomEvent, RoomEventHandlerMap } from 'matrix-js-sdk';
 
 export const useRoomLocalEchoRefresh = (room: Room, onRefresh: () => void) => {
   useEffect(() => {
-    const handleLocalEcho: RoomEventHandlerMap[RoomEvent.LocalEchoUpdated] = (
-      _event,
-      eventRoom
-    ) => {
-      if (eventRoom.roomId !== room.roomId) return;
+    const handleLocalEcho: RoomEventHandlerMap[RoomEvent.LocalEchoUpdated] = () => {
       onRefresh();
     };
 

--- a/src/app/mindroom/threads/threadRecord.ts
+++ b/src/app/mindroom/threads/threadRecord.ts
@@ -20,10 +20,8 @@ import {
   getPreferredVisibleThreadReplyEvents,
   getVisibleThreadParticipantIds,
 } from './threadUtils';
-import {
-  EMPTY_THREAD_SCHEDULED_STATUS,
-  type ThreadScheduledStatus,
-} from './threadScheduledStatus';
+import { EMPTY_THREAD_SCHEDULED_STATUS, type ThreadScheduledStatus } from './threadScheduledStatus';
+import { isPendingLocalEchoEvent } from '../messages/pendingLocalEcho';
 import type { ThreadCacheCoverage, ThreadRecord } from './types';
 
 const THREAD_PARTICIPANT_LIMIT = 3;
@@ -83,6 +81,18 @@ const getLoadedThreadEvents = (thread: ReturnType<Room['getThread']>): MatrixEve
     : thread?.timeline && thread.timeline.length > 0
     ? thread.timeline
     : undefined;
+
+const isPendingThreadEvent = (event: MatrixEvent | undefined): boolean =>
+  isPendingLocalEchoEvent(event) || isPendingLocalEchoEvent(event?.replacingEvent?.());
+
+const getThreadPendingSend = (
+  threadRootEvent: MatrixEvent | undefined,
+  thread: ReturnType<Room['getThread']>
+): boolean => {
+  if (isPendingThreadEvent(threadRootEvent)) return true;
+
+  return getPreferredVisibleThreadReplyEvents(thread).some((event) => isPendingThreadEvent(event));
+};
 
 export const getThreadReplyCount = (
   room: Room,
@@ -296,6 +306,7 @@ export const buildThreadRecord = ({
     (thread && currentUserId ? getThreadUnread(room, thread, currentUserId) : false);
   const isResolved = threadResolution?.isResolved ?? false;
   const isStreaming = getThreadStreamingState(room, threadRootId);
+  const hasPendingSend = getThreadPendingSend(resolvedThreadRootEvent, thread);
 
   return {
     roomId: room.roomId,
@@ -325,6 +336,7 @@ export const buildThreadRecord = ({
       isResolved,
       isUnread,
       isStreaming,
+      hasPendingSend,
       scheduledTaskCount: resolvedScheduledTaskCount,
       nextScheduledTs: resolvedNextScheduledTs,
       lastActivityTs,

--- a/src/app/mindroom/threads/types.ts
+++ b/src/app/mindroom/threads/types.ts
@@ -25,6 +25,7 @@ export type ThreadStatusSnapshot = {
   isResolved: boolean;
   isUnread: boolean;
   isStreaming: boolean;
+  hasPendingSend?: boolean;
   scheduledTaskCount: number;
   nextScheduledTs?: number;
   lastActivityTs?: number;
@@ -80,6 +81,7 @@ export type CompactThreadCardViewModel = {
   isResolved: boolean;
   isUnread: boolean;
   isStreaming: boolean;
+  hasPendingSend?: boolean;
   scheduledDisplayText?: string;
   scheduledTaskLabel?: string;
   lastActivityTs?: number;


### PR DESCRIPTION
## Summary

- Adds a subtle inline clock indicator for Cine messages that are still Matrix local echoes.
- Composes the pending indicator with streaming and edited message suffixes.
- Extends the same indicator to compact MindRoom overview cards and open-thread composer sends while the server has not accepted the message yet.
- Refreshes room/thread timelines on Matrix `RoomEvent.LocalEchoUpdated` so pending state clears after SDK status updates.

## Screenshots

Captured from the actual Cinny app against the local Matrix e2e fixture. The real `/send/m.room.message` request is held pending so the message remains an unresolved Matrix local echo.

### Pending row
![Actual pending row](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/pending-send-row.png)

### Desktop room timeline
![Actual desktop room timeline](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/pending-send-desktop.png)

### Compact pending root card
![Actual compact pending root card](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/compact-pending-root-card.png)

### Compact room overview
![Actual compact room overview](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/compact-pending-root-desktop.png)

### Open thread pending composer
![Actual open thread pending composer](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/thread-pending-reply-composer.png)

### Open thread context
![Actual open thread context](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/thread-pending-reply-desktop.png)

### Mobile room timeline
![Actual mobile room timeline](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/pending-send-mobile.png)

### Mobile pending row
![Actual mobile pending row](https://raw.githubusercontent.com/mindroom-ai/mindroom-cinny/ffd475797c4738ddad7ca331f728e49b87a71f90/docs/pr-assets/pending-send-indicator/pending-send-mobile-row.png)

## Test Plan

- `npm test` (306 files, 2278 tests)
- `npm run typecheck`
- `npm run lint` (0 errors, 18 existing warnings)
- `npm run build`
- `npx prettier --check ...` on Prettier-managed changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “pending send” indicator (muted clock) with accessible status text/tooltip for messages awaiting server acceptance, including combinations with edited and streaming states.
  * Extended pending send UI to thread contexts, including the reply composer and compact thread preview cards.
* **Bug Fixes**
  * Automatically refreshes pending send status when local echoes update, keeping indicators accurate.
* **Documentation**
  * Added the pending send indicator design specification and implementation plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->