### PR TITLE
Open compact sends as threads

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -13,6 +13,12 @@
     classic mode and existing thread sends are unchanged.
   - Upload send sessions also notify on the root upload only, skipping child
     uploads and caption replies that already target the generated thread root.
+  - PR review follow-up: root-send notification rules now live in one shared
+    helper, and text, upload, and voice send paths finish local cleanup before
+    invoking the callback that may navigate away.
+  - PR review follow-up: added coverage for voice-send notification cleanup
+    ordering, upload-root cleanup ordering, the shared helper, and the
+    `effectiveThreadId` guard without an explicit `threadId` prop.
 - Decisions:
   - Keep the routing policy in `useRoomViewThreadState`, beside view-mode and
     thread-route ownership, instead of putting navigation decisions inside the
@@ -55,6 +61,42 @@
     console/unused-var warning class).
   - Rebase green: `npm run build` (existing Vite runtime-config, sourcemap,
     localStorage, and chunk-size warnings only).
+  - PR review red focused check:
+    `npm test -- src/app/mindroom/threads/roomMessageSent.test.ts src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts`
+    failed while the helper module did not exist and voice/upload callbacks
+    still observed stale local state.
+  - PR review green focused check:
+    `npm test -- src/app/mindroom/threads/roomMessageSent.test.ts src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts`
+    (4 files, 74 tests).
+  - PR review green: `npm run typecheck`.
+  - PR review green: `npm test` (307 files, 2289 tests).
+  - PR review green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - PR review green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+  - PR review green:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/room-input/MindroomRoomInput.tsx src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/MindroomRoomView.tsx src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts src/app/mindroom/threads/useRoomViewThreadState.ts src/app/mindroom/threads/roomMessageSent.ts src/app/mindroom/threads/roomMessageSent.test.ts`
+    and `git diff --check`.
+  - PR review second self-review: verified no remaining duplicated inline
+    root-send notification condition and no remaining `room.roomId` dependency
+    references in the touched hook.
+  - Latest rebase check: rebased onto `origin/dev` at `4ae69f37`; resolved
+    `FORK_CHANGES.md` by preserving upstream `CINNY-207`/`CINNY-133` entries
+    and renumbering this entry to `CINNY-208`, and resolved
+    `RoomInput.test.ts` by preserving both upstream thread-helper coverage and
+    this branch's send-notification coverage.
+  - Latest rebase green focused check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/threads/roomMessageSent.test.ts src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts`
+    (4 files, 75 tests).
+  - Latest rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`.
+  - Latest rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run lint`
+    (18 warnings, 0 errors - existing warning class).
+  - Latest rebase green:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test` (307 files, 2292
+    tests).
+  - Latest rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
+    (existing Vite runtime-config, sourcemap, localStorage, and chunk-size
+    warnings only).
 
 ### CINNY-207 - Hide thread-only composer helper in thread view (2026-06-17)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,60 @@
 
 ## Runbook
 
+### CINNY-208 - Auto-open compact sends as threads (2026-06-17)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Compact room overview now opens a newly sent top-level room message as its
+    thread once Matrix returns the sent event id.
+  - The route change reuses the existing MindRoom thread navigation path, so
+    classic mode and existing thread sends are unchanged.
+  - Upload send sessions also notify on the root upload only, skipping child
+    uploads and caption replies that already target the generated thread root.
+- Decisions:
+  - Keep the routing policy in `useRoomViewThreadState`, beside view-mode and
+    thread-route ownership, instead of putting navigation decisions inside the
+    composer.
+  - Treat only confirmed Matrix event ids as auto-open targets, avoiding
+    persisted navigation to local-echo ids.
+  - Notify only root sends with no active thread or reply draft; existing
+    threads, replies, and classic sends keep their current destination.
+- Risks:
+  - Navigating immediately after an upload root may unmount the composer while
+    the local send-session loop continues sending child uploads and captions.
+    Existing send-session state already owns those captured files, but live
+    multi-upload smoke testing is still useful.
+- Validation:
+  - Red check:
+    `npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts`
+    failed while the send callback and compact route handler did not exist.
+  - Green focused check:
+    `npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts`
+    (3 files, 69 tests).
+  - Independent review green check: separate reviewer found no blockers; minor
+    helper typing and compact guard coverage suggestions were addressed.
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Green: `npm test` (302 files, 2258 tests).
+  - Green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md src/app/mindroom/room-input/MindroomRoomInput.tsx src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/MindroomRoomView.tsx src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts src/app/mindroom/threads/useRoomViewThreadState.ts`.
+  - Green: `git diff --check`.
+  - Rebase green check: rebased onto `origin/dev` at `3c2ff596` and resolved
+    composer conflicts with the pending-send indicator path.
+  - Rebase green focused check:
+    `npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts`
+    (3 files, 70 tests).
+  - Rebase green: `npm run typecheck`.
+  - Rebase green: `npm test` (306 files, 2285 tests).
+  - Rebase green: `npm run lint` (18 warnings, 0 errors - existing
+    console/unused-var warning class).
+  - Rebase green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+
 ### CINNY-207 - Hide thread-only composer helper in thread view (2026-06-17)
 
 - Status:

--- a/src/app/mindroom/room-input/MindroomRoomInput.tsx
+++ b/src/app/mindroom/room-input/MindroomRoomInput.tsx
@@ -203,9 +203,21 @@ export interface RoomInputProps {
   room: Room;
   threadId?: string;
   threadingEnabled?: boolean;
+  onRoomMessageSent?: (eventId: string) => void;
 }
 export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
-  ({ editor, fileDropContainerRef, roomId, room, threadId, threadingEnabled = true }, ref) => {
+  (
+    {
+      editor,
+      fileDropContainerRef,
+      roomId,
+      room,
+      threadId,
+      threadingEnabled = true,
+      onRoomMessageSent,
+    },
+    ref
+  ) => {
     const mx = useMatrixClient();
     const store = useStore();
     const useAuthentication = useMediaAuthentication();
@@ -289,12 +301,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     // account; ignore (and clean up) any draft that does not belong to us.
     const currentSessionId = mx.getUserId() ?? undefined;
     const draftBelongsToCurrentSession =
-      !!pendingVoiceSendDraft &&
-      pendingVoiceSendDraft.context.ownerSessionId === currentSessionId;
+      !!pendingVoiceSendDraft && pendingVoiceSendDraft.context.ownerSessionId === currentSessionId;
     const ownsPendingVoiceDraft =
       draftBelongsToCurrentSession && pendingVoiceSendDraft?.context.roomId === roomId;
-    const otherRoomOwnsPendingVoiceDraft =
-      draftBelongsToCurrentSession && !ownsPendingVoiceDraft;
+    const otherRoomOwnsPendingVoiceDraft = draftBelongsToCurrentSession && !ownsPendingVoiceDraft;
     const otherPendingVoiceRoomName =
       otherRoomOwnsPendingVoiceDraft && pendingVoiceSendDraft
         ? pendingVoiceSendDraft.context.room.name ?? pendingVoiceSendDraft.context.roomId
@@ -725,9 +735,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             }
           : content;
 
-        await mx.sendMessage(context.roomId, contentWithRelation as any);
+        const response = await mx.sendMessage(context.roomId, contentWithRelation as any);
+        if (!relation && !context.threadId && !context.replyDraft && response.event_id) {
+          onRoomMessageSent?.(response.event_id);
+        }
       },
-      [mx, buildUploadMessageContent]
+      [mx, buildUploadMessageContent, onRoomMessageSent]
     );
 
     const clearReplyDraftForVoiceContext = useCallback(
@@ -759,6 +772,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       uploadsRef,
       buildUploadMessageContent,
       removeUploadsFromBoard,
+      onRoomMessageSent,
       shouldBlockStartSendSession: () => store.get(voiceAutoSendPendingAtom),
     });
 
@@ -1013,7 +1027,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         }
         submitPendingStarted = true;
         setSubmitPending(true);
-        await mx.sendMessage(roomId, content as any);
+        const response = await mx.sendMessage(roomId, content as any);
+        if (!relation && !threadId && !replyDraft && response.event_id) {
+          onRoomMessageSent?.(response.event_id);
+        }
         resetEditor(editor);
         resetEditorHistory(editor);
         setReplyDraft(undefined);
@@ -1037,6 +1054,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       threadingEnabled,
       startSendSession,
       store,
+      onRoomMessageSent,
     ]);
 
     const handleUploadBoardSend = useCallback(async () => {

--- a/src/app/mindroom/room-input/MindroomRoomInput.tsx
+++ b/src/app/mindroom/room-input/MindroomRoomInput.tsx
@@ -144,6 +144,7 @@ import {
   withMindroomPasteAttachmentMetadata,
 } from '../messages/pasteAttachmentMarker';
 import { shouldConvertPasteToAttachment } from './pasteAttachment';
+import { getRoomMessageSentNotificationEventId } from '../threads/roomMessageSent';
 
 type RoomInputAutocompletePrefix = AutocompletePrefix | MindroomRoomInputAutocompletePrefix;
 
@@ -736,11 +737,14 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           : content;
 
         const response = await mx.sendMessage(context.roomId, contentWithRelation as any);
-        if (!relation && !context.threadId && !context.replyDraft && response.event_id) {
-          onRoomMessageSent?.(response.event_id);
-        }
+        return getRoomMessageSentNotificationEventId({
+          eventId: response.event_id,
+          relation,
+          replyDraft: context.replyDraft,
+          threadId: context.threadId,
+        });
       },
-      [mx, buildUploadMessageContent, onRoomMessageSent]
+      [mx, buildUploadMessageContent]
     );
 
     const clearReplyDraftForVoiceContext = useCallback(
@@ -837,6 +841,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         // calling it unconditionally is safe even on the un-claimed path.
         let fileItems: TUploadItem[] = [];
         let liveContext: MindroomVoiceSendContext | null = null;
+        let sentEventIdToNotify: string | undefined;
         const logAndThrowUploadError = (err: unknown, stage: MatrixUploadErrorStage): never => {
           const originalName =
             getMatrixUploadOriginalName(err) ?? (err instanceof Error ? err.name : typeof err);
@@ -904,7 +909,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             return logAndThrowUploadError(err, 'upload');
           }
           try {
-            await sendVoiceItem(liveContext, fileItem, mxc);
+            sentEventIdToNotify = await sendVoiceItem(liveContext, fileItem, mxc);
           } catch (err) {
             return logAndThrowUploadError(err, 'send');
           }
@@ -918,6 +923,9 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           }
           releaseVoiceAutoSend();
         }
