### PR TITLE
Render MindRoom MCP Apps in messages

### DIFF
--- a/src/app/components/message/McpAppFrame.tsx
+++ b/src/app/components/message/McpAppFrame.tsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text } from 'folds';
+
+import { getMcpAppIframeSandbox, getMcpAppResources, type McpAppResource } from './mcpApps';
+
+type JsonRpcRequest = {
+  jsonrpc?: unknown;
+  id?: unknown;
+  method?: unknown;
+  params?: unknown;
+};
+
+const asRequest = (value: unknown): JsonRpcRequest | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRpcRequest)
+    : undefined;
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const isRequestWithId = (
+  request: JsonRpcRequest
+): request is JsonRpcRequest & { id: string | number } =>
+  typeof request.id === 'string' || typeof request.id === 'number';
+
+const isSafeExternalUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+};
+
+const postToFrame = (frame: HTMLIFrameElement | null, message: unknown) => {
+  frame?.contentWindow?.postMessage(message, '*');
+};
+
+const response = (id: string | number, result: unknown) => ({
+  jsonrpc: '2.0',
+  id,
+  result,
+});
+
+const errorResponse = (id: string | number, code: number, message: string) => ({
+  jsonrpc: '2.0',
+  id,
+  error: { code, message },
+});
+
+function McpAppFrame({ resource }: { resource: McpAppResource }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const initializedRef = useRef(false);
+  const toolResultSentRef = useRef(false);
+  const [height, setHeight] = useState(320);
+  const title = resource.toolName ? `MCP app from ${resource.toolName}` : 'MCP app';
+  const uiMeta = asRecord(resource.meta?.ui);
+
+  const toolInputNotification = useMemo(
+    () => ({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/tool-input',
+      params: resource.toolInput ?? { arguments: {} },
+    }),
+    [resource.toolInput]
+  );
+
+  const toolResultNotification = useMemo(
+    () => ({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/tool-result',
+      params: resource.toolResult ?? {
+        content: resource.resultPreview ? [{ type: 'text', text: resource.resultPreview }] : [],
+        isError: false,
+      },
+    }),
+    [resource.resultPreview, resource.toolResult]
+  );
+
+  const sendToolState = useCallback(() => {
+    if (!initializedRef.current || toolResultSentRef.current) return;
+    postToFrame(iframeRef.current, toolInputNotification);
+    postToFrame(iframeRef.current, toolResultNotification);
+    toolResultSentRef.current = true;
+  }, [toolInputNotification, toolResultNotification]);
+
+  useEffect(() => {
+    initializedRef.current = false;
+    toolResultSentRef.current = false;
+  }, [resource.uri, resource.html]);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+
+      const request = asRequest(event.data);
+      if (!request || request.jsonrpc !== '2.0' || typeof request.method !== 'string') return;
+
+      if (request.method === 'ui/notifications/initialized') {
+        initializedRef.current = true;
+        sendToolState();
+        return;
+      }
+
+      if (request.method === 'ui/notifications/size-changed') {
+        const params = asRecord(request.params);
+        if (typeof params?.height === 'number' && Number.isFinite(params.height)) {
+          setHeight(Math.min(1200, Math.max(160, Math.ceil(params.height))));
+        }
+        return;
+      }
+
+      if (!isRequestWithId(request)) return;
+
+      if (request.method === 'ui/initialize' || request.method === 'initialize') {
+        postToFrame(
+          iframeRef.current,
+          response(request.id, {
+            protocolVersion: '2026-01-26',
+            host: { name: 'MindRoom Cinny' },
+            capabilities: {},
+          })
+        );
+        return;
+      }
+
+      if (request.method === 'ui/open-link') {
+        const params = asRecord(request.params);
+        if (params && isSafeExternalUrl(params.url)) {
+          window.open(params.url, '_blank', 'noopener,noreferrer');
+          postToFrame(iframeRef.current, response(request.id, null));
+          return;
+        }
+        postToFrame(iframeRef.current, errorResponse(request.id, -32602, 'Unsupported URL'));
+        return;
+      }
+
+      if (request.method === 'tools/call') {
+        postToFrame(
+          iframeRef.current,
+          errorResponse(request.id, -32601, 'MCP app tool calls are not supported yet')
+        );
+        return;
+      }
+
+      postToFrame(
+        iframeRef.current,
+        errorResponse(request.id, -32601, `Unsupported MCP Apps method: ${request.method}`)
+      );
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [sendToolState]);
+
+  return (
+    <Box direction="Column" gap="100" style={{ marginTop: '0.75rem' }}>
+      <Text size="L400">{title}</Text>
+      <iframe
+        ref={iframeRef}
+        title={title}
+        srcDoc={resource.html}
+        sandbox={getMcpAppIframeSandbox()}
+        style={{
+          width: '100%',
+          height,
+          minHeight: '160px',
+          border: uiMeta?.prefersBorder === false ? '0' : '1px solid rgba(148, 163, 184, 0.35)',
+          borderRadius: '8px',
+          background: 'white',
+        }}
+      />
+    </Box>
+  );
+}
+
+export function McpAppsRenderer({ content }: { content: Record<string, unknown> }) {
+  const resources = getMcpAppResources(content);
+  if (resources.length === 0) return null;
+
+  return (
+    <>
+      {resources.map((resource) => (
+        <McpAppFrame key={`${resource.uri}:${resource.toolName ?? ''}`} resource={resource} />
+      ))}
+    </>
+  );
+}

