### PR TITLE
Fix compact thread unread receipts

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -88,6 +88,34 @@
     class).
   - Rebase green:
     `npx prettier --check FORK_CHANGES.md src/app/mindroom/threads/roomThreadList.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/threadRecord.ts src/app/mindroom/threads/threadRecord.test.ts`.
+  - PR review follow-up: addressed Sourcery/Gemini/Greptile inline comments by
+    removing the unreachable `undefined` unread guard, replacing the receipt
+    candidate array copy with direct event lookup, and documenting the
+    paginated-out receipt fallback.
+  - PR review green focused check:
+    `npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts`
+    (2 files, 18 tests).
+  - PR review green: `npm run typecheck`.
+  - PR review green: `npm run lint` (18 warnings, 0 errors - existing warning
+    class).
+  - PR review green: `npm test` (306 files, 2280 tests).
+  - PR review green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+  - PR review green:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/threads/roomThreadList.ts src/app/mindroom/threads/threadRecord.ts`.
+  - PR review green: `git diff --check`.
+  - Latest rebase check: rebased onto `origin/dev` at `38cb0a4d` after
+    `CINNY-207`; resolved the `FORK_CHANGES.md` conflict by preserving both
+    runbook entries.
+  - Latest rebase green focused check:
+    `npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/compactThreadCardViewModel.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.architecture.test.ts`
+    (4 files, 118 tests).
+  - Latest rebase green: `npm run typecheck`.
+  - Latest rebase green: `npm run lint` (18 warnings, 0 errors - existing
+    warning class).
+  - Latest rebase green: `npm test` (306 files, 2281 tests).
+  - Latest rebase green: `npm run build` (existing Vite runtime-config,
+    sourcemap, localStorage, and chunk-size warnings only).
 
 ### CINNY-132 - Pending local echo send indicator (2026-06-13)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -31,6 +31,64 @@
     Prettier still flags the legacy room-input files at `HEAD`, so those were
     left unformatted to avoid unrelated churn.
 
+### CINNY-133 - Compact thread unread clears from thread receipts (2026-06-17)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Investigated compact thread cards staying unread after opening an unread
+    thread.
+  - Root cause: compact/thread-list unread status compared the latest visible
+    reply against the room-level read marker only. Opening a thread sends a
+    thread-scoped read receipt via `markThreadAsRead`, so the compact card could
+    stay unread until another action, such as resolve/unresolve, caused a
+    room-level receipt or refresh path to move.
+  - Thread unread calculations now use the newest available read timestamp from
+    the thread-scoped receipt and the room-level receipt. Room receipts still
+    work as a fallback for whole-room mark-read flows.
+- Files changed:
+  - `FORK_CHANGES.md`
+  - `src/app/mindroom/threads/roomThreadList.ts`
+  - `src/app/mindroom/threads/roomThreadList.test.ts`
+  - `src/app/mindroom/threads/threadRecord.ts`
+  - `src/app/mindroom/threads/threadRecord.test.ts`
+- Validation:
+  - Red check:
+    `npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts`
+    failed because both compact record and thread-list unread helpers ignored
+    the thread-scoped receipt.
+  - Green focused check:
+    `npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts`
+    (2 files, 18 tests).
+  - Green broader thread check:
+    `npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/threadIndexRecords.test.ts src/app/mindroom/threads/compactThreadCardViewModel.test.ts src/app/mindroom/threads/ThreadIndicator.test.ts src/app/mindroom/threads/useMindroomThreadIndex.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts`
+    (7 files, 109 tests).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/threads/roomThreadList.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/threadRecord.ts src/app/mindroom/threads/threadRecord.test.ts`.
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (18 warnings, 0 errors - existing warning class).
+  - Green: `npm test` (302 files, 2253 tests).
+  - Green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+  - Green: `git diff --check`.
+  - Independent review: separate subagent review found no blocking issues; it
+    suggested optional extra coverage for hidden metadata receipt targets, but
+    assessed the helper behavior as sound and ready.
+  - Dependency sync: `npm ci` restored local `node_modules`; npm reported 27
+    audit findings in existing dependencies.
+  - Rebase check: rebased onto `origin/dev` at `3c2ff596` after the pending
+    local echo send indicator landed; resolved conflicts by preserving pending
+    send state in `threadRecord.ts` and renumbering this entry to CINNY-133.
+  - Rebase green focused check:
+    `npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/compactThreadCardViewModel.test.ts`
+    (3 files, 24 tests).
+  - Rebase green: `npm test` (306 files, 2280 tests).
+  - Rebase green: `npm run typecheck`.
+  - Rebase green: `npm run lint` (18 warnings, 0 errors - existing warning
+    class).
+  - Rebase green:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/threads/roomThreadList.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/threadRecord.ts src/app/mindroom/threads/threadRecord.test.ts`.
+
 ### CINNY-132 - Pending local echo send indicator (2026-06-13)
 
 - Status:

--- a/src/app/mindroom/threads/roomThreadList.test.ts
+++ b/src/app/mindroom/threads/roomThreadList.test.ts
@@ -231,6 +231,22 @@ describe('thread visibility helpers', () => {
 
     expect(getThreadUnread(room as never, thread, '@self:example.org')).toBe(false);
   });
+
+  it('uses the thread-scoped read receipt before falling back to the room read marker', () => {
+    const visibleReply = makeThreadReplyEvent('$reply-visible', 300, '@other:example.org');
+    const room = {
+      getEventReadUpTo: vi.fn(() => '$room-read'),
+      findEventById: vi.fn(() => ({ getTs: () => 100 })),
+    };
+    const thread = {
+      events: [visibleReply],
+      getEventReadUpTo: vi.fn(() => '$reply-visible'),
+      replyToEvent: undefined,
+      rootEvent: { getTs: () => 50 },
+    } as never;
+
+    expect(getThreadUnread(room as never, thread, '@self:example.org')).toBe(false);
+  });
 });
 
 describe('roomThreadListIsComplete', () => {

--- a/src/app/mindroom/threads/roomThreadList.ts
+++ b/src/app/mindroom/threads/roomThreadList.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import { Direction } from 'matrix-js-sdk/lib/models/event-timeline';
+import type { MatrixEvent } from 'matrix-js-sdk';
 import type { Room } from 'matrix-js-sdk/lib/models/room';
 import { Thread } from 'matrix-js-sdk/lib/models/thread';
 import { isVisibleThreadReplyEvent } from './threadUtils';
@@ -11,30 +12,59 @@ const getLatestVisibleReply = (thread: Thread) =>
     ? thread.replyToEvent
     : undefined);
 
+const getThreadReceiptCandidates = (thread: Thread): MatrixEvent[] => {
+  const candidates = [...(thread.events ?? [])];
+  if (thread.replyToEvent) candidates.push(thread.replyToEvent);
+  if (thread.rootEvent) candidates.push(thread.rootEvent);
+  return candidates;
+};
+
+export const getThreadReadUpToTs = (
+  thread: Thread | null | undefined,
+  userId: string | undefined
+): number | undefined => {
+  if (!thread || !userId || typeof thread.getEventReadUpTo !== 'function') return undefined;
+
+  const readUpToId = thread.getEventReadUpTo(userId);
+  if (!readUpToId) return undefined;
+
+  return getThreadReceiptCandidates(thread)
+    .find((event) => event.getId() === readUpToId)
+    ?.getTs();
+};
+
+export const getEffectiveThreadReadUpToTs = (
+  thread: Thread | null | undefined,
+  userId: string | undefined,
+  roomReadUpToTs: number | null | undefined
+): number | null | undefined => {
+  const threadReadUpToTs = getThreadReadUpToTs(thread, userId);
+  if (threadReadUpToTs === undefined) return roomReadUpToTs;
+  if (typeof roomReadUpToTs !== 'number') return threadReadUpToTs;
+  return Math.max(threadReadUpToTs, roomReadUpToTs);
+};
+
 export const getThreadLastActivityTs = (thread: Thread): number =>
   getLatestVisibleReply(thread)?.getTs() ?? thread.rootEvent?.getTs() ?? 0;
 
 /**
  * Check if a single thread has unread messages.
  * A thread is unread when its latest reply is from another user
- * and is newer than the room-level read receipt.
+ * and is newer than both the thread-scoped and room-level read receipts.
  */
-export const getThreadUnread = (
-  room: Room,
-  thread: Thread,
-  userId: string
-): boolean => {
+export const getThreadUnread = (room: Room, thread: Thread, userId: string): boolean => {
   const latestReply = getLatestVisibleReply(thread);
   if (!latestReply) return false;
 
   if (latestReply.getSender() === userId) return false;
 
   const readUpToId = room.getEventReadUpTo(userId);
-  if (!readUpToId) return true;
-  const readUpToEvent = room.findEventById(readUpToId);
-  if (!readUpToEvent) return true;
+  const roomReadUpToTs = readUpToId ? room.findEventById(readUpToId)?.getTs() : null;
+  const readUpToTs = getEffectiveThreadReadUpToTs(thread, userId, roomReadUpToTs ?? null);
+  if (readUpToTs === null) return true;
+  if (readUpToTs === undefined) return true;
 
-  return latestReply.getTs() > readUpToEvent.getTs();
+  return latestReply.getTs() > readUpToTs;
 };
 
 /**

--- a/src/app/mindroom/threads/roomThreadList.ts
+++ b/src/app/mindroom/threads/roomThreadList.ts
@@ -12,11 +12,12 @@ const getLatestVisibleReply = (thread: Thread) =>
     ? thread.replyToEvent
     : undefined);
 
-const getThreadReceiptCandidates = (thread: Thread): MatrixEvent[] => {
-  const candidates = [...(thread.events ?? [])];
-  if (thread.replyToEvent) candidates.push(thread.replyToEvent);
-  if (thread.rootEvent) candidates.push(thread.rootEvent);
-  return candidates;
+const findThreadReceiptEvent = (thread: Thread, eventId: string): MatrixEvent | undefined => {
+  const timelineEvent = thread.events?.find((event) => event.getId() === eventId);
+  if (timelineEvent) return timelineEvent;
+  if (thread.replyToEvent?.getId?.() === eventId) return thread.replyToEvent;
+  if (thread.rootEvent?.getId?.() === eventId) return thread.rootEvent;
+  return undefined;
 };
 
 export const getThreadReadUpToTs = (
@@ -28,9 +29,10 @@ export const getThreadReadUpToTs = (
   const readUpToId = thread.getEventReadUpTo(userId);
   if (!readUpToId) return undefined;
 
-  return getThreadReceiptCandidates(thread)
-    .find((event) => event.getId() === readUpToId)
-    ?.getTs();
+  const readUpToEvent = findThreadReceiptEvent(thread, readUpToId);
+  // A thread receipt can target a paginated-out event; without its timestamp,
+  // the room-level receipt is the only orderable fallback.
+  return readUpToEvent?.getTs();
 };
 
 export const getEffectiveThreadReadUpToTs = (
@@ -60,9 +62,8 @@ export const getThreadUnread = (room: Room, thread: Thread, userId: string): boo
 
   const readUpToId = room.getEventReadUpTo(userId);
   const roomReadUpToTs = readUpToId ? room.findEventById(readUpToId)?.getTs() : null;
-  const readUpToTs = getEffectiveThreadReadUpToTs(thread, userId, roomReadUpToTs ?? null);
+  const readUpToTs = getEffectiveThreadReadUpToTs(thread, userId, roomReadUpToTs ?? null) ?? null;
   if (readUpToTs === null) return true;
-  if (readUpToTs === undefined) return true;
 
   return latestReply.getTs() > readUpToTs;
 };

--- a/src/app/mindroom/threads/threadRecord.test.ts
+++ b/src/app/mindroom/threads/threadRecord.test.ts
@@ -162,6 +162,53 @@ describe('buildThreadRecord', () => {
     });
   });
 
+  it('uses the thread-scoped receipt to clear unread status when the room read marker is older', () => {
+    const rootEvent = makeEvent({
+      eventId: '$root',
+      sender: '@me:server',
+      body: 'Root body',
+      ts: 1000,
+    });
+    const latestReply = makeEvent({
+      eventId: '$reply',
+      threadRootId: '$root',
+      sender: '@agent:server',
+      body: 'Reply body',
+      ts: 3000,
+    });
+    const room = makeRoom({
+      rootEvent,
+      thread: {
+        id: '$root',
+        rootEvent,
+        events: [latestReply],
+        timeline: [latestReply],
+        length: 1,
+        lastReply: () => latestReply,
+        getEventReadUpTo: vi.fn(() => latestReply.getId()),
+        getUnfilteredTimelineSet: () => ({
+          getLiveTimeline: () => ({
+            getEvents: () => [rootEvent, latestReply],
+            getNeighbouringTimeline: () => undefined,
+          }),
+          relations: {
+            getChildEventsForEvent: () => undefined,
+          },
+        }),
+      } as unknown as ReturnType<Room['getThread']>,
+    });
+
+    const record = buildThreadRecord({
+      room,
+      threadRootId: '$root',
+      threadRootEvent: rootEvent,
+      currentUserId: '@me:server',
+      readUpToTs: rootEvent.getTs(),
+    });
+
+    expect(record.status.isUnread).toBe(false);
+  });
+
   it('builds a per-room record map from direct source maps', () => {
     const rootEvent = makeEvent({
       eventId: '$root',

--- a/src/app/mindroom/threads/threadRecord.ts
+++ b/src/app/mindroom/threads/threadRecord.ts
@@ -8,7 +8,7 @@ import { getThreadStreamingState } from './useThreadStreamingState';
 import { getThreadLastActivityTs } from './useThreadLastActivityTs';
 import { resolveRecentThreadSummaryText } from '../recent-threads/recentThreadSummaryUtils';
 import { isZeroReplyStandaloneThreadRootEvent } from './compactThreadRootData';
-import { getThreadUnread } from './roomThreadList';
+import { getEffectiveThreadReadUpToTs, getThreadUnread } from './roomThreadList';
 import { getEffectiveThreadRootActivityTs } from './threadRouteUtils';
 import {
   getThreadPrimarySummaryText,
@@ -190,13 +190,15 @@ const getThreadUnreadFromReadUpToTs = (
   readUpToTs: number | null | undefined
 ): boolean | undefined => {
   if (readUpToTs === undefined || !thread || !currentUserId) return undefined;
+  const effectiveReadUpToTs = getEffectiveThreadReadUpToTs(thread, currentUserId, readUpToTs);
 
   const replyEvents = getPreferredVisibleThreadReplyEvents(thread);
   const latestReply = replyEvents[replyEvents.length - 1];
   if (!latestReply) return false;
   if (latestReply.getSender() === currentUserId) return false;
-  if (readUpToTs === null) return true;
-  return latestReply.getTs() > readUpToTs;
+  if (effectiveReadUpToTs === null) return true;
+  if (effectiveReadUpToTs === undefined) return true;
+  return latestReply.getTs() > effectiveReadUpToTs;
 };
 
 const buildDefaultThreadCacheCoverage = (


### PR DESCRIPTION
## Summary
- Make thread unread state honor thread-scoped read receipts before falling back to the room marker.
- Reuse the same effective read timestamp for compact thread records and thread-list unread state.
- Add regression coverage for compact/thread-list unread clearing after a thread-scoped receipt.

## Test Plan
- [x] npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts
- [x] npm test -- src/app/mindroom/threads/threadRecord.test.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/threadIndexRecords.test.ts src/app/mindroom/threads/compactThreadCardViewModel.test.ts src/app/mindroom/threads/ThreadIndicator.test.ts src/app/mindroom/threads/useMindroomThreadIndex.test.ts src/app/mindroom/threads/__tests__/RoomTimeline.cache.test.ts
- [x] npm test
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] npx prettier --check FORK_CHANGES.md src/app/mindroom/threads/roomThreadList.ts src/app/mindroom/threads/roomThreadList.test.ts src/app/mindroom/threads/threadRecord.ts src/app/mindroom/threads/threadRecord.test.ts
- [x] git diff --check

## Summary by Sourcery

Align thread unread status with thread-scoped read receipts so compact thread cards and thread lists clear unread state correctly after opening a thread.

Bug Fixes:
- Fix compact thread and thread-list unread indicators so they respect thread-scoped read receipts instead of relying solely on room-level read markers.

Enhancements:
- Introduce shared helpers to derive effective thread read timestamps from both thread-scoped and room-level receipts for consistent unread calculations across thread views.

Documentation:
- Document CINNY-133 runbook entry describing the compact thread unread behavior, root cause, and validation steps.

Tests:
- Add regression tests ensuring compact thread records and room thread list unread states are cleared when a newer thread-scoped receipt exists than the room read marker.