+        if (sentEventIdToNotify) {
+          onRoomMessageSent?.(sentEventIdToNotify);
+        }
       },
       [
         appendUploadItemsToRoomBoard,
@@ -929,6 +937,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         sendVoiceItem,
         store,
         uploadVoiceItem,
+        onRoomMessageSent,
       ]
     );
 
@@ -1028,13 +1037,21 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         submitPendingStarted = true;
         setSubmitPending(true);
         const response = await mx.sendMessage(roomId, content as any);
-        if (!relation && !threadId && !replyDraft && response.event_id) {
-          onRoomMessageSent?.(response.event_id);
-        }
+        const sentEventIdToNotify = getRoomMessageSentNotificationEventId({
+          eventId: response.event_id,
+          relation,
+          replyDraft,
+          threadId,
+        });
         resetEditor(editor);
         resetEditorHistory(editor);
         setReplyDraft(undefined);
         sendTypingStatus(false);
+        setSubmitPending(false);
+        submitPendingStarted = false;
+        if (sentEventIdToNotify) {
+          onRoomMessageSent?.(sentEventIdToNotify);
+        }
       } finally {
         if (submitPendingStarted) {
           setSubmitPending(false);

--- a/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
+++ b/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
@@ -1219,7 +1219,16 @@ describe('RoomInput', () => {
   });
 
   it('notifies successful top-level room text sends with the new event id', async () => {
-    const onRoomMessageSent = vi.fn();
+    const notificationOrder: string[] = [];
+    editorMocks.resetEditor.mockImplementation(() => {
+      notificationOrder.push('reset-editor');
+    });
+    editorMocks.resetEditorHistory.mockImplementation(() => {
+      notificationOrder.push('reset-history');
+    });
+    const onRoomMessageSent = vi.fn(() => {
+      notificationOrder.push('notify');
+    });
     const { renderer } = await renderRoomInput(createStore(), { onRoomMessageSent });
 
     editorOutputState.plainText = 'Start a compact thread';
@@ -1231,6 +1240,10 @@ describe('RoomInput', () => {
     });
 
     expect(onRoomMessageSent).toHaveBeenCalledWith('$sent');
+    const notifyIndex = notificationOrder.indexOf('notify');
+    expect(notifyIndex).toBeGreaterThan(-1);
+    expect(notificationOrder.indexOf('reset-editor')).toBeLessThan(notifyIndex);
+    expect(notificationOrder.indexOf('reset-history')).toBeLessThan(notifyIndex);
 
     renderer.unmount();
   });
@@ -1442,6 +1455,31 @@ describe('RoomInput', () => {
 
     expect(mxState.sendMessage).toHaveBeenCalledTimes(1);
     expect(mxState.sendMessage.mock.calls[0][1]).not.toHaveProperty('m.relates_to');
+
+    renderer.unmount();
+  });
+
+  it('notifies top-level voice sends after clearing local voice state', async () => {
+    const store = createStore();
+    const notificationState: Array<{ pending: boolean; uploads: File[] }> = [];
+    const onRoomMessageSent = vi.fn(() => {
+      notificationState.push({
+        pending: store.get(voiceAutoSendPendingAtom),
+        uploads: store.get(roomIdToUploadItemsAtomFamily(ROOM_ID)).map((item) => item.file),
+      });
+    });
+    const { renderer } = await renderRoomInput(store, { onRoomMessageSent });
+    await openVoiceRecorder(renderer);
+    const file = new File(['voice'], 'voice.m4a', { type: 'audio/mp4' });
+
+    await act(async () => {
+      await voiceRecorderState.props?.onSendRecording(file, 900);
+    });
+
+    expect(mxState.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mxState.sendMessage.mock.calls[0][1]).not.toHaveProperty('m.relates_to');
+    expect(onRoomMessageSent).toHaveBeenCalledWith('$sent');
+    expect(notificationState).toEqual([{ pending: false, uploads: [] }]);
 
     renderer.unmount();
   });

--- a/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
+++ b/src/app/mindroom/room-input/__tests__/RoomInput.test.ts
@@ -698,6 +698,8 @@ const createRoomInputTree = (
   props?: {
     roomId?: string;
     threadId?: string;
+    threadingEnabled?: boolean;
+    onRoomMessageSent?: (eventId: string) => void;
     keyedRoomSubtree?: boolean;
     encryptedRoom?: boolean;
   }
@@ -712,6 +714,8 @@ const createRoomInputTree = (
       roomId: props?.roomId ?? ROOM_ID,
       room: createRoom(props?.roomId ?? ROOM_ID, props?.encryptedRoom),
       threadId: props?.threadId,
+      threadingEnabled: props?.threadingEnabled,
+      onRoomMessageSent: props?.onRoomMessageSent,
     })
   );
 
@@ -720,6 +724,8 @@ const renderRoomInput = async (
   props?: {
     roomId?: string;
     threadId?: string;
+    threadingEnabled?: boolean;
+    onRoomMessageSent?: (eventId: string) => void;
     keyedRoomSubtree?: boolean;
     encryptedRoom?: boolean;
   }
@@ -739,6 +745,8 @@ const updateRoomInput = async (
   props?: {
     roomId?: string;
     threadId?: string;
+    threadingEnabled?: boolean;
+    onRoomMessageSent?: (eventId: string) => void;
     keyedRoomSubtree?: boolean;
     encryptedRoom?: boolean;
   }
@@ -1206,6 +1214,44 @@ describe('RoomInput', () => {
 
     expect(customEditorState.replyContextRenderCount).toBe(0);
     expect(JSON.stringify(renderer.toJSON())).not.toContain('Sending to this thread');
+
+    renderer.unmount();
+  });
+
+  it('notifies successful top-level room text sends with the new event id', async () => {
+    const onRoomMessageSent = vi.fn();
+    const { renderer } = await renderRoomInput(createStore(), { onRoomMessageSent });
+
+    editorOutputState.plainText = 'Start a compact thread';
+    editorOutputState.customHtml = 'Start a compact thread';
+    editorOutputState.htmlEqualsPlainText = true;
+
+    await act(async () => {
+      customEditorState.props!.onKeyDown?.({ key: 'Enter', preventDefault: vi.fn() });
+    });
+
+    expect(onRoomMessageSent).toHaveBeenCalledWith('$sent');
+
+    renderer.unmount();
+  });
+
+  it('does not notify thread-targeted text sends as new room message roots', async () => {
+    const onRoomMessageSent = vi.fn();
+    const { renderer } = await renderRoomInput(createStore(), {
+      threadId: '$thread-a',
+      onRoomMessageSent,
+    });
+
+    editorOutputState.plainText = 'Reply in thread';
+    editorOutputState.customHtml = 'Reply in thread';
+    editorOutputState.htmlEqualsPlainText = true;
+
+    await act(async () => {
+      customEditorState.props!.onKeyDown?.({ key: 'Enter', preventDefault: vi.fn() });
+    });
+
+    expect(mxState.sendMessage).toHaveBeenCalledTimes(1);
+    expect(onRoomMessageSent).not.toHaveBeenCalled();
 
     renderer.unmount();
   });
@@ -2059,12 +2105,7 @@ describe('RoomInput', () => {
     let rejected: unknown;
     await act(async () => {
       try {
-        await voiceRecorderState.props!.onSendRecording(
-          file,
-          1100,
-          undefined,
-          capturedContext
-        );
+        await voiceRecorderState.props!.onSendRecording(file, 1100, undefined, capturedContext);
       } catch (err) {
         rejected = err;
       }
@@ -2120,12 +2161,7 @@ describe('RoomInput', () => {
     let rejected: unknown;
     await act(async () => {
       try {
-        await voiceRecorderState.props!.onSendRecording(
-          file,
-          1100,
-          undefined,
-          capturedContext
-        );
+        await voiceRecorderState.props!.onSendRecording(file, 1100, undefined, capturedContext);
       } catch (err) {
         rejected = err;
       }

--- a/src/app/mindroom/threads/MindroomRoomView.tsx
+++ b/src/app/mindroom/threads/MindroomRoomView.tsx
@@ -96,6 +96,7 @@ export function RoomView({
     handleExitThread,
     handleRemoveTag,
     handleReset,
+    handleRoomMessageSent,
     handleSearchQueryChange,
     handleSortDirectionChange,
     handleToggle,
@@ -186,6 +187,7 @@ export function RoomView({
                   roomId={roomId}
                   threadId={effectiveThreadId}
                   threadingEnabled={viewMode !== 'classic'}
+                  onRoomMessageSent={handleRoomMessageSent}
                   fileDropContainerRef={roomViewRef}
                   ref={roomInputRef}
                 />

--- a/src/app/mindroom/threads/__tests__/RoomView.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomView.test.ts
@@ -1153,6 +1153,34 @@ describe('RoomView', () => {
     expect(navigateRoomThreadMock).not.toHaveBeenCalled();
   });
 
+  it('does not open successful sends when only an effective thread id is active', async () => {
+    const { useRoomViewThreadState } = await import('../useRoomViewThreadState');
+    const ThreadStateHarness = createThreadStateHarness(useRoomViewThreadState);
+    const room = makeRoom(nextRoomId('room-a'));
+    let threadState: import('../useRoomViewThreadState').RoomViewThreadState | undefined;
+
+    useThreadRootEventMock.mockReturnValue('$thread-from-state');
+
+    await act(async () => {
+      create(
+        React.createElement(ThreadStateHarness, {
+          onState: (state) => {
+            threadState = state;
+          },
+          room,
+        })
+      );
+    });
+
+    expect(threadState?.effectiveThreadId).toBe('$thread-from-state');
+
+    await act(async () => {
+      threadState?.handleRoomMessageSent('$sent');
+    });
+
+    expect(navigateRoomThreadMock).not.toHaveBeenCalled();
+  });
+
   it('does not open unresolved local-echo sends as compact threads', async () => {
     const { useRoomViewThreadState } = await import('../useRoomViewThreadState');
     const ThreadStateHarness = createThreadStateHarness(useRoomViewThreadState);

--- a/src/app/mindroom/threads/__tests__/RoomView.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomView.test.ts
@@ -1104,6 +1104,106 @@ describe('RoomView', () => {
     );
   });
 
+  it('opens a successful compact room message send as a thread', async () => {
+    const { useRoomViewThreadState } = await import('../useRoomViewThreadState');
+    const ThreadStateHarness = createThreadStateHarness(useRoomViewThreadState);
+    const room = makeRoom(nextRoomId('room-a'));
+    let threadState: import('../useRoomViewThreadState').RoomViewThreadState | undefined;
+
+    await act(async () => {
+      create(
+        React.createElement(ThreadStateHarness, {
+          onState: (state) => {
+            threadState = state;
+          },
+          room,
+        })
+      );
+    });
+
+    await act(async () => {
+      threadState?.handleRoomMessageSent('$sent');
+    });
+
+    expect(navigateRoomThreadMock).toHaveBeenCalledWith(room.roomId, '$sent');
+  });
+
+  it('does not open successful sends as new threads outside the compact room overview', async () => {
+    const { useRoomViewThreadState } = await import('../useRoomViewThreadState');
+    const ThreadStateHarness = createThreadStateHarness(useRoomViewThreadState);
+    const room = makeRoom(nextRoomId('room-a'));
+    let threadState: import('../useRoomViewThreadState').RoomViewThreadState | undefined;
+
+    await act(async () => {
+      create(
+        React.createElement(ThreadStateHarness, {
+          onState: (state) => {
+            threadState = state;
+          },
+          room,
+          threadId: '$thread-a',
+        })
+      );
+    });
+
+    await act(async () => {
+      threadState?.handleRoomMessageSent('$sent');
+    });
+
+    expect(navigateRoomThreadMock).not.toHaveBeenCalled();
+  });
+
+  it('does not open unresolved local-echo sends as compact threads', async () => {
+    const { useRoomViewThreadState } = await import('../useRoomViewThreadState');
+    const ThreadStateHarness = createThreadStateHarness(useRoomViewThreadState);
+    const room = makeRoom(nextRoomId('room-a'));
+    let threadState: import('../useRoomViewThreadState').RoomViewThreadState | undefined;
+
+    await act(async () => {
+      create(
+        React.createElement(ThreadStateHarness, {
+          onState: (state) => {
+            threadState = state;
+          },
+          room,
+        })
+      );
+    });
+
+    await act(async () => {
+      threadState?.handleRoomMessageSent('~local-echo');
+    });
+
+    expect(navigateRoomThreadMock).not.toHaveBeenCalled();
+  });
+
+  it('does not open successful sends as new threads in classic mode', async () => {
+    const { useRoomViewThreadState } = await import('../useRoomViewThreadState');
+    const ThreadStateHarness = createThreadStateHarness(useRoomViewThreadState);
+    const room = makeRoom(nextRoomId('room-a'));
+    let threadState: import('../useRoomViewThreadState').RoomViewThreadState | undefined;
+
+    await act(async () => {
+      create(
+        React.createElement(ThreadStateHarness, {
+          onState: (state) => {
+            threadState = state;
+          },
+          room,
+        })
+      );
+    });
+
+    await act(async () => {
+      threadState?.handleViewModeChange('classic');
+    });
+    await act(async () => {
+      threadState?.handleRoomMessageSent('$sent');
+    });
+
+    expect(navigateRoomThreadMock).not.toHaveBeenCalled();
+  });
+
   it('does not persist unresolved local-echo ids in the recent-thread list', async () => {
     const { RoomView } = await import('../../../features/room/RoomView');
     const room = makeRoom(nextRoomId('room-a'));

--- a/src/app/mindroom/threads/roomMessageSent.test.ts
+++ b/src/app/mindroom/threads/roomMessageSent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getRoomMessageSentNotificationEventId } from './roomMessageSent';
+
+describe('getRoomMessageSentNotificationEventId', () => {
+  it('returns the event id for root sends only', () => {
+    expect(
+      getRoomMessageSentNotificationEventId({
+        eventId: '$root',
+        relation: undefined,
+        replyDraft: undefined,
+        threadId: undefined,
+      })
+    ).toBe('$root');
+  });
+
+  it('skips related, threaded, reply, and missing-event sends', () => {
+    expect(
+      getRoomMessageSentNotificationEventId({
+        eventId: '$reply',
+        relation: { rel_type: 'm.thread' },
+        replyDraft: undefined,
+        threadId: undefined,
+      })
+    ).toBeUndefined();
+    expect(
+      getRoomMessageSentNotificationEventId({
+        eventId: '$thread',
+        relation: undefined,
+        replyDraft: undefined,
+        threadId: '$existing-thread',
+      })
+    ).toBeUndefined();
+    expect(
+      getRoomMessageSentNotificationEventId({
+        eventId: '$draft',
+        relation: undefined,
+        replyDraft: { eventId: '$parent' },
+        threadId: undefined,
+      })
+    ).toBeUndefined();
+    expect(
+      getRoomMessageSentNotificationEventId({
+        eventId: undefined,
+        relation: undefined,
+        replyDraft: undefined,
+        threadId: undefined,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/src/app/mindroom/threads/roomMessageSent.ts
+++ b/src/app/mindroom/threads/roomMessageSent.ts
@@ -1,0 +1,17 @@
+export type RoomMessageSentNotificationInput = {
+  eventId?: string;
+  relation?: unknown;
+  replyDraft?: unknown;
+  threadId?: string;
+};
+
+export const getRoomMessageSentNotificationEventId = ({
+  eventId,
+  relation,
+  replyDraft,
+  threadId,
+}: RoomMessageSentNotificationInput): string | undefined => {
+  if (!eventId || relation || threadId || replyDraft) return undefined;
+
+  return eventId;
+};

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.test.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.test.ts
@@ -73,10 +73,12 @@ const prepErrorUpload = (file: File): Upload => ({
 
 const TestHarness = ({
   onReady,
+  onRoomMessageSent,
   mx,
   editor,
 }: {
   onReady: (api: HarnessApi) => void;
+  onRoomMessageSent?: (eventId: string) => void;
   mx: {
     sendMessage: ReturnType<typeof vi.fn>;
   };
@@ -122,6 +124,7 @@ const TestHarness = ({
       );
       uploadsRef.current = uploadsRef.current.filter((item) => !uploadList.includes(item.file));
     },
+    onRoomMessageSent,
   });
 
   useEffect(() => {
@@ -137,7 +140,7 @@ const TestHarness = ({
   return null;
 };
 
-const renderHarness = () => {
+const renderHarness = (options: { onRoomMessageSent?: (eventId: string) => void } = {}) => {
   let sentEvents = 0;
   const mx = {
     sendMessage: vi.fn(async () => {
@@ -156,6 +159,7 @@ const renderHarness = () => {
       React.createElement(TestHarness, {
         mx,
         editor,
+        onRoomMessageSent: options.onRoomMessageSent,
         onReady: (nextApi) => {
           api = nextApi;
         },
@@ -301,6 +305,26 @@ describe('useRoomInputSendSessionController prep-error uploads', () => {
         is_falling_back: true,
       },
     });
+  });
+
+  it('notifies the auto-thread upload root once and skips child uploads', async () => {
+    const onRoomMessageSent = vi.fn();
+    const { api } = renderHarness({ onRoomMessageSent });
+    const root = createFile('root.txt');
+    const child = createFile('child.txt');
+
+    api.selectedFilesRef.current = [createUploadItem(root), createUploadItem(child)];
+    api.uploadsRef.current = [
+      successUpload(root, 'mxc://mindroom/root'),
+      successUpload(child, 'mxc://mindroom/child'),
+    ];
+
+    await act(async () => {
+      await api.startSendSession();
+    });
+
+    expect(onRoomMessageSent).toHaveBeenCalledTimes(1);
+    expect(onRoomMessageSent).toHaveBeenCalledWith('$event-0');
   });
 });
 

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.test.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.test.ts
@@ -308,8 +308,20 @@ describe('useRoomInputSendSessionController prep-error uploads', () => {
   });
 
   it('notifies the auto-thread upload root once and skips child uploads', async () => {
+    const notificationSnapshots: Array<{ selectedFiles: string[]; uploadFiles: string[] }> = [];
     const onRoomMessageSent = vi.fn();
-    const { api } = renderHarness({ onRoomMessageSent });
+    const apiRef: { current?: HarnessApi } = {};
+    const { api } = renderHarness({
+      onRoomMessageSent: (eventId) => {
+        onRoomMessageSent(eventId);
+        notificationSnapshots.push({
+          selectedFiles:
+            apiRef.current?.selectedFilesRef.current.map((item) => item.file.name) ?? [],
+          uploadFiles: apiRef.current?.uploadsRef.current.map((upload) => upload.file.name) ?? [],
+        });
+      },
+    });
+    apiRef.current = api;
     const root = createFile('root.txt');
     const child = createFile('child.txt');
 
@@ -325,6 +337,12 @@ describe('useRoomInputSendSessionController prep-error uploads', () => {
 
     expect(onRoomMessageSent).toHaveBeenCalledTimes(1);
     expect(onRoomMessageSent).toHaveBeenCalledWith('$event-0');
+    expect(notificationSnapshots).toEqual([
+      {
+        selectedFiles: ['child.txt'],
+        uploadFiles: ['child.txt'],
+      },
+    ]);
   });
 });
 

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.ts
@@ -70,6 +70,7 @@ type UseRoomInputSendSessionControllerOptions = {
     signalBridgedRoom: boolean
   ) => Promise<IContent>;
   removeUploadsFromBoard: (upload: TUploadContent | TUploadContent[]) => void;
+  onRoomMessageSent?: (eventId: string) => void;
   shouldBlockStartSendSession?: () => boolean;
 };
 
@@ -126,6 +127,7 @@ export const useRoomInputSendSessionController = ({
   uploadsRef,
   buildUploadMessageContent,
   removeUploadsFromBoard,
+  onRoomMessageSent,
   shouldBlockStartSendSession,
 }: UseRoomInputSendSessionControllerOptions): {
   processSendSession: () => Promise<void>;
@@ -177,12 +179,15 @@ export const useRoomInputSendSessionController = ({
             'm.relates_to': relation,
           }
         : session.textContent;
-      await mx.sendMessage(session.roomId, content as any);
+      const response = await mx.sendMessage(session.roomId, content as any);
+      if (!relation && !session.threadId && !session.replyDraft && response.event_id) {
+        onRoomMessageSent?.(response.event_id);
+      }
 
       session.textPending = false;
       clearReplyDraftForSession(session);
     },
-    [mx, clearReplyDraftForSession]
+    [mx, clearReplyDraftForSession, onRoomMessageSent]
   );
 
   const sendSessionUpload = useCallback(
@@ -203,6 +208,9 @@ export const useRoomInputSendSessionController = ({
           }
         : content;
       const response = await mx.sendMessage(session.roomId, contentWithRelation as any);
+      if (!relation && !session.threadId && !session.replyDraft && response.event_id) {
+        onRoomMessageSent?.(response.event_id);
+      }
 
       session.sentFiles.add(file);
       session.failedFiles.delete(file);
@@ -218,6 +226,7 @@ export const useRoomInputSendSessionController = ({
       sendSessionUploadItemsRef,
       buildUploadMessageContent,
       clearReplyDraftForSession,
+      onRoomMessageSent,
       removeUploadsFromBoard,
     ]
   );

--- a/src/app/mindroom/threads/useRoomInputSendSessionController.ts
+++ b/src/app/mindroom/threads/useRoomInputSendSessionController.ts
@@ -21,6 +21,7 @@ import {
   resolveRoomInputSendStep,
   RoomInputSendSessionState,
 } from './roomInputSendSession';
+import { getRoomMessageSentNotificationEventId } from './roomMessageSent';
 
 type SendSession = RoomInputSendSessionState & {
   roomId: string;
@@ -180,12 +181,18 @@ export const useRoomInputSendSessionController = ({
           }
         : session.textContent;
       const response = await mx.sendMessage(session.roomId, content as any);
-      if (!relation && !session.threadId && !session.replyDraft && response.event_id) {
-        onRoomMessageSent?.(response.event_id);
-      }
+      const sentEventIdToNotify = getRoomMessageSentNotificationEventId({
+        eventId: response.event_id,
+        relation,
+        replyDraft: session.replyDraft,
+        threadId: session.threadId,
+      });
 
       session.textPending = false;
       clearReplyDraftForSession(session);
+      if (sentEventIdToNotify) {
+        onRoomMessageSent?.(sentEventIdToNotify);
+      }
     },
     [mx, clearReplyDraftForSession, onRoomMessageSent]
   );
@@ -208,9 +215,12 @@ export const useRoomInputSendSessionController = ({
           }
         : content;
       const response = await mx.sendMessage(session.roomId, contentWithRelation as any);
-      if (!relation && !session.threadId && !session.replyDraft && response.event_id) {
-        onRoomMessageSent?.(response.event_id);
-      }
+      const sentEventIdToNotify = getRoomMessageSentNotificationEventId({
+        eventId: response.event_id,
+        relation,
+        replyDraft: session.replyDraft,
+        threadId: session.threadId,
+      });
 
       session.sentFiles.add(file);
       session.failedFiles.delete(file);
@@ -219,6 +229,9 @@ export const useRoomInputSendSessionController = ({
       }
       clearReplyDraftForSession(session);
       removeUploadsFromBoard(file);
+      if (sentEventIdToNotify) {
+        onRoomMessageSent?.(sentEventIdToNotify);
+      }
     },
     [
       mx,

--- a/src/app/mindroom/threads/useRoomViewThreadState.ts
+++ b/src/app/mindroom/threads/useRoomViewThreadState.ts
@@ -120,12 +120,9 @@ export const useRoomViewThreadState = ({
 
   const handleExitThread = useCallback(() => {
     if (!effectiveThreadId) return;
-    setLastExitedThread({ roomId: room.roomId, threadId: effectiveThreadId });
+    setLastExitedThread({ roomId, threadId: effectiveThreadId });
     const historyExitTarget = getRoomThreadExitTargetFromHistoryState(window.history.state);
-    if (
-      historyExitTarget?.roomId === room.roomId &&
-      historyExitTarget.threadId === effectiveThreadId
-    ) {
+    if (historyExitTarget?.roomId === roomId && historyExitTarget.threadId === effectiveThreadId) {
       const standaloneWebApp = isIOSStandaloneWebApp();
       if (historyExitTarget.exitPath && (!historyExitTarget.useHistoryBack || standaloneWebApp)) {
         navigatePath(historyExitTarget.exitPath, { replace: true });
@@ -136,23 +133,23 @@ export const useRoomViewThreadState = ({
         return;
       }
     }
-    navigateRoomFocusEvent(room.roomId, effectiveThreadId, { replace: true });
-  }, [effectiveThreadId, navigatePath, navigateRoomFocusEvent, room.roomId, setLastExitedThread]);
+    navigateRoomFocusEvent(roomId, effectiveThreadId, { replace: true });
+  }, [effectiveThreadId, navigatePath, navigateRoomFocusEvent, roomId, setLastExitedThread]);
 
   const handleSwipeForwardToThread = useCallback(() => {
     if (viewMode === 'classic') return;
     if (threadId) return;
-    if (!lastExitedThread || lastExitedThread.roomId !== room.roomId) return;
+    if (!lastExitedThread || lastExitedThread.roomId !== roomId) return;
 
     const targetThreadId = lastExitedThread.threadId;
-    navigateRoomThread(room.roomId, targetThreadId);
+    navigateRoomThread(roomId, targetThreadId);
     setLastExitedThread(null);
-  }, [lastExitedThread, navigateRoomThread, room.roomId, setLastExitedThread, threadId, viewMode]);
+  }, [lastExitedThread, navigateRoomThread, roomId, setLastExitedThread, threadId, viewMode]);
 
   useEdgeSwipeBack(handleExitThread, viewMode !== 'classic' && !!threadId);
   useEdgeSwipeForward(
     handleSwipeForwardToThread,
-    viewMode !== 'classic' && !threadId && lastExitedThread?.roomId === room.roomId
+    viewMode !== 'classic' && !threadId && lastExitedThread?.roomId === roomId
   );
 
   const updateFromEffectiveQueryState = useCallback(
@@ -248,9 +245,9 @@ export const useRoomViewThreadState = ({
       if (viewMode !== 'compact' || threadId || effectiveThreadId) return;
       if (!isConfirmedMatrixEventId(sentEventId)) return;
 
-      navigateRoomThread(room.roomId, sentEventId);
+      navigateRoomThread(roomId, sentEventId);
     },
-    [effectiveThreadId, navigateRoomThread, room.roomId, threadId, viewMode]
+    [effectiveThreadId, navigateRoomThread, roomId, threadId, viewMode]
   );
 
   useEffect(() => {
@@ -279,14 +276,14 @@ export const useRoomViewThreadState = ({
   useEffect(() => {
     if (!threadId || !effectiveThreadId || threadId === effectiveThreadId) return;
 
-    navigateRoomThread(room.roomId, effectiveThreadId, eventId, { replace: true });
-  }, [effectiveThreadId, eventId, navigateRoomThread, room.roomId, threadId]);
+    navigateRoomThread(roomId, effectiveThreadId, eventId, { replace: true });
+  }, [effectiveThreadId, eventId, navigateRoomThread, roomId, threadId]);
 
   useEffect(() => {
     if (viewMode === 'classic' || !isConfirmedMatrixEventId(effectiveThreadId)) return;
 
-    bumpRecentThread(room.roomId, effectiveThreadId, undefined, recentThreadSummaryText);
-  }, [effectiveThreadId, recentThreadSummaryText, room.roomId, viewMode]);
+    bumpRecentThread(roomId, effectiveThreadId, undefined, recentThreadSummaryText);
+  }, [effectiveThreadId, recentThreadSummaryText, roomId, viewMode]);
 
   return {
     effectiveThreadId,

--- a/src/app/mindroom/threads/useRoomViewThreadState.ts
+++ b/src/app/mindroom/threads/useRoomViewThreadState.ts
@@ -61,6 +61,7 @@ export type RoomViewThreadState = {
   handleSortDirectionChange: () => void;
   handleToggle: (key: ThreadFilterKey) => void;
   handleToggleThreadSortFreeze: () => void;
+  handleRoomMessageSent: (eventId: string) => void;
   handleViewModeChange: (mode: RoomViewMode) => void;
   setThreadSortFreezeState: Dispatch<SetStateAction<ThreadSortFreezeState | null>>;
   storeThreadSummary: ReturnType<typeof useRoomThreadSummaryState>['storeThreadSummary'];
@@ -242,6 +243,16 @@ export const useRoomViewThreadState = ({
     [setViewMode]
   );
 
+  const handleRoomMessageSent = useCallback(
+    (sentEventId: string) => {
+      if (viewMode !== 'compact' || threadId || effectiveThreadId) return;
+      if (!isConfirmedMatrixEventId(sentEventId)) return;
+
+      navigateRoomThread(room.roomId, sentEventId);
+    },
+    [effectiveThreadId, navigateRoomThread, room.roomId, threadId, viewMode]
+  );
+
   useEffect(() => {
     setThreadSortFreezeState(null);
   }, [roomId]);
@@ -289,6 +300,7 @@ export const useRoomViewThreadState = ({
     handleSortDirectionChange,
     handleToggle,
     handleToggleThreadSortFreeze,
+    handleRoomMessageSent,
     handleViewModeChange,
     setThreadSortFreezeState,
     storeThreadSummary,


### PR DESCRIPTION
## Summary
- Auto-open newly sent top-level compact room messages as their own thread once Matrix returns the sent event id.
- Wire composer and upload send callbacks into the existing MindRoom thread navigation path while leaving active-thread and classic-mode sends unchanged.
- Add focused coverage for text sends, upload-root sends, compact/classic/thread guards, and the runbook entry.

## Test Plan
- [x] `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`
- [x] `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts`
- [x] `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`
- [x] `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run lint`
- [x] `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
- [x] `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npx prettier --check FORK_CHANGES.md src/app/mindroom/room-input/MindroomRoomInput.tsx src/app/mindroom/room-input/__tests__/RoomInput.test.ts src/app/mindroom/threads/MindroomRoomView.tsx src/app/mindroom/threads/__tests__/RoomView.test.ts src/app/mindroom/threads/useRoomInputSendSessionController.ts src/app/mindroom/threads/useRoomInputSendSessionController.test.ts src/app/mindroom/threads/useRoomViewThreadState.ts`
- [x] `git diff --check`

## Summary by Sourcery

Auto-open compact room overview message sends as threads and plumb composer send callbacks into thread navigation while keeping classic and existing thread behavior unchanged.

New Features:
- Trigger navigation to a new thread when a top-level room message is successfully sent from the compact room overview using confirmed Matrix event IDs.
- Expose a room input callback to notify consumers when a top-level room message (text or upload root) is successfully sent.

Enhancements:
- Extend room input send-session handling so only root uploads notify the new message callback, skipping child uploads and caption replies that already target the thread.
- Centralize compact auto-thread routing logic in the room view thread state hook to guard against local-echo IDs, classic mode, and existing thread contexts.

Documentation:
- Add a CINNY-133 runbook entry documenting the compact auto-thread behavior, routing decisions, risks, and validation steps.

Tests:
- Add focused tests for room input callbacks, send-session upload notification behavior, and room view auto-thread routing in compact versus classic or existing-thread contexts.