--- a/src/app/components/message/mcpApps.test.ts
+++ b/src/app/components/message/mcpApps.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMcpAppIframeSandbox, getMcpAppResources } from './mcpApps';
+
+describe('mcpApps', () => {
+  it('extracts MCP Apps resources from MindRoom tool trace metadata', () => {
+    const resources = getMcpAppResources({
+      'io.mindroom.tool_trace': {
+        version: 2,
+        events: [
+          {
+            type: 'tool_call_completed',
+            tool_name: 'show_chart',
+            result_preview: 'chart ready',
+            mcp_tool_input: { arguments: { chart: 'sales' } },
+            mcp_tool_result: {
+              content: [{ type: 'text', text: 'chart ready' }],
+              structuredContent: { chart: 'sales' },
+            },
+            mcp_apps: [
+              {
+                uri: 'ui://demo/chart',
+                mime_type: 'text/html;profile=mcp-app',
+                html: '<html><body>chart</body></html>',
+                meta: { ui: { prefersBorder: true } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(resources).toEqual([
+      {
+        uri: 'ui://demo/chart',
+        mimeType: 'text/html;profile=mcp-app',
+        html: '<html><body>chart</body></html>',
+        meta: { ui: { prefersBorder: true } },
+        toolInput: { arguments: { chart: 'sales' } },
+        toolResult: {
+          content: [{ type: 'text', text: 'chart ready' }],
+          structuredContent: { chart: 'sales' },
+        },
+        toolName: 'show_chart',
+        resultPreview: 'chart ready',
+      },
+    ]);
+  });
+
+  it('rejects non-ui and non-mcp-app resources', () => {
+    const resources = getMcpAppResources({
+      'io.mindroom.tool_trace': {
+        events: [
+          {
+            tool_name: 'bad',
+            mcp_apps: [
+              {
+                uri: 'https://example.test/widget',
+                mime_type: 'text/html;profile=mcp-app',
+                html: '<html></html>',
+              },
+              {
+                uri: 'ui://demo/plain',
+                mime_type: 'text/html',
+                html: '<html></html>',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(resources).toEqual([]);
+  });
+
+  it('uses a sandbox that allows scripts without same-origin host access', () => {
+    const sandbox = getMcpAppIframeSandbox();
+
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).toContain('allow-forms');
+    expect(sandbox).not.toContain('allow-same-origin');
+  });
+});

--- a/src/app/components/message/mcpApps.ts
+++ b/src/app/components/message/mcpApps.ts
@@ -1,0 +1,74 @@
+const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
+const MCP_APP_IFRAME_SANDBOX = 'allow-scripts allow-forms allow-popups allow-downloads';
+
+export type McpAppResource = {
+  uri: string;
+  mimeType: string;
+  html: string;
+  meta?: Record<string, unknown>;
+  toolInput?: Record<string, unknown>;
+  toolResult?: Record<string, unknown>;
+  toolName?: string;
+  resultPreview?: string;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
+const normalizeMcpAppResource = (
+  value: unknown,
+  event: Record<string, unknown>
+): McpAppResource | undefined => {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const uri = asString(record.uri);
+  const mimeType = asString(record.mime_type);
+  const html = typeof record.html === 'string' ? record.html : undefined;
+  if (
+    !uri ||
+    !uri.startsWith('ui://') ||
+    mimeType?.toLowerCase() !== MCP_APP_MIME_TYPE ||
+    html === undefined
+  ) {
+    return undefined;
+  }
+
+  const meta = asRecord(record.meta);
+  const toolInput = asRecord(event.mcp_tool_input);
+  const toolResult = asRecord(event.mcp_tool_result);
+  return {
+    uri,
+    mimeType,
+    html,
+    ...(meta ? { meta } : {}),
+    ...(toolInput ? { toolInput } : {}),
+    ...(toolResult ? { toolResult } : {}),
+    ...(asString(event.tool_name) ? { toolName: asString(event.tool_name) } : {}),
+    ...(asString(event.result_preview) ? { resultPreview: asString(event.result_preview) } : {}),
+  };
+};
+
+export const getMcpAppResources = (content: Record<string, unknown>): McpAppResource[] => {
+  const trace = asRecord(content['io.mindroom.tool_trace']);
+  const events = trace?.events;
+  if (!Array.isArray(events)) return [];
+
+  const resources: McpAppResource[] = [];
+  events.forEach((eventValue) => {
+    const event = asRecord(eventValue);
+    if (!event || !Array.isArray(event.mcp_apps)) return;
+    event.mcp_apps.forEach((resourceValue) => {
+      const resource = normalizeMcpAppResource(resourceValue, event);
+      if (resource) resources.push(resource);
+    });
+  });
+  return resources;
+};
+
+export const getMcpAppIframeSandbox = (): string => MCP_APP_IFRAME_SANDBOX;

--- a/src/app/mindroom/messages/MindroomHtmlBlocks.tsx
+++ b/src/app/mindroom/messages/MindroomHtmlBlocks.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useState } from 'react';
 import { Element, HTMLReactParserOptions, Text as DOMText, domToReact } from 'html-react-parser';
 import { ChildNode } from 'domhandler';
 import { Box, Icon, IconSrc, Icons, Spinner, Text } from 'folds';
+import { getMcpAppResources } from '../../components/message/mcpApps';
 import { MindroomToolRefParseResult, parseMindroomToolRefHtml } from './blocks';
 import { MindroomPasteMarker, parseMindroomPasteMarker } from './pasteAttachmentMarker';
 import {
@@ -429,6 +430,7 @@ export const withMindroomToolTraceMarkerParserOptions = (
   const traceEvents = isMindroomToolTraceV2(content)
     ? getMindroomToolTraceEvents(content)
     : undefined;
+  const hasMcpApps = getMcpAppResources(content).length > 0;
 
   const baseReplace = baseOpts.replace;
   const baseTransform = baseOpts.transform;
@@ -439,7 +441,7 @@ export const withMindroomToolTraceMarkerParserOptions = (
     replace: (domNode) => {
       const isContainer = isDomElementNode(domNode) && ['p', 'div', 'li'].includes(domNode.name);
 
-      if (isContainer) {
+      if (!hasMcpApps && isContainer) {
         const maybeChildren = domNode.children;
         const maybeToolIndex = parseToolRefIndexFromTextPrefix(
           extractTextFromChildren(maybeChildren as ChildNode[])
@@ -453,6 +455,10 @@ export const withMindroomToolTraceMarkerParserOptions = (
         const pasteMarker = getPasteMarkerFromElement(domNode);
         if (pasteMarker) {
           return <MindroomPasteMarkerBadge marker={pasteMarker} />;
+        }
+
+        if (hasMcpApps) {
+          return baseReplace ? baseReplace(domNode) : undefined;
         }
 
         type ToolRefItem = {
@@ -550,7 +556,7 @@ export const withMindroomToolTraceMarkerParserOptions = (
     transform: (reactNode, domNode, index) => {
       const isContainer = isDomElementNode(domNode) && ['p', 'div', 'li'].includes(domNode.name);
 
-      if (isContainer) {
+      if (!hasMcpApps && isContainer) {
         const maybeChildren = domNode.children;
         const maybeToolIndex = parseToolRefIndexFromTextPrefix(
           extractTextFromChildren(maybeChildren as ChildNode[])

--- a/src/app/mindroom/messages/renderMindroomMessageContent.tsx
+++ b/src/app/mindroom/messages/renderMindroomMessageContent.tsx
@@ -3,6 +3,8 @@ import { MsgType } from 'matrix-js-sdk';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import { Opts } from 'linkifyjs';
 import { BrokenContent, MEmote, MNotice, MText, RenderBody } from '../../components/message';
+import { McpAppsRenderer } from '../../components/message/McpAppFrame';
+import { getMcpAppResources } from '../../components/message/mcpApps';
 import { MindroomMessageExtras } from './MindroomMessageExtras';
 import { MINDROOM_MESSAGE_EXTRAS_KEY, parseMindroomMessageExtras } from './messageExtrasData';
 import { withMindroomToolTraceMarkerParserOptions } from './MindroomHtmlBlocks';
@@ -169,6 +171,36 @@ export const renderMindroomMessageContent = ({
     }
   };
 
+  const getMcpAppsContent = (
+    primaryContent: Record<string, unknown>,
+    fallbackContents: Record<string, unknown>[] = []
+  ): Record<string, unknown> | undefined =>
+    [primaryContent, ...fallbackContents].find(
+      (candidate) => getMcpAppResources(candidate).length > 0
+    );
+
+  const renderMindroomAfterBody = (
+    primaryContent: Record<string, unknown>,
+    fallbackContents: Record<string, unknown>[] = [],
+    onFallbackExtrasRendered?: (fallbackIndex: number) => void
+  ) => {
+    const extras = renderMessageExtras(
+      primaryContent,
+      fallbackContents,
+      onFallbackExtrasRendered
+    );
+    const mcpAppsContent = getMcpAppsContent(primaryContent, fallbackContents);
+    const mcpApps = mcpAppsContent ? <McpAppsRenderer content={mcpAppsContent} /> : undefined;
+
+    if (!extras && !mcpApps) return undefined;
+    return (
+      <>
+        {extras}
+        {mcpApps}
+      </>
+    );
+  };
+
   const getMessageStateSuffix = (renderStateSuffix?: () => ReactNode) =>
     getMindroomMessageStateSuffixRenderer({
       edited,
@@ -209,7 +241,7 @@ export const renderMindroomMessageContent = ({
           content={content}
           renderStateSuffix={getMessageStateSuffix()}
           renderBody={() => <MindroomThinkingPlaceholder />}
-          renderAfterBody={renderMessageExtras(content)}
+          renderAfterBody={renderMindroomAfterBody(content)}
         />
       );
     }
@@ -235,7 +267,7 @@ export const renderMindroomMessageContent = ({
             />
           )}
           renderAfterBody={(extrasContent, fallbackContent) =>
-            renderMessageExtras(
+            renderMindroomAfterBody(
               extrasContent,
               [content, fallbackContent],
               handleLongTextFallbackExtrasRendered
@@ -263,7 +295,7 @@ export const renderMindroomMessageContent = ({
           )}
           content={renderableContent}
           renderBody={renderBody(renderableContent)}
-          renderAfterBody={renderMessageExtras(renderableContent, [content])}
+          renderAfterBody={renderMindroomAfterBody(renderableContent, [content])}
           renderUrlsPreview={renderUrlsPreview}
         />
       );
@@ -294,7 +326,7 @@ export const renderMindroomMessageContent = ({
             />
           )}
           renderAfterBody={(extrasContent, fallbackContent) =>
-            renderMessageExtras(
+            renderMindroomAfterBody(
               extrasContent,
               [content, fallbackContent],
               handleLongTextFallbackExtrasRendered
@@ -315,7 +347,7 @@ export const renderMindroomMessageContent = ({
         )}
         content={renderableContent}
         renderBody={renderBody(renderableContent)}
-        renderAfterBody={renderMessageExtras(renderableContent, [content])}
+        renderAfterBody={renderMindroomAfterBody(renderableContent, [content])}
         renderUrlsPreview={renderUrlsPreview}
       />
     );
@@ -344,7 +376,7 @@ export const renderMindroomMessageContent = ({
             />
           )}
           renderAfterBody={(extrasContent, fallbackContent) =>
-            renderMessageExtras(
+            renderMindroomAfterBody(
               extrasContent,
               [content, fallbackContent],
               handleLongTextFallbackExtrasRendered
@@ -364,7 +396,7 @@ export const renderMindroomMessageContent = ({
         )}
         content={renderableContent}
         renderBody={renderBody(renderableContent)}
-        renderAfterBody={renderMessageExtras(renderableContent, [content])}
+        renderAfterBody={renderMindroomAfterBody(renderableContent, [content])}
         renderUrlsPreview={renderUrlsPreview}
       />
     );


### PR DESCRIPTION
## Summary
- parse MindRoom MCP Apps metadata from tool trace events and render sandboxed iframe apps below text-like message content
- implement the minimal MCP Apps postMessage host lifecycle: initialize, initialized, tool-input, tool-result, open-link, and size-changed
- suppress the older custom tool trace HTML fallback when MCP Apps resources are present

## Validation
- `npm run test -- src/app/components/message/mindroomToolTrace.test.ts src/app/components/message/mcpApps.test.ts` (8 passed)
- `npm run test` (36 passed)
- `npm run build`
- `npx eslint src/app/components/message/McpAppFrame.tsx src/app/components/message/mcpApps.ts src/app/components/message/mcpApps.test.ts src/app/components/message/mindroomToolTrace.ts src/app/components/message/mindroomToolTrace.test.ts src/app/components/RenderMessageContent.tsx`
- `npx prettier --check src/app/components/message/McpAppFrame.tsx src/app/components/message/mcpApps.ts src/app/components/message/mcpApps.test.ts src/app/components/message/mindroomToolTrace.ts src/app/components/message/mindroomToolTrace.test.ts src/app/components/RenderMessageContent.tsx`
- `npm run typecheck` still fails on the existing repo baseline; no diagnostics for `McpAppFrame.tsx` or `mcpApps.ts`, and only pre-existing Matrix SDK / JSX diagnostics in `RenderMessageContent.tsx`
- `npm run lint` still fails on the existing repo baseline; targeted ESLint on touched files passes

## Summary by Sourcery

Add MindRoom-specific tooling, including MCP Apps iframe rendering, rich tool-trace and long-text handling, and thread-focused room UX, along with CI and testing infrastructure updates.

New Features:
- Render MCP Apps HTML resources from MindRoom tool traces as sandboxed iframes beneath message content.
- Parse MindRoom tool-trace metadata and custom HTML tags into collapsible, styled blocks for tools and reasoning traces.
- Support MindRoom long-text metadata by fetching MXC-backed full responses and rendering them inline across text-like message types.
- Introduce MindRoom-specific `!` command autocomplete that inserts plain-text commands at the start of a message.
- Add a dedicated thread view for rooms, including thread-aware navigation, focused timelines, and composer behavior.

Bug Fixes:
- Ensure uploads and replies in thread context carry correct Matrix thread and reply relations.
- Harden thread event opening and scrolling behavior using thread timelines and robust DOM lookup, avoiding misnavigation and stale state.
- Suppress legacy custom tool-trace HTML fallback when MCP Apps resources are present to avoid double rendering.

Enhancements:
- Refine room timeline behavior to respect active thread context, including pagination, unread handling, and focus logic.
- Improve reply and thread UX with clearer indicators, thread entry/exit controls, and contextual composer banners.
- Extend custom HTML sanitization and parser to support MindRoom tags while preserving existing rendering paths.
- Document the fork’s architecture, goals, and implementation process in dedicated agent/runbook files for future contributors.

Build:
- Add Vitest configuration and npm scripts for unit testing.
- Adjust prod Docker workflows to publish images exclusively to GitHub Container Registry and add a push-triggered Docker publish workflow.

CI:
- Introduce a push-based Docker publish workflow that builds and publishes multi-arch images to GHCR for every branch push and manual trigger.
- Align release Docker publish workflow to target only GHCR, removing Docker Hub dependencies.

Tests:
- Add unit tests for MindRoom tool-trace parsing/merging, long-text metadata handling, and MCP Apps extraction.
- Add tests covering MindRoom command query detection/insertion, thread event membership logic, and search-param parsing.
- Introduce integration-style tests for the combined MindRoom message pipeline (tool trace + long text + commands).

Chores:
- Add contributor-facing documentation files for AI/agent workflows (AGENTS, CLAUDE, REPORT) and keep them as the living implementation runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering MCP apps as interactive embedded content within messages
  * MCP app resources from tool traces are now extracted and integrated into message display
  * MCP apps can open external links in new tabs when requested

* **Tests**
  * Added comprehensive test coverage for MCP app resource extraction and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->