### PR TITLE
fix: show accepted invitees in open members drawer

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,56 @@
 
 ## Runbook
 
+### CINNY-132 - Live members drawer updates during invites (2026-06-17)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Reproduced a stale members drawer list when a newly invited user joins while
+    the drawer is already open.
+  - Root cause: `useRoomMembers` ignored live membership and power-level events
+    while `room.loadMembersIfNeeded()` was pending. The drawer header read the
+    room's live joined-member count directly, but the list rendered the stale
+    hook state until the drawer remounted.
+  - Updated `useRoomMembers` so live member events refresh the member array even
+    while the full member load is still pending. The load completion path still
+    refreshes the list again once full member data is available.
+- Decisions:
+  - Keep the fix in the shared `useRoomMembers` hook so the members drawer,
+    room settings members page, lobby members list, and mention autocomplete use
+    the same live update behavior.
+  - Preserve room-id filtering and the final refresh after
+    `loadMembersIfNeeded()` resolves.
+- Risks:
+  - Live member updates can now re-render member-backed surfaces during an
+    in-flight full load; this is expected and limited to membership/power-level
+    event cadence.
+- Validation:
+  - RED observed:
+    `npm test -- src/app/hooks/useRoomMembers.test.tsx` failed because a live
+    join emitted while `loadMembersIfNeeded()` was pending left the hook output
+    at only `@alice:example.org`.
+  - Green focused check:
+    `npm test -- src/app/hooks/useRoomMembers.test.tsx`.
+  - Green affected check:
+    `npm test -- src/app/hooks/useRoomMembers.test.tsx src/app/features/room/MembersDrawer.test.ts`
+    (2 files, 3 tests).
+  - Green:
+    `npx prettier --check FORK_CHANGES.md src/app/hooks/useRoomMembers.ts src/app/hooks/useRoomMembers.test.tsx src/app/features/room/MembersDrawer.test.ts`.
+  - Green: `npm run typecheck`.
+  - Green: `npm run lint` (18 warnings, 0 errors - existing console/unused-var
+    warning class).
+  - Rebase green check: rebased onto `origin/dev` at `11fc880b` and resolved
+    the runbook top-entry conflict.
+  - Green: `npm test` (309 files, 2299 tests; existing localStorage and React
+    Router future-flag warnings).
+  - Green: `npm run build` (existing Vite runtime-config, sourcemap,
+    localStorage, and chunk-size warnings only).
+  - Green: `git diff --check`.
+  - Independent review: subagent review found no issues, confirmed the narrow
+    root fix, and ran the focused hook regression test plus cached diff
+    whitespace check.
+
 ### CINNY-209 - Repair Xcode Cloud App Store versioning (2026-06-17)
 
 - Status:

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Runbook
 
-### CINNY-132 - Live members drawer updates during invites (2026-06-17)
+### CINNY-210 - Live members drawer updates during invites (2026-06-17)
 
 - Status:
   - Complete locally.
@@ -16,6 +16,9 @@
   - Updated `useRoomMembers` so live member events refresh the member array even
     while the full member load is still pending. The load completion path still
     refreshes the list again once full member data is available.
+  - PR review follow-up: handled `loadMembersIfNeeded()` rejection without an
+    unhandled promise, tightened hook test renderer assertions/cleanup, and
+    renumbered this runbook entry away from the existing `CINNY-132`.
 - Decisions:
   - Keep the fix in the shared `useRoomMembers` hook so the members drawer,
     room settings members page, lobby members list, and mention autocomplete use
@@ -31,11 +34,15 @@
     `npm test -- src/app/hooks/useRoomMembers.test.tsx` failed because a live
     join emitted while `loadMembersIfNeeded()` was pending left the hook output
     at only `@alice:example.org`.
+  - Review RED observed:
+    `npm test -- src/app/hooks/useRoomMembers.test.tsx` failed because a
+    rejected `loadMembersIfNeeded()` promise was not logged and produced a
+    Vitest unhandled rejection.
   - Green focused check:
-    `npm test -- src/app/hooks/useRoomMembers.test.tsx`.
+    `npm test -- src/app/hooks/useRoomMembers.test.tsx` (2 tests).
   - Green affected check:
     `npm test -- src/app/hooks/useRoomMembers.test.tsx src/app/features/room/MembersDrawer.test.ts`
-    (2 files, 3 tests).
+    (2 files, 4 tests).
   - Green:
     `npx prettier --check FORK_CHANGES.md src/app/hooks/useRoomMembers.ts src/app/hooks/useRoomMembers.test.tsx src/app/features/room/MembersDrawer.test.ts`.
   - Green: `npm run typecheck`.
@@ -43,7 +50,7 @@
     warning class).
   - Rebase green check: rebased onto `origin/dev` at `11fc880b` and resolved
     the runbook top-entry conflict.
