### PR TITLE
Hide thread-only composer helper

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,35 @@
 
 ## Runbook
 
+### CINNY-207 - Hide thread-only composer helper in thread view (2026-06-17)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Removed the redundant `Sending to this thread` composer text when the room
+    input is already scoped to an open thread view.
+  - Kept explicit reply-draft context and the submit-pending clock visible.
+- Decisions:
+  - Treat `threadId` as send-target state, not as a reason to render visible
+    composer text by itself.
+- Validation:
+  - Green focused check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (3 files, 135 tests, after rebase onto `origin/dev` at `3c2ff596`).
+  - PR review follow-up: removed the dead `threadId` prop from
+    `MindroomRoomInputReplyContextProps`, removed the matching dead unit-test
+    argument, and added a RoomInput regression test proving a static
+    thread-scoped composer renders no helper context.
+  - PR review follow-up green focused check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (3 files, 136 tests).
+  - PR review follow-up green: `npm run typecheck`, `npm test` (306 files,
+    2279 tests), `npm run lint` (18 existing warnings), `npm run build`
+    (existing Vite warnings), and `git diff --check`.
+  - PR review follow-up green: `npx prettier --check FORK_CHANGES.md`.
+    Prettier still flags the legacy room-input files at `HEAD`, so those were
+    left unformatted to avoid unrelated churn.
+
 ### CINNY-132 - Pending local echo send indicator (2026-06-13)
 
 - Status:

--- a/src/app/mindroom/room-input/MindroomRoomInput.tsx
+++ b/src/app/mindroom/room-input/MindroomRoomInput.tsx
@@ -1236,14 +1236,16 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           onKeyUp={handleKeyUp}
           onPaste={handlePaste}
           top={
-            (replyDraft || threadId || voiceRecorderOpen || ownsPendingVoiceDraft) && (
+            (replyDraft ||
+              (!!threadId && submitPending) ||
+              voiceRecorderOpen ||
+              ownsPendingVoiceDraft) && (
               <div>
-                {(replyDraft || threadId) && (
+                {(replyDraft || (!!threadId && submitPending)) && (
                   <MindroomRoomInputReplyContext
                     room={room}
                     relation={replyDraft?.relation}
                     pendingSend={!!threadId && submitPending}
-                    threadId={threadId}
                     leading={
                       replyDraft && (
                         <IconButton

--- a/src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts
+++ b/src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts
@@ -98,7 +98,7 @@ describe('RoomInputMindroomExtensions', () => {
     ).not.toBeNull();
   });
 
-  it('renders the composer context only for replies or active thread sends', () => {
+  it('renders the composer context only for replies or pending sends', () => {
     expect(
       MindroomRoomInputReplyContext({
         room: {} as never,
@@ -108,9 +108,9 @@ describe('RoomInputMindroomExtensions', () => {
 
     expect(
       MindroomRoomInputReplyContext({
+        pendingSend: true,
         room: {} as never,
         relation: undefined,
-        threadId: '$thread',
       })
     ).not.toBeNull();
 

--- a/src/app/mindroom/room-input/RoomInputMindroomExtensions.tsx
+++ b/src/app/mindroom/room-input/RoomInputMindroomExtensions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MatrixClient, RelationType, Room } from 'matrix-js-sdk';
 import { BaseRange, Descendant, Editor, Element, Transforms } from 'slate';
-import { Box, Text, config } from 'folds';
+import { Box, config } from 'folds';
 import { Membership } from '../../../types/matrix/room';
 import type { AutocompleteQuery } from '../../components/editor/autocomplete/autocompleteQuery';
 import type { PasteMarkerElement } from '../../components/editor/slate';
@@ -55,7 +55,6 @@ type MindroomRoomInputReplyContextProps = {
   pendingSend?: boolean;
   relation: IReplyDraft['relation'] | undefined;
   room: Room;
-  threadId?: string;
 };
 
 export const getMindroomRoomInputAutocompleteQuery = (
@@ -231,9 +230,8 @@ export function MindroomRoomInputReplyContext({
   pendingSend,
   relation,
   room,
-  threadId,
 }: MindroomRoomInputReplyContextProps) {
-  if (!leading && !children && !threadId) return null;
+  if (!leading && !children && !pendingSend) return null;
 
   return (
     <Box
@@ -244,11 +242,7 @@ export function MindroomRoomInputReplyContext({
       {leading}
       <Box direction="Row" gap="200" alignItems="Center">
         <MindroomRoomInputThreadIndicator room={room} relation={relation} />
-        {children ?? (
-          <Text size="T300" priority="300">
-            Sending to this thread
-          </Text>
-        )}
+        {children}
         {pendingSend && <PendingSendIndicator />}
       </Box>
     </Box>

--- a/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
+++ b/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
@@ -58,6 +58,7 @@ const {
           onKeyUp?: (evt: { key: string; preventDefault: () => void }) => void;
         }
       | undefined,
+    replyContextRenderCount: 0,
   },
   editorOutputState: {
     plainText: '',
@@ -559,11 +560,12 @@ vi.mock('../RoomInputMindroomExtensions', async () => {
     }: {
       children?: React.ReactNode;
       pendingSend?: boolean;
-    }) =>
-      React.createElement(
+    }) => {
+      customEditorState.replyContextRenderCount += 1;
+      return React.createElement(
         'div',
         null,
-        children ?? 'Sending to this thread',
+        children,
         pendingSend
           ? React.createElement(
               'span',
@@ -574,7 +576,8 @@ vi.mock('../RoomInputMindroomExtensions', async () => {
               'Message sending'
             )
           : null
-      ),
+      );
+    },
     MindroomVoiceRecorderComposer: ({
       onSendRecording,
       getSendContext,
@@ -765,6 +768,7 @@ afterEach(() => {
   customEditorState.autocompleteQuery = undefined;
   customEditorState.editor = undefined;
   customEditorState.props = undefined;
+  customEditorState.replyContextRenderCount = 0;
   editorOutputState.plainText = '';
   editorOutputState.customHtml = '';
   editorOutputState.htmlEqualsPlainText = true;
@@ -1185,6 +1189,7 @@ describe('RoomInput', () => {
 
     expect(JSON.stringify(renderer.toJSON())).toContain('Message sending');
     expect(JSON.stringify(renderer.toJSON())).toContain('Waiting for server');
+    expect(JSON.stringify(renderer.toJSON())).not.toContain('Sending to this thread');
 
     await act(async () => {
       send.resolve({ event_id: '$sent' });
@@ -1192,6 +1197,15 @@ describe('RoomInput', () => {
     });
 
     expect(JSON.stringify(renderer.toJSON())).not.toContain('Message sending');
+
+    renderer.unmount();
+  });
+
+  it('does not render thread helper context for static thread composers', async () => {
+    const { renderer } = await renderRoomInput(createStore(), { threadId: '$thread' });
+
+    expect(customEditorState.replyContextRenderCount).toBe(0);
+    expect(JSON.stringify(renderer.toJSON())).not.toContain('Sending to this thread');
 
     renderer.unmount();
   });

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts
@@ -569,7 +569,7 @@ describe('RoomTimeline architecture', () => {
     expect(roomInputExtensionsSource).toContain("from '../commands/MindroomCommandAutocomplete'");
     expect(roomInputExtensionsSource).toContain("from '../voice/VoiceRecorderDialog'");
     expect(roomInputExtensionsSource).toContain('MindroomRoomInputReplyContext');
-    expect(roomInputExtensionsSource).toContain('Sending to this thread');
+    expect(roomInputExtensionsSource).not.toContain('Sending to this thread');
     expect(roomInputExtensionsSource).toContain(
       "from '../threads/useRoomInputSendSessionController'"
     );


### PR DESCRIPTION
## Summary
- remove the redundant "Sending to this thread" text when the composer is already scoped to a thread
- keep explicit reply-draft context visible in thread view
- preserve the pending-send clock for unresolved thread sends without showing the helper text

## Validation
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/room-input/RoomInputMindroomExtensions.test.ts src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts` (3 files, 135 tests)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`
- `git diff --check`

Additional pre-shrink validation on the same behavior after rebase:
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test` (306 files, 2278 tests)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run lint` (18 existing warnings, 0 errors)
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build` (existing Vite warnings)
