### PR TITLE
feat: add router delegate menu

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -120,6 +120,11 @@
     `room.getMembers()` snapshot.
   - Review follow-up fixed both issues and added regression coverage for the
     encoded mention link and reactive member source.
+  - PR-hosted review triage accepted the actionable Gemini/Greptile findings:
+    restrict delegation to text messages, ignore empty mention ids, normalize
+    CRLF line breaks in formatted HTML, remove the `sendMessage` `as any` cast,
+    and style delegate send errors with the standard critical color token.
+  - Non-actionable bot limit/summary/preview comments were ignored.
 - Validation:
   - Dependency sync: `npm ci` installed local dependencies; npm reported 27
     audit findings.
@@ -189,6 +194,25 @@
   - Second rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
     (existing Vite runtime-config, sourcemap, localStorage, and chunk-size
     warnings only).
+  - PR review red helper check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/messages/delegation.test.ts`
+    failed with 3 expected regressions for empty mention ids, non-text router
+    messages, and CRLF formatted HTML.
+  - PR review green focused check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+    (2 files, 17 tests).
+  - PR review green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`.
+  - PR review green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run lint`
+    (18 warnings, 0 errors - existing warning class).
+  - PR review green:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test` (309 files, 2311
+    tests).
+  - PR review green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
+    (existing Vite runtime-config, sourcemap, localStorage, and chunk-size
+    warnings only).
+  - PR review green:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npx prettier --check FORK_CHANGES.md src/app/mindroom/messages/delegation.ts src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/MindroomMessageControls.tsx`
+    and `git diff --check`.
 
 ### CINNY-208 - Auto-open compact sends as threads (2026-06-17)
 

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -76,6 +76,120 @@
   - Monitor the next `origin/dev` Xcode Cloud archive for Apple version
     `4.12.2` and a fresh integer build number.
 
+### CINNY-210 - Delegate unassigned router messages to agents (2026-06-17)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Added a MindRoom message-menu delegate action for unassigned
+    `@mindroom_router:mindroom.chat` messages rendered inside an existing
+    Matrix thread.
+  - The action appears only when the router message has no `m.mentions` user or
+    room mention, has a thread root id, and the room has joined
+    `@mindroom_*:mindroom.chat` agents besides the router.
+  - Selecting an agent sends a same-thread Matrix reply that quotes the original
+    router message, includes a clickable Matrix.to mention in `formatted_body`,
+    and sets `m.mentions.user_ids` for the selected agent.
+  - Added design and implementation-plan docs under `docs/superpowers/` for
+    the route from brainstorm to implementation.
+- Decisions:
+  - Keep the first version specific to the current MindRoom router and
+    `mindroom.chat` agent namespace, but isolate the policy in
+    `messages/delegation.ts` constants so a later generic policy can be added
+    without touching menu plumbing.
+  - Use joined room members only; invited agents are excluded until there is a
+    product need to delegate to agents that cannot receive the message yet.
+  - Treat `m.mentions` as the source of truth for whether a message is already
+    tagged. Raw `@...` text without `m.mentions` does not suppress delegation.
+  - Send directly from the message menu instead of pre-filling the composer so
+    the relation, formatted mention, and `m.mentions` payload stay atomic.
+- Risks:
+  - Router or agent ids outside the current namespace will not appear until the
+    isolated constants become configuration.
+  - Raw-text mentions without Matrix mention metadata are intentionally ignored
+    for now.
+- Next steps:
+  - Watch real router rooms for whether non-`mindroom.chat` agent namespaces or
+    invited agents need support.
+  - If a second router or domain appears, lift the constants into a small
+    configurable policy instead of duplicating checks in the UI.
+- Review:
+  - Independent subagent review found no critical issues and two important
+    follow-ups: the Matrix.to mention href needed URL encoding, and the delegate
+    menu needed the reactive room-member hook instead of a one-time
+    `room.getMembers()` snapshot.
+  - Review follow-up fixed both issues and added regression coverage for the
+    encoded mention link and reactive member source.
+- Validation:
+  - Dependency sync: `npm ci` installed local dependencies; npm reported 27
+    audit findings.
+  - Red check:
+    `npm test -- src/app/mindroom/messages/delegation.test.ts` failed while the
+    helper module did not exist.
+  - Red check:
+    `npm test -- src/app/mindroom/messages/delegation.test.ts` failed with 4
+    assertion failures against compile stubs.
+  - Green helper check:
+    `npm test -- src/app/mindroom/messages/delegation.test.ts` (6 tests).
+  - Red UI check:
+    `npm test -- src/app/mindroom/messages/__tests__/Message.test.ts` failed
+    while `Delegate to` did not render.
+  - Green focused check:
+    `npm test -- src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+    (2 files, 13 tests).
+  - Review red helper check:
+    `npm test -- src/app/mindroom/messages/delegation.test.ts` failed while the
+    Matrix.to mention href was not URL encoded.
+  - Review red UI check:
+    `npm test -- src/app/mindroom/messages/__tests__/Message.test.ts` failed
+    while the Matrix.to mention href was not URL encoded and the delegate menu
+    used stale `room.getMembers()` data.
+  - Review green focused check:
+    `npm test -- src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+    (2 files, 14 tests).
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (18 warnings, 0 errors - existing console/unused-var
+    warning class).
+  - Green: `npm test` (303 files, 2261 tests).
+  - Green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-17-router-delegate-design.md docs/superpowers/plans/2026-06-17-router-delegate.md src/app/mindroom/messages/delegation.ts src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/messageExtensions.tsx src/app/mindroom/messages/MindroomMessage.tsx src/app/mindroom/messages/__tests__/Message.test.ts`.
+  - Green: `git diff --check`.
+  - Latest rebase check: rebased onto `origin/dev` at `8ab6f9b4`; resolved the
+    `FORK_CHANGES.md` conflict by preserving upstream `CINNY-208`/`CINNY-207`
+    entries and renumbering this entry to `CINNY-209`.
+  - Latest rebase green focused check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+    (2 files, 14 tests).
+  - Latest rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`.
+  - Latest rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run lint`
+    (18 warnings, 0 errors - existing warning class).
+  - Latest rebase green:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test` (308 files, 2302
+    tests).
+  - Latest rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
+    (existing Vite runtime-config, sourcemap, localStorage, and chunk-size
+    warnings only).
+  - Second rebase check: rebased onto `origin/dev` at `11fc880b`; resolved the
+    `FORK_CHANGES.md` conflict by preserving upstream `CINNY-209` and
+    renumbering this entry to `CINNY-210`.
+  - CI title check root cause: GitHub `Check PR title / lint` failed because
+    the PR title `Add router delegate menu` lacked a Conventional Commit type;
+    renamed the PR to `feat: add router delegate menu`.
+  - Second rebase green focused check:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/__tests__/Message.test.ts`
+    (2 files, 14 tests).
+  - Second rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`.
+  - Second rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run lint`
+    (18 warnings, 0 errors - existing warning class).
+  - Second rebase green:
+    `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test` (309 files, 2308
+    tests).
+  - Second rebase green: `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
+    (existing Vite runtime-config, sourcemap, localStorage, and chunk-size
+    warnings only).
+
 ### CINNY-208 - Auto-open compact sends as threads (2026-06-17)
 
 - Status:

--- a/docs/superpowers/plans/2026-06-17-router-delegate.md
+++ b/docs/superpowers/plans/2026-06-17-router-delegate.md
@@ -1,0 +1,237 @@
+# Router Delegate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a message-menu delegate action for unassigned MindRoom router messages inside threads.
+
+**Architecture:** Put pure matching/content logic in `src/app/mindroom/messages/delegation.ts`, then wire it into the existing MindRoom message-menu extension path. The UI sends a same-thread Matrix reply with clickable formatted Matrix.to mention and explicit `m.mentions`.
+
+**Tech Stack:** React 18, TypeScript, matrix-js-sdk, Folds menu components, Vitest.
+
+---
+
+## File Structure
+
+- Create `src/app/mindroom/messages/delegation.ts` for pure helper logic.
+- Create `src/app/mindroom/messages/delegation.test.ts` for helper tests.
+- Modify `src/app/mindroom/messages/MindroomMessageControls.tsx` to add the delegate menu popout and send action.
+- Modify `src/app/mindroom/messages/messageExtensions.tsx` to pass room/event/content context into the delegate menu extension.
+- Modify `src/app/mindroom/messages/MindroomMessage.tsx` to provide `room`, `mEvent`, and effective content to menu extensions.
+- Modify `src/app/mindroom/messages/__tests__/Message.test.ts` for menu integration coverage.
+- Modify `FORK_CHANGES.md` with the runbook entry and validation notes.
+
+### Task 1: Helper Red Test
+
+**Files:**
+
+- Create: `src/app/mindroom/messages/delegation.test.ts`
+- Create: `src/app/mindroom/messages/delegation.ts`
+
+- [ ] **Step 1: Write the failing helper test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  buildMindroomDelegateMessageContent,
+  getMindroomDelegateAgents,
+  shouldShowMindroomDelegateAction,
+} from './delegation';
+
+describe('mindroom delegation helpers', () => {
+  it('detects unassigned router messages inside threads', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: { msgtype: 'm.text', body: 'Who owns this?' },
+        eventId: '$router',
+        threadRootId: '$thread',
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(true);
+  });
+
+  it('hides delegation when the router message already mentions someone', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: {
+          msgtype: 'm.text',
+          body: '@mindroom_worker:mindroom.chat already tagged',
+          'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
+        },
+        eventId: '$router',
+        threadRootId: '$thread',
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(false);
+  });
+
+  it('filters joined MindRoom agents and excludes the router', () => {
+    expect(
+      getMindroomDelegateAgents([
+        { userId: '@mindroom_router:mindroom.chat', membership: 'join' },
+        { userId: '@mindroom_worker:mindroom.chat', membership: 'join' },
+        { userId: '@mindroom_invited:mindroom.chat', membership: 'invite' },
+        { userId: '@alice:mindroom.chat', membership: 'join' },
+      ])
+    ).toEqual(['@mindroom_worker:mindroom.chat']);
+  });
+
+  it('builds same-thread reply content with clickable mention metadata', () => {
+    expect(
+      buildMindroomDelegateMessageContent({
+        originalBody: 'Who owns <this>?',
+        selectedAgentId: '@mindroom_worker:mindroom.chat',
+        routerEventId: '$router',
+        threadRootId: '$thread',
+      })
+    ).toEqual({
+      msgtype: 'm.text',
+      body: 'Who owns <this>?\n\n@mindroom_worker:mindroom.chat, can you address this question?',
+      format: 'org.matrix.custom.html',
+      formatted_body:
+        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/@mindroom_worker:mindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
+      'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
+      'm.relates_to': {
+        rel_type: 'm.thread',
+        event_id: '$thread',
+        is_falling_back: false,
+        'm.in_reply_to': { event_id: '$router' },
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run red helper test**
+
+Run: `npm test -- src/app/mindroom/messages/delegation.test.ts`
+
+Expected: FAIL because `./delegation` does not export the helper functions.
+
+### Task 2: Helper Green
+
+**Files:**
+
+- Modify: `src/app/mindroom/messages/delegation.ts`
+- Test: `src/app/mindroom/messages/delegation.test.ts`
+
+- [ ] **Step 1: Implement helper functions**
+
+Implement constants for router id and agent regex, a safe HTML escape helper,
+`getMindroomDelegateAgents`, `hasMindroomDelegateMention`, `shouldShowMindroomDelegateAction`,
+`getMindroomDelegateOriginalBody`, and `buildMindroomDelegateMessageContent`.
+
+- [ ] **Step 2: Run helper test**
+
+Run: `npm test -- src/app/mindroom/messages/delegation.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit helper slice**
+
+Run:
+
+```bash
+git add src/app/mindroom/messages/delegation.ts src/app/mindroom/messages/delegation.test.ts docs/superpowers/specs/2026-06-17-router-delegate-design.md docs/superpowers/plans/2026-06-17-router-delegate.md
+git commit -m "feat: add router delegate helpers"
+```
+
+### Task 3: UI Red Test
+
+**Files:**
+
+- Modify: `src/app/mindroom/messages/__tests__/Message.test.ts`
+
+- [ ] **Step 1: Extend message-menu integration tests**
+
+Add tests that render a router message with `threadRootId = '$thread'`, room
+members including `@mindroom_worker:mindroom.chat`, open the context menu, click
+`Delegate to`, click the agent, and assert `sendMessage` received the expected
+Matrix content.
+
+- [ ] **Step 2: Run red UI test**
+
+Run: `npm test -- src/app/mindroom/messages/__tests__/Message.test.ts`
+
+Expected: FAIL because no `Delegate to` menu item is rendered.
+
+### Task 4: UI Green
+
+**Files:**
+
+- Modify: `src/app/mindroom/messages/MindroomMessageControls.tsx`
+- Modify: `src/app/mindroom/messages/messageExtensions.tsx`
+- Modify: `src/app/mindroom/messages/MindroomMessage.tsx`
+- Test: `src/app/mindroom/messages/__tests__/Message.test.ts`
+
+- [ ] **Step 1: Wire delegate menu context**
+
+Pass `room`, `mEvent`, and `menuMessageContent` into `MindroomMessageMenuExtensions`.
+
+- [ ] **Step 2: Add delegate menu item**
+
+In `MindroomMessageControls.tsx`, use `room.getMembers()` to collect joined
+agents, render `Delegate to`, render agent choices in a nested `PopOut`, and call
+`mx.sendMessage(room.roomId, buildMindroomDelegateMessageContent(...))` on
+selection.
+
+- [ ] **Step 3: Run UI test**
+
+Run: `npm test -- src/app/mindroom/messages/__tests__/Message.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit UI slice**
+
+Run:
+
+```bash
+git add src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/messageExtensions.tsx src/app/mindroom/messages/MindroomMessage.tsx src/app/mindroom/messages/__tests__/Message.test.ts
+git commit -m "feat: add router delegate menu"
+```
+
+### Task 5: Runbook and Validation
+
+**Files:**
+
+- Modify: `FORK_CHANGES.md`
+
+- [ ] **Step 1: Add runbook entry**
+
+Add a new `CINNY-132 - Delegate unassigned router messages to agents` section
+with status, summary, decisions, risks, next steps, and validation commands.
+
+- [ ] **Step 2: Run final checks**
+
+Run:
+
+```bash
+npx prettier --check FORK_CHANGES.md docs/superpowers/specs/2026-06-17-router-delegate-design.md docs/superpowers/plans/2026-06-17-router-delegate.md src/app/mindroom/messages/delegation.ts src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/MindroomMessageControls.tsx src/app/mindroom/messages/messageExtensions.tsx src/app/mindroom/messages/MindroomMessage.tsx src/app/mindroom/messages/__tests__/Message.test.ts
+npm run typecheck
+npm test
+npm run build
+git diff --check
+```
+
+Expected: all commands exit 0. Existing build warnings are acceptable if they
+match current Vite warning class.
+
+- [ ] **Step 3: Commit validation docs**
+
+Run:
+
+```bash
+git add FORK_CHANGES.md
+git commit -m "docs: record router delegate validation"
+```
+
+## Self-Review
+
+Spec coverage: plan covers eligibility, joined-agent filtering, same-thread
+reply relation, clickable Matrix.to mention, `m.mentions`, UI integration,
+errors, runbook, and validation.
+
+Placeholder scan: no placeholder markers remain.
+
+Type consistency: helper names and file paths are consistent across tasks.

--- a/docs/superpowers/specs/2026-06-17-router-delegate-design.md
+++ b/docs/superpowers/specs/2026-06-17-router-delegate-design.md
@@ -1,0 +1,67 @@
+# Router Delegate Design
+
+## Goal
+
+Add a MindRoom message-menu action that lets a user delegate an unassigned router
+message to one joined MindRoom agent in the same thread.
+
+## Behavior
+
+The delegate action appears only when all conditions are true:
+
+- The message sender is `@mindroom_router:mindroom.chat`.
+- The effective message content has no direct user mentions in `m.mentions.user_ids`
+  and no room mention in `m.mentions.room`.
+- The message is rendered inside a Matrix thread and exposes a thread root id.
+- The room has at least one joined member matching
+  `^@mindroom_[^:]+:mindroom\.chat$`, excluding the router user.
+
+The menu item is labeled `Delegate to`. Opening it shows the eligible joined
+agents in the room. Selecting an agent sends a new text message in the same
+thread, replying to the router message.
+
+The sent message body is:
+
+```text
+<original message>
+
+@selected_agent:mindroom.chat, can you address this question?
+```
+
+The sent message also includes formatted HTML with a clickable Matrix.to user
+link and `m.mentions.user_ids` containing the selected agent id.
+
+## Architecture
+
+Use the existing MindRoom message-menu extension path. Add focused delegate
+helpers in `src/app/mindroom/messages/delegation.ts` for eligibility, agent
+collection, mention detection, HTML escaping, and Matrix event content creation.
+Render the UI from `MindroomMessageControls.tsx` and pass room/message context
+through `MindroomMessageMenuExtensions`.
+
+Sending uses `mx.sendMessage(room.roomId, content)` directly. The content uses
+`m.relates_to.rel_type = m.thread`, `m.relates_to.event_id = threadRootId`,
+`m.relates_to.is_falling_back = false`, and `m.in_reply_to.event_id` pointing at
+the router message id.
+
+## Errors
+
+If sending is in flight, agent menu items are disabled. If Matrix send rejects,
+the delegate menu stays open and displays a short failure message so the user can
+retry or close the menu.
+
+## Tests
+
+Add unit tests for pure delegate helpers and focused message-menu integration:
+
+- delegate action hidden for non-router senders,
+- hidden when the router message already has `m.mentions`,
+- hidden when the message is not in a thread,
+- shows joined MindRoom agents only,
+- selected agent send includes same-thread reply relation, plain body,
+  clickable formatted mention, and `m.mentions.user_ids`.
+
+## Validation
+
+Run the focused delegate tests first, then typecheck and the normal test suite
+before completion.

--- a/src/app/mindroom/messages/MindroomMessage.tsx
+++ b/src/app/mindroom/messages/MindroomMessage.tsx
@@ -804,9 +804,7 @@ export const Message = as<'div', MessageProps>(
     const [menuAnchor, setMenuAnchor] = useState<RectCords>();
     const [emojiBoardAnchor, setEmojiBoardAnchor] = useState<RectCords>();
     const menuMessageContent = resolvedMessageContent ?? getMenuMessageContent(room, mEvent);
-    const showCopyText = isCopyTextMessageContent(
-      menuMessageContent as Record<string, unknown>
-    );
+    const showCopyText = isCopyTextMessageContent(menuMessageContent as Record<string, unknown>);
     const mindroomMessageExtensions = useMindroomMessageExtensionState(
       menuMessageContent,
       menuAnchor !== undefined
@@ -1176,10 +1174,13 @@ export const Message = as<'div', MessageProps>(
                               />
                             )}
                             <MindroomMessageMenuExtensions
+                              content={menuMessageContent}
                               controls={mindroomAiRunControls}
+                              mEvent={mEvent}
                               state={mindroomMessageExtensions}
                               onClose={closeMenu}
                               onOpenAiRun={handleOpenMindroomAiRun}
+                              room={room}
                             />
                             {showDeveloperTools && (
                               <MessageSourceCodeItem

--- a/src/app/mindroom/messages/MindroomMessageControls.tsx
+++ b/src/app/mindroom/messages/MindroomMessageControls.tsx
@@ -24,6 +24,7 @@ import { MatrixEvent, Room } from 'matrix-js-sdk';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { useRoomMembers } from '../../hooks/useRoomMembers';
 import { stopPropagation } from '../../utils/keyboard';
 import { assignElementRef } from '../../utils/react';
 import { MindroomAiRunInfo, getMindroomAiRunInfo } from './aiRun';
@@ -316,7 +317,8 @@ export function MindroomDelegateMenuItem({
   const [agentMenuAnchor, setAgentMenuAnchor] = useState<RectCords>();
   const [submittingAgentId, setSubmittingAgentId] = useState<string>();
   const [errorMessage, setErrorMessage] = useState<string>();
-  const agents = useMemo(() => getMindroomDelegateAgents(room.getMembers()), [room]);
+  const members = useRoomMembers(mx, room.roomId);
+  const agents = useMemo(() => getMindroomDelegateAgents(members), [members]);
   const routerEventId = mEvent.getId() ?? undefined;
   const threadRootId = mEvent.threadRootId;
   const originalBody = getMindroomDelegateOriginalBody(content);

--- a/src/app/mindroom/messages/MindroomMessageControls.tsx
+++ b/src/app/mindroom/messages/MindroomMessageControls.tsx
@@ -15,6 +15,7 @@ import {
   Spinner,
   Text,
   as,
+  color,
   config,
 } from 'folds';
 import React, { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
@@ -351,7 +352,7 @@ export function MindroomDelegateMenuItem({
           selectedAgentId: agentId,
           routerEventId,
           threadRootId,
-        }) as any
+        })
       );
       setAgentMenuAnchor(undefined);
       onClose?.();
@@ -395,7 +396,7 @@ export function MindroomDelegateMenuItem({
             ))}
             {errorMessage && (
               <Box style={{ padding: config.space.S200 }}>
-                <Text as="span" size="T200" priority="400">
+                <Text style={{ color: color.Critical.Main }} as="span" size="T200" priority="400">
                   {errorMessage}
                 </Text>
               </Box>

--- a/src/app/mindroom/messages/MindroomMessageControls.tsx
+++ b/src/app/mindroom/messages/MindroomMessageControls.tsx
@@ -5,10 +5,13 @@ import {
   Icon,
   IconButton,
   Icons,
+  Menu,
   MenuItem,
   Overlay,
   OverlayBackdrop,
   OverlayCenter,
+  PopOut,
+  RectCords,
   Spinner,
   Text,
   as,
@@ -17,6 +20,7 @@ import {
 import React, { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import FileSaver from 'file-saver';
+import { MatrixEvent, Room } from 'matrix-js-sdk';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
@@ -40,6 +44,12 @@ import {
   downloadMindroomLongTextSidecarBlob,
   useMindroomLongTextResolvedContent,
 } from './MindroomLongTextText';
+import {
+  buildMindroomDelegateMessageContent,
+  getMindroomDelegateAgents,
+  getMindroomDelegateOriginalBody,
+  shouldShowMindroomDelegateAction,
+} from './delegation';
 import * as css from './MindroomMessageControls.css';
 
 export function useMindroomMessageControls(content: Record<string, unknown>, menuOpen: boolean) {
@@ -287,3 +297,123 @@ export const MindroomDownloadOriginalMenuItem = as<
     </MenuItem>
   );
 });
+
+const getDelegateErrorMessage = (error: unknown): string =>
+  error instanceof Error && error.message ? error.message : 'Unable to delegate. Please try again.';
+
+export function MindroomDelegateMenuItem({
+  content,
+  mEvent,
+  onClose,
+  room,
+}: {
+  content: Record<string, unknown>;
+  mEvent: MatrixEvent;
+  onClose?: () => void;
+  room: Room;
+}) {
+  const mx = useMatrixClient();
+  const [agentMenuAnchor, setAgentMenuAnchor] = useState<RectCords>();
+  const [submittingAgentId, setSubmittingAgentId] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const agents = useMemo(() => getMindroomDelegateAgents(room.getMembers()), [room]);
+  const routerEventId = mEvent.getId() ?? undefined;
+  const threadRootId = mEvent.threadRootId;
+  const originalBody = getMindroomDelegateOriginalBody(content);
+  const showDelegate = shouldShowMindroomDelegateAction({
+    agents,
+    content,
+    eventId: routerEventId,
+    senderId: mEvent.getSender() ?? undefined,
+    threadRootId,
+  });
+
+  if (!showDelegate || !routerEventId || !threadRootId) return null;
+
+  const handleOpenAgents = (evt: React.MouseEvent<HTMLButtonElement>) => {
+    setErrorMessage(undefined);
+    setAgentMenuAnchor(evt.currentTarget.getBoundingClientRect());
+  };
+
+  const handleDelegate = async (agentId: string) => {
+    if (submittingAgentId) return;
+
+    setErrorMessage(undefined);
+    setSubmittingAgentId(agentId);
+
+    try {
+      await mx.sendMessage(
+        room.roomId,
+        buildMindroomDelegateMessageContent({
+          originalBody,
+          selectedAgentId: agentId,
+          routerEventId,
+          threadRootId,
+        }) as any
+      );
+      setAgentMenuAnchor(undefined);
+      onClose?.();
+    } catch (error) {
+      setErrorMessage(getDelegateErrorMessage(error));
+    } finally {
+      setSubmittingAgentId(undefined);
+    }
+  };
+
+  return (
+    <PopOut
+      anchor={agentMenuAnchor}
+      position="Bottom"
+      align={agentMenuAnchor?.width === 0 ? 'Start' : 'End'}
+      offset={agentMenuAnchor?.width === 0 ? 0 : undefined}
+      content={
+        <Menu>
+          <Box direction="Column" gap="100">
+            {agents.map((agentId) => (
+              <MenuItem
+                key={agentId}
+                size="300"
+                after={
+                  submittingAgentId === agentId ? (
+                    <Spinner fill="Soft" size="100" />
+                  ) : (
+                    <Icon size="100" src={Icons.User} />
+                  )
+                }
+                radii="300"
+                onClick={() => {
+                  void handleDelegate(agentId);
+                }}
+                aria-disabled={submittingAgentId !== undefined}
+              >
+                <Text className={css.MenuItemText} as="span" size="T300" truncate>
+                  {agentId}
+                </Text>
+              </MenuItem>
+            ))}
+            {errorMessage && (
+              <Box style={{ padding: config.space.S200 }}>
+                <Text as="span" size="T200" priority="400">
+                  {errorMessage}
+                </Text>
+              </Box>
+            )}
+          </Box>
+        </Menu>
+      }
+    >
+      <MenuItem
+        size="300"
+        after={<Icon size="100" src={Icons.User} />}
+        radii="300"
+        onClick={handleOpenAgents}
+        aria-haspopup="menu"
+        aria-pressed={agentMenuAnchor !== undefined}
+      >
+        <Text className={css.MenuItemText} as="span" size="T300" truncate>
+          Delegate to
+        </Text>
+      </MenuItem>
+    </PopOut>
+  );
+}

--- a/src/app/mindroom/messages/__tests__/Message.test.ts
+++ b/src/app/mindroom/messages/__tests__/Message.test.ts
@@ -17,6 +17,9 @@ const domMocks = vi.hoisted(() => ({
 const matrixMocks = vi.hoisted(() => ({
   sendMessage: vi.fn(),
 }));
+const roomMemberMocks = vi.hoisted(() => ({
+  members: [] as Array<{ membership?: string | null; userId?: string | null }>,
+}));
 const longTextMocks = vi.hoisted(() => ({
   downloadMindroomLongTextSidecarBlob: vi.fn(),
   getMindroomLongTextSource: vi.fn(() => undefined),
@@ -240,6 +243,10 @@ vi.mock('../../../hooks/useMatrixClient', () => ({
   }),
 }));
 
+vi.mock('../../../hooks/useRoomMembers', () => ({
+  useRoomMembers: () => roomMemberMocks.members,
+}));
+
 vi.mock('../../../hooks/useRecentEmoji', () => ({
   useRecentEmoji: () => [],
 }));
@@ -343,6 +350,7 @@ beforeEach(() => {
   lastMessageBaseNode = undefined;
   vi.clearAllMocks();
   matrixMocks.sendMessage.mockResolvedValue({ event_id: '$delegate' });
+  roomMemberMocks.members = [];
   longTextMocks.getMindroomLongTextSource.mockReturnValue(undefined);
   longTextMocks.useMindroomLongTextResolvedContent.mockReturnValue(undefined);
 });
@@ -381,12 +389,14 @@ const renderMessage = async (
   {
     collapse = true,
     eventId,
+    hookMembers,
     members,
     senderId,
     threadRootId,
   }: {
     collapse?: boolean;
     eventId?: string;
+    hookMembers?: Array<{ membership?: string | null; userId?: string | null }>;
     members?: Array<{ membership?: string | null; userId?: string | null }>;
     senderId?: string;
     threadRootId?: string;
@@ -395,6 +405,7 @@ const renderMessage = async (
   const Message = await getMessageComponent();
   let renderer!: ReactTestRenderer;
   lastMessageBaseNode = undefined;
+  roomMemberMocks.members = hookMembers ?? members ?? [];
 
   await act(async () => {
     renderer = create(
@@ -751,7 +762,7 @@ describe('Router delegate menu item', () => {
       body: 'Who owns <this>?\n\n@mindroom_worker:mindroom.chat, can you address this question?',
       format: 'org.matrix.custom.html',
       formatted_body:
-        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/@mindroom_worker:mindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
+        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/%40mindroom_worker%3Amindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
       'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
       'm.relates_to': {
         rel_type: 'm.thread',
@@ -760,5 +771,25 @@ describe('Router delegate menu item', () => {
         'm.in_reply_to': { event_id: '$router' },
       },
     });
+  });
+
+  it('uses the reactive room-member hook instead of a stale room member snapshot', async () => {
+    const { renderer } = await renderMessage(
+      {
+        msgtype: 'm.text',
+        body: 'Who owns this?',
+      },
+      {
+        eventId: '$router',
+        hookMembers: delegateMembers,
+        members: [],
+        senderId: '@mindroom_router:mindroom.chat',
+        threadRootId: '$thread',
+      }
+    );
+
+    await openContextMenu(renderer);
+
+    expect(getButtonByText(renderer, 'Delegate to')).toBeDefined();
   });
 });

--- a/src/app/mindroom/messages/__tests__/Message.test.ts
+++ b/src/app/mindroom/messages/__tests__/Message.test.ts
@@ -14,6 +14,9 @@ let lastMessageBaseNode: HostNodeMock | undefined;
 const domMocks = vi.hoisted(() => ({
   copyToClipboard: vi.fn(),
 }));
+const matrixMocks = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+}));
 const longTextMocks = vi.hoisted(() => ({
   downloadMindroomLongTextSidecarBlob: vi.fn(),
   getMindroomLongTextSource: vi.fn(() => undefined),
@@ -230,6 +233,7 @@ vi.mock('../../../utils/matrix', () => ({
 vi.mock('../../../hooks/useMatrixClient', () => ({
   useMatrixClient: () => ({
     getUserId: () => '@alice:example.org',
+    sendMessage: matrixMocks.sendMessage,
     sendStateEvent: vi.fn(),
     redactEvent: vi.fn(),
     reportEvent: vi.fn(),
@@ -338,23 +342,32 @@ const getMessageComponent = async () =>
 beforeEach(() => {
   lastMessageBaseNode = undefined;
   vi.clearAllMocks();
+  matrixMocks.sendMessage.mockResolvedValue({ event_id: '$delegate' });
   longTextMocks.getMindroomLongTextSource.mockReturnValue(undefined);
   longTextMocks.useMindroomLongTextResolvedContent.mockReturnValue(undefined);
 });
 
-const createMessageEvent = (content: Record<string, unknown>) =>
+const createMessageEvent = (
+  content: Record<string, unknown>,
+  overrides: {
+    eventId?: string;
+    senderId?: string;
+    threadRootId?: string;
+  } = {}
+) =>
   ({
-    threadRootId: undefined,
+    threadRootId: overrides.threadRootId,
     getContent: () => content,
-    getId: () => '$event',
-    getSender: () => '@alice:example.org',
+    getId: () => overrides.eventId ?? '$event',
+    getSender: () => overrides.senderId ?? '@alice:example.org',
     getTs: () => 1,
     isRedacted: () => false,
   } as const);
 
-const createRoom = () =>
+const createRoom = (members: Array<{ membership?: string | null; userId?: string | null }> = []) =>
   ({
     roomId: '!room:example.org',
+    getMembers: () => members,
     getTimelineForEvent: () => undefined,
   } as const);
 
@@ -365,7 +378,19 @@ type RenderedMessage = {
 
 const renderMessage = async (
   content: Record<string, unknown>,
-  { collapse = true }: { collapse?: boolean } = {}
+  {
+    collapse = true,
+    eventId,
+    members,
+    senderId,
+    threadRootId,
+  }: {
+    collapse?: boolean;
+    eventId?: string;
+    members?: Array<{ membership?: string | null; userId?: string | null }>;
+    senderId?: string;
+    threadRootId?: string;
+  } = {}
 ): Promise<RenderedMessage> => {
   const Message = await getMessageComponent();
   let renderer!: ReactTestRenderer;
@@ -376,8 +401,8 @@ const renderMessage = async (
       React.createElement(
         Message,
         {
-          room: createRoom(),
-          mEvent: createMessageEvent(content),
+          room: createRoom(members),
+          mEvent: createMessageEvent(content, { eventId, senderId, threadRootId }),
           collapse,
           highlight: false,
           messageLayout: 'Modern',
@@ -632,5 +657,108 @@ describe('Message copy text overflow integration', () => {
     });
 
     expect(domMocks.copyToClipboard).toHaveBeenCalledWith('Resolved overflow body');
+  });
+});
+
+describe('Router delegate menu item', () => {
+  const delegateMembers = [
+    { userId: '@mindroom_router:mindroom.chat', membership: 'join' },
+    { userId: '@mindroom_worker:mindroom.chat', membership: 'join' },
+    { userId: '@mindroom_invited:mindroom.chat', membership: 'invite' },
+    { userId: '@alice:example.org', membership: 'join' },
+  ];
+
+  it('does not render Delegate to for non-router messages', async () => {
+    const { renderer } = await renderMessage(
+      {
+        msgtype: 'm.text',
+        body: 'Who owns this?',
+      },
+      {
+        members: delegateMembers,
+        senderId: '@alice:example.org',
+        threadRootId: '$thread',
+      }
+    );
+
+    await openContextMenu(renderer);
+
+    expect(getButtonByText(renderer, 'Delegate to')).toBeUndefined();
+  });
+
+  it('does not render Delegate to when the router message already mentions an agent', async () => {
+    const { renderer } = await renderMessage(
+      {
+        msgtype: 'm.text',
+        body: '@mindroom_worker:mindroom.chat already tagged',
+        'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
+      },
+      {
+        members: delegateMembers,
+        senderId: '@mindroom_router:mindroom.chat',
+        threadRootId: '$thread',
+      }
+    );
+
+    await openContextMenu(renderer);
+
+    expect(getButtonByText(renderer, 'Delegate to')).toBeUndefined();
+  });
+
+  it('sends a same-thread delegate message with clickable mention metadata', async () => {
+    const { renderer } = await renderMessage(
+      {
+        msgtype: 'm.text',
+        body: 'Who owns <this>?',
+      },
+      {
+        eventId: '$router',
+        members: delegateMembers,
+        senderId: '@mindroom_router:mindroom.chat',
+        threadRootId: '$thread',
+      }
+    );
+
+    await openContextMenu(renderer);
+
+    const delegateButton = getButtonByText(renderer, 'Delegate to');
+
+    expect(delegateButton).toBeDefined();
+
+    await act(async () => {
+      delegateButton?.props.onClick({
+        currentTarget: {
+          getBoundingClientRect: () => ({
+            x: 100,
+            y: 200,
+            width: 24,
+            height: 24,
+          }),
+        },
+      });
+    });
+
+    const agentButton = getButtonByText(renderer, '@mindroom_worker:mindroom.chat');
+
+    expect(agentButton).toBeDefined();
+
+    await act(async () => {
+      await agentButton?.props.onClick();
+    });
+
+    expect(matrixMocks.sendMessage).toHaveBeenCalledWith('!room:example.org', {
+      msgtype: 'm.text',
+      body: 'Who owns <this>?\n\n@mindroom_worker:mindroom.chat, can you address this question?',
+      format: 'org.matrix.custom.html',
+      formatted_body:
+        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/@mindroom_worker:mindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
+      'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
+      'm.relates_to': {
+        rel_type: 'm.thread',
+        event_id: '$thread',
+        is_falling_back: false,
+        'm.in_reply_to': { event_id: '$router' },
+      },
+    });
   });
 });

--- a/src/app/mindroom/messages/delegation.test.ts
+++ b/src/app/mindroom/messages/delegation.test.ts
@@ -35,6 +35,34 @@ describe('mindroom delegation helpers', () => {
     ).toBe(false);
   });
 
+  it('does not treat empty mention ids as assigned agents', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: {
+          msgtype: 'm.text',
+          body: 'Who owns this?',
+          'm.mentions': { user_ids: [''] },
+        },
+        eventId: '$router',
+        threadRootId: '$thread',
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(true);
+  });
+
+  it('hides delegation for non-text router messages', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: { msgtype: 'm.file', body: 'question.txt' },
+        eventId: '$router',
+        threadRootId: '$thread',
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(false);
+  });
+
   it('hides delegation when the router message is outside a thread', () => {
     expect(
       shouldShowMindroomDelegateAction({
@@ -91,5 +119,17 @@ describe('mindroom delegation helpers', () => {
         'm.in_reply_to': { event_id: '$router' },
       },
     });
+  });
+
+  it('formats CRLF line breaks without preserving carriage returns in HTML', () => {
+    const content = buildMindroomDelegateMessageContent({
+      originalBody: 'Line one\r\nLine two',
+      selectedAgentId: '@mindroom_worker:mindroom.chat',
+      routerEventId: '$router',
+      threadRootId: '$thread',
+    });
+
+    expect(content.formatted_body).toContain('Line one<br>Line two');
+    expect(content.formatted_body).not.toContain('\r');
   });
 });

--- a/src/app/mindroom/messages/delegation.test.ts
+++ b/src/app/mindroom/messages/delegation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMindroomDelegateMessageContent,
+  getMindroomDelegateAgents,
+  getMindroomDelegateOriginalBody,
+  shouldShowMindroomDelegateAction,
+} from './delegation';
+
+describe('mindroom delegation helpers', () => {
+  it('detects unassigned router messages inside threads', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: { msgtype: 'm.text', body: 'Who owns this?' },
+        eventId: '$router',
+        threadRootId: '$thread',
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(true);
+  });
+
+  it('hides delegation when the router message already mentions someone', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: {
+          msgtype: 'm.text',
+          body: '@mindroom_worker:mindroom.chat already tagged',
+          'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
+        },
+        eventId: '$router',
+        threadRootId: '$thread',
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(false);
+  });
+
+  it('hides delegation when the router message is outside a thread', () => {
+    expect(
+      shouldShowMindroomDelegateAction({
+        senderId: '@mindroom_router:mindroom.chat',
+        content: { msgtype: 'm.text', body: 'Who owns this?' },
+        eventId: '$router',
+        threadRootId: undefined,
+        agents: ['@mindroom_worker:mindroom.chat'],
+      })
+    ).toBe(false);
+  });
+
+  it('filters joined MindRoom agents and excludes the router', () => {
+    expect(
+      getMindroomDelegateAgents([
+        { userId: '@mindroom_router:mindroom.chat', membership: 'join' },
+        { userId: '@mindroom_worker:mindroom.chat', membership: 'join' },
+        { userId: '@mindroom_invited:mindroom.chat', membership: 'invite' },
+        { userId: '@alice:mindroom.chat', membership: 'join' },
+      ])
+    ).toEqual(['@mindroom_worker:mindroom.chat']);
+  });
+
+  it('prefers edited message body for delegation text', () => {
+    expect(
+      getMindroomDelegateOriginalBody({
+        body: 'old',
+        'm.new_content': {
+          body: 'edited',
+        },
+      })
+    ).toBe('edited');
+  });
+
+  it('builds same-thread reply content with clickable mention metadata', () => {
+    expect(
+      buildMindroomDelegateMessageContent({
+        originalBody: 'Who owns <this>?',
+        selectedAgentId: '@mindroom_worker:mindroom.chat',
+        routerEventId: '$router',
+        threadRootId: '$thread',
+      })
+    ).toEqual({
+      msgtype: 'm.text',
+      body: 'Who owns <this>?\n\n@mindroom_worker:mindroom.chat, can you address this question?',
+      format: 'org.matrix.custom.html',
+      formatted_body:
+        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/@mindroom_worker:mindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
+      'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
+      'm.relates_to': {
+        rel_type: 'm.thread',
+        event_id: '$thread',
+        is_falling_back: false,
+        'm.in_reply_to': { event_id: '$router' },
+      },
+    });
+  });
+});

--- a/src/app/mindroom/messages/delegation.test.ts
+++ b/src/app/mindroom/messages/delegation.test.ts
@@ -82,7 +82,7 @@ describe('mindroom delegation helpers', () => {
       body: 'Who owns <this>?\n\n@mindroom_worker:mindroom.chat, can you address this question?',
       format: 'org.matrix.custom.html',
       formatted_body:
-        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/@mindroom_worker:mindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
+        'Who owns &lt;this&gt;?<br><br><a href="https://matrix.to/#/%40mindroom_worker%3Amindroom.chat">@mindroom_worker:mindroom.chat</a>, can you address this question?',
       'm.mentions': { user_ids: ['@mindroom_worker:mindroom.chat'] },
       'm.relates_to': {
         rel_type: 'm.thread',

--- a/src/app/mindroom/messages/delegation.ts
+++ b/src/app/mindroom/messages/delegation.ts
@@ -87,7 +87,9 @@ export const buildMindroomDelegateMessageContent = (options: {
     msgtype: 'm.text',
     body,
     format: 'org.matrix.custom.html',
-    formatted_body: `${formattedOriginalBody}<br><br><a href="https://matrix.to/#/${options.selectedAgentId}">${formattedAgentId}</a>, ${MINDROOM_DELEGATE_PROMPT}`,
+    formatted_body: `${formattedOriginalBody}<br><br><a href="https://matrix.to/#/${encodeURIComponent(
+      options.selectedAgentId
+    )}">${formattedAgentId}</a>, ${MINDROOM_DELEGATE_PROMPT}`,
     'm.mentions': { user_ids: [options.selectedAgentId] },
     'm.relates_to': {
       rel_type: 'm.thread',

--- a/src/app/mindroom/messages/delegation.ts
+++ b/src/app/mindroom/messages/delegation.ts
@@ -1,3 +1,5 @@
+import { MsgType, RelationType } from 'matrix-js-sdk';
+import { type RoomMessageEventContent } from 'matrix-js-sdk/lib/@types/events';
 import { sanitizeText } from '../../utils/sanitize';
 
 export type MindroomDelegateMember = {
@@ -8,6 +10,15 @@ export type MindroomDelegateMember = {
 export const MINDROOM_ROUTER_USER_ID = '@mindroom_router:mindroom.chat';
 export const MINDROOM_DELEGATE_AGENT_PATTERN = /^@mindroom_[^:]+:mindroom\.chat$/;
 export const MINDROOM_DELEGATE_PROMPT = 'can you address this question?';
+
+export type MindroomDelegateMessageContent = RoomMessageEventContent & {
+  'm.relates_to': {
+    rel_type: RelationType.Thread;
+    event_id: string;
+    is_falling_back: false;
+    'm.in_reply_to': { event_id: string };
+  };
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value);
@@ -40,6 +51,14 @@ export const getMindroomDelegateOriginalBody = (content: Record<string, unknown>
   return typeof body === 'string' ? body.trim() : '';
 };
 
+const getMindroomDelegateMsgType = (content: Record<string, unknown>): unknown => {
+  const newContent = isRecord(content['m.new_content'])
+    ? (content['m.new_content'] as Record<string, unknown>)
+    : undefined;
+
+  return newContent?.msgtype ?? content.msgtype;
+};
+
 export const hasMindroomDelegateMention = (content: Record<string, unknown>): boolean => {
   const newContent = isRecord(content['m.new_content'])
     ? (content['m.new_content'] as Record<string, unknown>)
@@ -54,7 +73,10 @@ export const hasMindroomDelegateMention = (content: Record<string, unknown>): bo
     if (mentions.room === true) return true;
 
     const userIds = mentions.user_ids;
-    return Array.isArray(userIds) && userIds.some((userId) => typeof userId === 'string');
+    return (
+      Array.isArray(userIds) &&
+      userIds.some((userId) => typeof userId === 'string' && userId.length > 0)
+    );
   });
 };
 
@@ -68,6 +90,7 @@ export const shouldShowMindroomDelegateAction = (options: {
   if (options.senderId !== MINDROOM_ROUTER_USER_ID) return false;
   if (!options.eventId) return false;
   if (!options.threadRootId) return false;
+  if (getMindroomDelegateMsgType(options.content) !== MsgType.Text) return false;
   if (options.agents.length === 0) return false;
   if (hasMindroomDelegateMention(options.content)) return false;
   return getMindroomDelegateOriginalBody(options.content).length > 0;
@@ -78,13 +101,13 @@ export const buildMindroomDelegateMessageContent = (options: {
   routerEventId: string;
   selectedAgentId: string;
   threadRootId: string;
-}): Record<string, unknown> => {
+}): MindroomDelegateMessageContent => {
   const body = `${options.originalBody}\n\n${options.selectedAgentId}, ${MINDROOM_DELEGATE_PROMPT}`;
-  const formattedOriginalBody = sanitizeText(options.originalBody).replace(/\n/g, '<br>');
+  const formattedOriginalBody = sanitizeText(options.originalBody).replace(/\r?\n/g, '<br>');
   const formattedAgentId = sanitizeText(options.selectedAgentId);
 
   return {
-    msgtype: 'm.text',
+    msgtype: MsgType.Text,
     body,
     format: 'org.matrix.custom.html',
     formatted_body: `${formattedOriginalBody}<br><br><a href="https://matrix.to/#/${encodeURIComponent(
@@ -92,7 +115,7 @@ export const buildMindroomDelegateMessageContent = (options: {
     )}">${formattedAgentId}</a>, ${MINDROOM_DELEGATE_PROMPT}`,
     'm.mentions': { user_ids: [options.selectedAgentId] },
     'm.relates_to': {
-      rel_type: 'm.thread',
+      rel_type: RelationType.Thread,
       event_id: options.threadRootId,
       is_falling_back: false,
       'm.in_reply_to': { event_id: options.routerEventId },

--- a/src/app/mindroom/messages/delegation.ts
+++ b/src/app/mindroom/messages/delegation.ts
@@ -1,0 +1,99 @@
+import { sanitizeText } from '../../utils/sanitize';
+
+export type MindroomDelegateMember = {
+  membership?: string | null;
+  userId?: string | null;
+};
+
+export const MINDROOM_ROUTER_USER_ID = '@mindroom_router:mindroom.chat';
+export const MINDROOM_DELEGATE_AGENT_PATTERN = /^@mindroom_[^:]+:mindroom\.chat$/;
+export const MINDROOM_DELEGATE_PROMPT = 'can you address this question?';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const getContentMentions = (
+  content: Record<string, unknown>
+): Record<string, unknown> | undefined =>
+  isRecord(content['m.mentions']) ? (content['m.mentions'] as Record<string, unknown>) : undefined;
+
+export const getMindroomDelegateAgents = (members: MindroomDelegateMember[]): string[] => {
+  const agents = new Set<string>();
+
+  members.forEach((member) => {
+    if (member.membership !== 'join') return;
+    if (typeof member.userId !== 'string') return;
+    if (member.userId === MINDROOM_ROUTER_USER_ID) return;
+    if (!MINDROOM_DELEGATE_AGENT_PATTERN.test(member.userId)) return;
+    agents.add(member.userId);
+  });
+
+  return Array.from(agents);
+};
+
+export const getMindroomDelegateOriginalBody = (content: Record<string, unknown>): string => {
+  const newContent = isRecord(content['m.new_content'])
+    ? (content['m.new_content'] as Record<string, unknown>)
+    : undefined;
+  const body = newContent?.body ?? content.body;
+
+  return typeof body === 'string' ? body.trim() : '';
+};
+
+export const hasMindroomDelegateMention = (content: Record<string, unknown>): boolean => {
+  const newContent = isRecord(content['m.new_content'])
+    ? (content['m.new_content'] as Record<string, unknown>)
+    : undefined;
+  const mentionSources = [
+    getContentMentions(content),
+    newContent && getContentMentions(newContent),
+  ];
+
+  return mentionSources.some((mentions) => {
+    if (!mentions) return false;
+    if (mentions.room === true) return true;
+
+    const userIds = mentions.user_ids;
+    return Array.isArray(userIds) && userIds.some((userId) => typeof userId === 'string');
+  });
+};
+
+export const shouldShowMindroomDelegateAction = (options: {
+  agents: string[];
+  content: Record<string, unknown>;
+  eventId?: string;
+  senderId?: string;
+  threadRootId?: string;
+}): boolean => {
+  if (options.senderId !== MINDROOM_ROUTER_USER_ID) return false;
+  if (!options.eventId) return false;
+  if (!options.threadRootId) return false;
+  if (options.agents.length === 0) return false;
+  if (hasMindroomDelegateMention(options.content)) return false;
+  return getMindroomDelegateOriginalBody(options.content).length > 0;
+};
+
+export const buildMindroomDelegateMessageContent = (options: {
+  originalBody: string;
+  routerEventId: string;
+  selectedAgentId: string;
+  threadRootId: string;
+}): Record<string, unknown> => {
+  const body = `${options.originalBody}\n\n${options.selectedAgentId}, ${MINDROOM_DELEGATE_PROMPT}`;
+  const formattedOriginalBody = sanitizeText(options.originalBody).replace(/\n/g, '<br>');
+  const formattedAgentId = sanitizeText(options.selectedAgentId);
+
+  return {
+    msgtype: 'm.text',
+    body,
+    format: 'org.matrix.custom.html',
+    formatted_body: `${formattedOriginalBody}<br><br><a href="https://matrix.to/#/${options.selectedAgentId}">${formattedAgentId}</a>, ${MINDROOM_DELEGATE_PROMPT}`,
+    'm.mentions': { user_ids: [options.selectedAgentId] },
+    'm.relates_to': {
+      rel_type: 'm.thread',
+      event_id: options.threadRootId,
+      is_falling_back: false,
+      'm.in_reply_to': { event_id: options.routerEventId },
+    },
+  };
+};

--- a/src/app/mindroom/messages/messageExtensions.tsx
+++ b/src/app/mindroom/messages/messageExtensions.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from 'react';
+import { MatrixEvent, Room } from 'matrix-js-sdk';
 
 import {
+  MindroomDelegateMenuItem,
   MindroomAiRunControls,
   MindroomAiRunControlsRenderProps,
   MindroomAiRunInfoButton,
@@ -69,18 +71,25 @@ export function MindroomMessageHeaderExtensions({
 }
 
 export function MindroomMessageMenuExtensions({
+  content,
   controls,
+  mEvent,
   state,
   onClose,
   onOpenAiRun,
+  room,
 }: {
+  content: Record<string, unknown>;
   controls?: MindroomMessageExtensionControls;
+  mEvent: MatrixEvent;
   state: MindroomMessageExtensionState;
   onClose?: () => void;
   onOpenAiRun: () => void;
+  room: Room;
 }) {
   return (
     <>
+      <MindroomDelegateMenuItem content={content} mEvent={mEvent} onClose={onClose} room={room} />
       {controls && <MindroomAiRunMenuItem onOpen={onOpenAiRun} />}
       {state.longTextSource && (
         <MindroomDownloadOriginalMenuItem source={state.longTextSource} onClose={onClose} />


### PR DESCRIPTION
## Summary
- Add a `Delegate to` message-menu action for unassigned `@mindroom_router:mindroom.chat` messages inside threads.
- Send same-thread Matrix replies with quoted original text, clickable Matrix.to mentions, and `m.mentions.user_ids` for the selected agent.
- Keep router/agent matching policy isolated in MindRoom delegation helpers and use reactive room membership for the agent list.

## Rebase / CI
- Rebased onto `origin/dev` at `11fc880b`.
- Resolved `FORK_CHANGES.md` conflict by preserving upstream `CINNY-209` and renumbering this feature to `CINNY-210`.
- Fixed failing `Check PR title / lint` by renaming PR to `feat: add router delegate menu`.
- Remote PR checks on `dd59e0c8`: Android PR Build passed, Build pull request passed, Docker publish passed, CodeRabbit passed, Sourcery skipped.

## Test Plan
- [x] `npm test -- src/app/mindroom/messages/delegation.test.ts src/app/mindroom/messages/__tests__/Message.test.ts` (2 files, 14 tests)
- [x] `npm run typecheck`
- [x] `npm run lint` (18 existing warnings, 0 errors)
- [x] `npm test` (309 files, 2308 tests)
- [x] `npm run build` (existing Vite/runtime-config/sourcemap/localStorage/chunk warnings)
- [x] `npx prettier --check ...`
- [x] `git diff --check`

## Review
- [x] Independent subagent review completed; important follow-ups fixed for URL-encoded Matrix.to hrefs and reactive room-member sourcing.