-  - Green: `npm test` (309 files, 2299 tests; existing localStorage and React
+  - Green: `npm test` (309 files, 2300 tests; existing localStorage and React
     Router future-flag warnings).
   - Green: `npm run build` (existing Vite runtime-config, sourcemap,
     localStorage, and chunk-size warnings only).

--- a/src/app/hooks/useRoomMembers.test.tsx
+++ b/src/app/hooks/useRoomMembers.test.tsx
@@ -1,9 +1,16 @@
 import { EventEmitter } from 'node:events';
 import React from 'react';
 import { act, create, ReactTestRenderer } from 'react-test-renderer';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MatrixClient, MatrixEvent, Room, RoomMember, RoomMemberEvent } from 'matrix-js-sdk';
+import { logger } from 'matrix-js-sdk/lib/logger';
 import { useRoomMembers } from './useRoomMembers';
+
+vi.mock('matrix-js-sdk/lib/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -38,6 +45,35 @@ function UseRoomMembersProbe({ mx, roomId }: UseRoomMembersProbeProps) {
   return <output>{members.map((member) => member.userId).join(',')}</output>;
 }
 
+const mountedRenderers = new Set<ReactTestRenderer>();
+
+const createRoomMembersRenderer = (mx: MatrixClient, roomId: string): ReactTestRenderer => {
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(<UseRoomMembersProbe mx={mx} roomId={roomId} />);
+  });
+  expect(renderer).toBeDefined();
+  mountedRenderers.add(renderer as ReactTestRenderer);
+  return renderer as ReactTestRenderer;
+};
+
+const readOutputText = (renderer: ReactTestRenderer): string =>
+  renderer.root.findByType('output').children.join('');
+
+const unmountRenderer = (renderer: ReactTestRenderer): void => {
+  act(() => {
+    renderer.unmount();
+  });
+  mountedRenderers.delete(renderer);
+};
+
+afterEach(() => {
+  for (const renderer of Array.from(mountedRenderers)) {
+    unmountRenderer(renderer);
+  }
+  vi.clearAllMocks();
+});
+
 describe('useRoomMembers', () => {
   it('publishes live membership updates while full member load is still pending', async () => {
     const roomId = '!room:example.org';
@@ -55,12 +91,9 @@ describe('useRoomMembers', () => {
       getRoom: vi.fn(() => room),
     }) as unknown as MatrixClient;
 
-    let renderer: ReactTestRenderer | undefined;
-    act(() => {
-      renderer = create(<UseRoomMembersProbe mx={mx} roomId={roomId} />);
-    });
+    const renderer = createRoomMembersRenderer(mx, roomId);
 
-    expect(renderer?.root.findByType('output').children.join('')).toBe('@alice:example.org');
+    expect(readOutputText(renderer)).toBe('@alice:example.org');
 
     members = [alice, bob];
     act(() => {
@@ -72,9 +105,7 @@ describe('useRoomMembers', () => {
       );
     });
 
-    expect(renderer?.root.findByType('output').children.join('')).toBe(
-      '@alice:example.org,@bob:example.org'
-    );
+    expect(readOutputText(renderer)).toBe('@alice:example.org,@bob:example.org');
 
     members = [alice, bob, carol];
     await act(async () => {
@@ -82,8 +113,37 @@ describe('useRoomMembers', () => {
       await memberLoad.promise;
     });
 
-    expect(renderer?.root.findByType('output').children.join('')).toBe(
-      '@alice:example.org,@bob:example.org,@carol:example.org'
+    expect(readOutputText(renderer)).toBe('@alice:example.org,@bob:example.org,@carol:example.org');
+
+    unmountRenderer(renderer);
+  });
+
+  it('handles member load rejection without an unhandled promise', async () => {
+    const roomId = '!room:example.org';
+    const alice = createMember('@alice:example.org');
+    const loadError = new Error('member load failed');
+    const room = {
+      roomId,
+      getMembers: vi.fn(() => [alice]),
+      loadMembersIfNeeded: vi.fn(() => Promise.reject(loadError)),
+    } as unknown as Room;
+    const mx = Object.assign(new EventEmitter(), {
+      getRoom: vi.fn(() => room),
+    }) as unknown as MatrixClient;
+
+    const renderer = createRoomMembersRenderer(mx, roomId);
+
+    expect(readOutputText(renderer)).toBe('@alice:example.org');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[useRoomMembers] Failed to load room members',
+      loadError
     );
+
+    unmountRenderer(renderer);
   });
 });

--- a/src/app/hooks/useRoomMembers.test.tsx
+++ b/src/app/hooks/useRoomMembers.test.tsx
@@ -1,0 +1,89 @@
+import { EventEmitter } from 'node:events';
+import React from 'react';
+import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { MatrixClient, MatrixEvent, Room, RoomMember, RoomMemberEvent } from 'matrix-js-sdk';
+import { useRoomMembers } from './useRoomMembers';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const deferred = <T,>(): Deferred<T> => {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const createMember = (userId: string): RoomMember =>
+  ({
+    userId,
+    membership: 'join',
+  } as RoomMember);
+
+const createMembershipEvent = (roomId: string): MatrixEvent =>
+  ({
+    getRoomId: () => roomId,
+  } as MatrixEvent);
+
+type UseRoomMembersProbeProps = {
+  mx: MatrixClient;
+  roomId: string;
+};
+function UseRoomMembersProbe({ mx, roomId }: UseRoomMembersProbeProps) {
+  const members = useRoomMembers(mx, roomId);
+  return <output>{members.map((member) => member.userId).join(',')}</output>;
+}
+
+describe('useRoomMembers', () => {
+  it('publishes live membership updates while full member load is still pending', async () => {
+    const roomId = '!room:example.org';
+    const alice = createMember('@alice:example.org');
+    const bob = createMember('@bob:example.org');
+    const carol = createMember('@carol:example.org');
+    let members = [alice];
+    const memberLoad = deferred<void>();
+    const room = {
+      roomId,
+      getMembers: vi.fn(() => members),
+      loadMembersIfNeeded: vi.fn(() => memberLoad.promise),
+    } as unknown as Room;
+    const mx = Object.assign(new EventEmitter(), {
+      getRoom: vi.fn(() => room),
+    }) as unknown as MatrixClient;
+
+    let renderer: ReactTestRenderer | undefined;
+    act(() => {
+      renderer = create(<UseRoomMembersProbe mx={mx} roomId={roomId} />);
+    });
+
+    expect(renderer?.root.findByType('output').children.join('')).toBe('@alice:example.org');
+
+    members = [alice, bob];
+    act(() => {
+      (mx as unknown as EventEmitter).emit(
+        RoomMemberEvent.Membership,
+        createMembershipEvent(roomId),
+        bob,
+        'invite'
+      );
+    });
+
+    expect(renderer?.root.findByType('output').children.join('')).toBe(
+      '@alice:example.org,@bob:example.org'
+    );
+
+    members = [alice, bob, carol];
+    await act(async () => {
+      memberLoad.resolve();
+      await memberLoad.promise;
+    });
+
+    expect(renderer?.root.findByType('output').children.join('')).toBe(
+      '@alice:example.org,@bob:example.org,@carol:example.org'
+    );
+  });
+});

--- a/src/app/hooks/useRoomMembers.ts
+++ b/src/app/hooks/useRoomMembers.ts
@@ -1,4 +1,5 @@
 import { MatrixClient, MatrixEvent, RoomMember, RoomMemberEvent } from 'matrix-js-sdk';
+import { logger } from 'matrix-js-sdk/lib/logger';
 import { useEffect, useState } from 'react';
 
 export const useRoomMembers = (mx: MatrixClient, roomId: string): RoomMember[] => {
@@ -15,10 +16,16 @@ export const useRoomMembers = (mx: MatrixClient, roomId: string): RoomMember[] =
 
     if (room) {
       setMembers(room.getMembers());
-      room.loadMembersIfNeeded().then(() => {
-        if (disposed) return;
-        updateMemberList();
-      });
+      room
+        .loadMembersIfNeeded()
+        .then(() => {
+          if (disposed) return;
+          updateMemberList();
+        })
+        .catch((error) => {
+          if (disposed) return;
+          logger.warn('[useRoomMembers] Failed to load room members', error);
+        });
     }
 
     mx.on(RoomMemberEvent.Membership, updateMemberList);

--- a/src/app/hooks/useRoomMembers.ts
+++ b/src/app/hooks/useRoomMembers.ts
@@ -6,19 +6,16 @@ export const useRoomMembers = (mx: MatrixClient, roomId: string): RoomMember[] =
 
   useEffect(() => {
     const room = mx.getRoom(roomId);
-    let loadingMembers = true;
     let disposed = false;
 
     const updateMemberList = (event?: MatrixEvent) => {
       if (!room || disposed || (event && event.getRoomId() !== roomId)) return;
-      if (loadingMembers) return;
       setMembers(room.getMembers());
     };
 
     if (room) {
       setMembers(room.getMembers());
       room.loadMembersIfNeeded().then(() => {
-        loadingMembers = false;
         if (disposed) return;
         updateMemberList();
       });


### PR DESCRIPTION
## Summary
- Refresh `useRoomMembers` on live membership and power-level events even while `loadMembersIfNeeded()` is still pending.
- Add a hook regression test for a joined member appearing without remounting the members drawer.
- Document CINNY-132 in `FORK_CHANGES.md`.

## Validation
- `npm test -- src/app/hooks/useRoomMembers.test.tsx src/app/features/room/MembersDrawer.test.ts`
- `npx prettier --check FORK_CHANGES.md src/app/hooks/useRoomMembers.ts src/app/hooks/useRoomMembers.test.tsx src/app/features/room/MembersDrawer.test.ts`
- `npm run typecheck`
- `npm run lint` (18 existing warnings, 0 errors)
- `npm test` (309 files, 2299 tests)
- `npm run build` (existing Vite runtime-config/sourcemap/localStorage/chunk-size warnings)
- `git diff --check`

## Review
- Independent subagent review found no issues and reran the focused hook regression test plus cached diff whitespace check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stale members drawer display when newly invited users join a room while the members drawer remains open. Member updates now reflect immediately during any in-progress full member load, and then refresh again after loading completes to ensure consistency.
  * Added graceful handling for member-load failures with warning logs instead of unhandled errors.

* **Tests**
  * Added/updated hook tests to verify real-time member updates during deferred full loading and proper warning behavior when member loading fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->