### PR TITLE
Improve AI summary cards and thread layout

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -2,6 +2,80 @@
 
 ## Runbook
 
+### CINNY-212 - Top-align short active thread timelines (2026-06-18)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Fixed short active thread timelines that were bottom-aligned above the
+    composer, leaving a large empty band between the thread header and the
+    messages.
+  - Changed the shared timeline content wrapper to use `justifyContent="Start"`
+    only when an active `threadId` is present.
+  - Normal room timelines keep the existing bottom-aligned behavior.
+- Decisions:
+  - Scope the layout change to active thread views instead of changing room
+    overview behavior.
+  - Keep existing timeline padding, composer placement, pagination controls,
+    and message rendering unchanged.
+- Validation:
+  - Red focused check:
+    `node node_modules/vitest/vitest.mjs run src/app/mindroom/threads/__tests__/RoomTimeline.layout.test.ts`
+    failed while active thread timelines still reported `justifyContent="End"`.
+  - Green focused check:
+    `node node_modules/vitest/vitest.mjs run src/app/mindroom/threads/__tests__/RoomTimeline.layout.test.ts`
+    (1 file, 2 tests).
+  - Rebased onto `origin/dev` at `c7397730`.
+  - Green rebase check: `npm test` (311 files, 2304 tests; existing React
+    Router/Vite warnings only).
+  - Green rebase check: `npm run typecheck`.
+  - Green rebase check: `npm run lint` (18 warnings, 0 errors; existing
+    console/unused-var warning class).
+  - Green rebase check: `npm run build` (existing Vite runtime-config,
+    sourcemap, and chunk-size warnings only).
+
+### CINNY-211 - Compact AI thread summary cards (2026-06-18)
+
+- Status:
+  - Complete locally.
+- Summary:
+  - Redesigned in-thread AI summary cards so the summary is primary and the
+    provenance is clear without making the message count look clickable.
+  - Replaced the old `Chip`-style message-count badge with plain static
+    provenance text.
+  - Removed the generated timestamp from inside the summary card because the
+    normal message timestamp is already displayed outside the card.
+  - Collapsed the header to `AI summary of last N messages`, reduced max width
+    to 420px, and pinned compact summary body typography to 15px/22px.
+  - Removed the later pill/badge styling per user preference, leaving the
+    provenance as plain muted text.
+- Decisions:
+  - Keep provenance visible for both normal and `compact` summary card usage.
+  - Avoid `Chip`, pill, or badge styling for static metadata because those
+    affordances imply an action.
+  - Keep the card compact while preserving the rendered summary content.
+- Validation:
+  - Red focused check:
+    `node node_modules/vitest/vitest.mjs run src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx`
+    failed while the card still rendered `3 messages` via `Chip` and lacked
+    static provenance text.
+  - Green focused check:
+    `node node_modules/vitest/vitest.mjs run src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx`
+    (1 file, 2 tests).
+  - Green related check:
+    `node node_modules/vitest/vitest.mjs run src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx src/app/mindroom/messages/renderMindroomMessageContent.test.ts src/app/mindroom/threads/ThreadBadgeRenderer.test.ts`
+    (3 files, 22 tests).
+  - Rebased onto `origin/dev` at `c7397730`.
+  - Green rebase check: `npm test` (311 files, 2304 tests; existing React
+    Router/Vite warnings only).
+  - Green rebase check: `npm run typecheck`.
+  - Green rebase check: `npm run lint` (18 warnings, 0 errors; existing
+    console/unused-var warning class).
+  - Green rebase check: `npm run build` (existing Vite runtime-config,
+    sourcemap, and chunk-size warnings only).
+  - Independent review: separate subagent found no issues after the final
+    badge/pill revert.
+
 ### CINNY-210 - Live members drawer updates during invites (2026-06-17)
 
 - Status:

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
@@ -24,6 +24,12 @@ export const ThreadSummaryLabel = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: config.space.S100,
+  width: 'fit-content',
+  minHeight: toRem(24),
+  padding: `0 ${config.space.S200}`,
+  borderRadius: config.radii.Pill,
+  border: `${config.borderWidth.B300} solid ${color.Secondary.ContainerLine}`,
+  backgroundColor: color.Secondary.Container,
   color: color.Secondary.Main,
 });
 

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
@@ -24,8 +24,7 @@ export const ThreadSummaryLabel = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: config.space.S100,
-  color: color.SurfaceVariant.OnContainer,
-  opacity: 0.72,
+  color: color.Secondary.Main,
 });
 
 export const ThreadSummaryBody = style({

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
@@ -24,13 +24,8 @@ export const ThreadSummaryLabel = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: config.space.S100,
-  width: 'fit-content',
-  minHeight: toRem(24),
-  padding: `0 ${config.space.S200}`,
-  borderRadius: config.radii.Pill,
-  border: `${config.borderWidth.B300} solid ${color.Secondary.ContainerLine}`,
-  backgroundColor: color.Secondary.Container,
-  color: color.Secondary.Main,
+  color: color.SurfaceVariant.OnContainer,
+  opacity: 0.72,
 });
 
 export const ThreadSummaryBody = style({

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
@@ -17,28 +17,25 @@ export const ThreadSummaryHeader = style({
   display: 'flex',
   flexWrap: 'wrap',
   alignItems: 'center',
-  columnGap: config.space.S200,
-  rowGap: config.space.S100,
+  gap: config.space.S100,
 });
 
 export const ThreadSummaryLabel = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: config.space.S100,
-  color: color.Secondary.Main,
-});
-
-export const ThreadSummaryMeta = style({
   color: color.SurfaceVariant.OnContainer,
   opacity: 0.72,
 });
 
 export const ThreadSummaryBody = style({
   minWidth: 0,
+  margin: 0,
   fontWeight: 500,
 });
 
 export const ThreadSummaryBodyCompact = style({
   minWidth: 0,
+  margin: 0,
   fontWeight: 500,
 });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
@@ -5,7 +5,7 @@ export const ThreadSummaryCard = style({
   alignSelf: 'flex-start',
   width: 'fit-content',
   minWidth: 0,
-  maxWidth: `min(100%, ${toRem(560)})`,
+  maxWidth: `min(100%, ${toRem(420)})`,
   padding: config.space.S200,
   borderRadius: config.radii.R300,
   border: `${config.borderWidth.B300} solid ${color.SurfaceVariant.ContainerLine}`,
@@ -31,11 +31,15 @@ export const ThreadSummaryLabel = style({
 export const ThreadSummaryBody = style({
   minWidth: 0,
   margin: 0,
+  fontSize: toRem(15),
   fontWeight: 500,
+  lineHeight: toRem(22),
 });
 
 export const ThreadSummaryBodyCompact = style({
   minWidth: 0,
   margin: 0,
+  fontSize: toRem(15),
   fontWeight: 500,
+  lineHeight: toRem(22),
 });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.css.ts
@@ -6,29 +6,31 @@ export const ThreadSummaryCard = style({
   width: 'fit-content',
   minWidth: 0,
   maxWidth: `min(100%, ${toRem(560)})`,
-  padding: config.space.S300,
-  borderRadius: config.radii.R400,
+  padding: config.space.S200,
+  borderRadius: config.radii.R300,
   border: `${config.borderWidth.B300} solid ${color.SurfaceVariant.ContainerLine}`,
   backgroundColor: color.SurfaceVariant.Container,
   color: color.SurfaceVariant.OnContainer,
 });
 
-export const ThreadSummaryMeta = style({
+export const ThreadSummaryHeader = style({
   display: 'flex',
   flexWrap: 'wrap',
   alignItems: 'center',
-  gap: config.space.S200,
+  columnGap: config.space.S200,
+  rowGap: config.space.S100,
 });
 
 export const ThreadSummaryLabel = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: config.space.S100,
-  padding: `${config.space.S100} ${config.space.S200}`,
-  borderRadius: config.radii.R300,
-  border: `${config.borderWidth.B300} solid ${color.Secondary.ContainerLine}`,
-  backgroundColor: color.Secondary.Container,
-  color: color.Secondary.OnContainer,
+  color: color.Secondary.Main,
+});
+
+export const ThreadSummaryMeta = style({
+  color: color.SurfaceVariant.OnContainer,
+  opacity: 0.72,
 });
 
 export const ThreadSummaryBody = style({

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -7,6 +7,7 @@ import { MindroomThreadSummaryCard } from './MindroomThreadSummaryCard';
 const chipMock = vi.fn(({ children }: { children?: React.ReactNode }) =>
   React.createElement('button', { 'data-chip': true }, children)
 );
+const timeMock = vi.fn(({ ts }: { ts: number }) => React.createElement('time', null, `time-${ts}`));
 
 vi.mock('folds', () => ({
   Box: ({
@@ -27,14 +28,6 @@ vi.mock('folds', () => ({
     React.createElement(Tag, props, children),
 }));
 
-vi.mock('../../state/hooks/settings', () => ({
-  useSetting: () => [false],
-}));
-
-vi.mock('../../state/settings', () => ({
-  settingsAtom: {},
-}));
-
 vi.mock('../../components/message/content', () => ({
   MessageEditedContent: () => React.createElement('span', null, 'edited'),
 }));
@@ -45,7 +38,7 @@ vi.mock('../../components/message/layout', () => ({
 }));
 
 vi.mock('../../components/message/Time', () => ({
-  Time: ({ ts }: { ts: number }) => React.createElement('time', null, `time-${ts}`),
+  Time: (props: { ts: number }) => timeMock(props),
 }));
 
 vi.mock('./MindroomThreadSummaryCard.css', () => ({
@@ -81,8 +74,8 @@ describe('MindroomThreadSummaryCard', () => {
     expect(text).toContain('AI summary');
     expect(text).toContain('Generated from last 3 messages');
     expect(text).toContain('Deployment completed and health checks passed.');
-    expect(text).toContain('time-1775000000000');
     expect(chipMock).not.toHaveBeenCalled();
+    expect(timeMock).not.toHaveBeenCalled();
 
     renderer.unmount();
   });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -90,11 +90,5 @@ describe('MindroomThreadSummaryCard', () => {
     expect(source).not.toContain('toRem(560)');
     expect(source).toContain('fontSize: toRem(15)');
     expect(source).toContain('lineHeight: toRem(22)');
-    expect(source).toContain('color: color.Secondary.Main');
-    expect(source).not.toContain('opacity: 0.72');
-    expect(source).toContain('borderRadius: config.radii.Pill');
-    expect(source).toContain('backgroundColor: color.Secondary.Container');
-    expect(source).toContain('config.borderWidth.B300');
-    expect(source).toContain('color.Secondary.ContainerLine');
   });
 });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -92,5 +92,9 @@ describe('MindroomThreadSummaryCard', () => {
     expect(source).toContain('lineHeight: toRem(22)');
     expect(source).toContain('color: color.Secondary.Main');
     expect(source).not.toContain('opacity: 0.72');
+    expect(source).toContain('borderRadius: config.radii.Pill');
+    expect(source).toContain('backgroundColor: color.Secondary.Container');
+    expect(source).toContain('config.borderWidth.B300');
+    expect(source).toContain('color.Secondary.ContainerLine');
   });
 });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable react/prop-types */
+import { readFileSync } from 'node:fs';
 import React from 'react';
 import { create, ReactTestInstance } from 'react-test-renderer';
 import { describe, expect, it, vi } from 'vitest';
 import { MindroomThreadSummaryCard } from './MindroomThreadSummaryCard';
+
+const cssSource = () =>
+  readFileSync(new URL('./MindroomThreadSummaryCard.css.ts', import.meta.url), 'utf8');
 
 const chipMock = vi.fn(({ children }: { children?: React.ReactNode }) =>
   React.createElement('button', { 'data-chip': true }, children)
@@ -77,5 +81,14 @@ describe('MindroomThreadSummaryCard', () => {
     expect(timeMock).not.toHaveBeenCalled();
 
     renderer.unmount();
+  });
+
+  it('keeps the summary card visually compact', () => {
+    const source = cssSource();
+
+    expect(source).toContain('toRem(420)');
+    expect(source).not.toContain('toRem(560)');
+    expect(source).toContain('fontSize: toRem(15)');
+    expect(source).toContain('lineHeight: toRem(22)');
   });
 });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -45,7 +45,6 @@ vi.mock('./MindroomThreadSummaryCard.css', () => ({
   ThreadSummaryCard: 'ThreadSummaryCard',
   ThreadSummaryHeader: 'ThreadSummaryHeader',
   ThreadSummaryLabel: 'ThreadSummaryLabel',
-  ThreadSummaryMeta: 'ThreadSummaryMeta',
   ThreadSummaryBody: 'ThreadSummaryBody',
   ThreadSummaryBodyCompact: 'ThreadSummaryBodyCompact',
 }));
@@ -71,8 +70,8 @@ describe('MindroomThreadSummaryCard', () => {
 
     const text = getNodeText(renderer.root);
 
-    expect(text).toContain('AI summary');
-    expect(text).toContain('Generated from last 3 messages');
+    expect(text).toContain('AI summary of last 3 messages');
+    expect(text).not.toContain('Generated from last 3 messages');
     expect(text).toContain('Deployment completed and health checks passed.');
     expect(chipMock).not.toHaveBeenCalled();
     expect(timeMock).not.toHaveBeenCalled();

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { create, ReactTestInstance } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { MindroomThreadSummaryCard } from './MindroomThreadSummaryCard';
+
+const chipMock = vi.fn(({ children }: { children?: React.ReactNode }) =>
+  React.createElement('button', { 'data-chip': true }, children)
+);
+
+vi.mock('folds', () => ({
+  Box: ({
+    as: Tag = 'div',
+    children,
+    ...props
+  }: {
+    as?: keyof JSX.IntrinsicElements;
+    children?: React.ReactNode;
+    [key: string]: unknown;
+  }) => React.createElement(Tag, props, children),
+  Chip: (props: { children?: React.ReactNode }) => chipMock(props),
+  Icon: ({ src }: { src?: string }) => React.createElement('span', null, src ?? 'icon'),
+  Icons: {
+    Bulb: 'Bulb',
+  },
+  Text: ({ as: Tag = 'span', children, ...props }: any) =>
+    React.createElement(Tag, props, children),
+}));
+
+vi.mock('../../state/hooks/settings', () => ({
+  useSetting: () => [false],
+}));
+
+vi.mock('../../state/settings', () => ({
+  settingsAtom: {},
+}));
+
+vi.mock('../../components/message/content', () => ({
+  MessageEditedContent: () => React.createElement('span', null, 'edited'),
+}));
+
+vi.mock('../../components/message/layout', () => ({
+  MessageTextBody: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('p', props, children),
+}));
+
+vi.mock('../../components/message/Time', () => ({
+  Time: ({ ts }: { ts: number }) => React.createElement('time', null, `time-${ts}`),
+}));
+
+vi.mock('./MindroomThreadSummaryCard.css', () => ({
+  ThreadSummaryCard: 'ThreadSummaryCard',
+  ThreadSummaryHeader: 'ThreadSummaryHeader',
+  ThreadSummaryLabel: 'ThreadSummaryLabel',
+  ThreadSummaryMeta: 'ThreadSummaryMeta',
+  ThreadSummaryBody: 'ThreadSummaryBody',
+  ThreadSummaryBodyCompact: 'ThreadSummaryBodyCompact',
+}));
+
+const getNodeText = (value: ReactTestInstance | string): string => {
+  if (typeof value === 'string') return value;
+  return value.children.map((child) => getNodeText(child as ReactTestInstance | string)).join('');
+};
+
+describe('MindroomThreadSummaryCard', () => {
+  it('renders compact non-interactive AI summary provenance', () => {
+    const renderer = create(
+      React.createElement(MindroomThreadSummaryCard, {
+        summaryInfo: {
+          summaryText: 'Deployment completed and health checks passed.',
+          messageCount: 3,
+          generatedTs: 1_775_000_000_000,
+        },
+        compact: true,
+        renderBody: ({ body }: { body: string }) => React.createElement('span', null, body),
+      })
+    );
+
+    const text = getNodeText(renderer.root);
+
+    expect(text).toContain('AI summary');
+    expect(text).toContain('Generated from last 3 messages');
+    expect(text).toContain('Deployment completed and health checks passed.');
+    expect(text).toContain('time-1775000000000');
+    expect(chipMock).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+});

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.test.tsx
@@ -90,5 +90,7 @@ describe('MindroomThreadSummaryCard', () => {
     expect(source).not.toContain('toRem(560)');
     expect(source).toContain('fontSize: toRem(15)');
     expect(source).toContain('lineHeight: toRem(22)');
+    expect(source).toContain('color: color.Secondary.Main');
+    expect(source).not.toContain('opacity: 0.72');
   });
 });

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.tsx
@@ -1,10 +1,7 @@
 import React, { ReactNode } from 'react';
 import { Box, Icon, Icons, Text } from 'folds';
-import { useSetting } from '../../state/hooks/settings';
-import { settingsAtom } from '../../state/settings';
 import { MessageEditedContent } from '../../components/message/content';
 import { MessageTextBody } from '../../components/message/layout';
-import { Time } from '../../components/message/Time';
 import {
   formatMindroomThreadSummaryMessageCount,
   type MindroomThreadSummaryInfo,
@@ -29,8 +26,6 @@ export function MindroomThreadSummaryCard({
   summaryInfo,
   renderBody,
 }: MindroomThreadSummaryCardProps) {
-  const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
-  const [dateFormatString] = useSetting(settingsAtom, 'dateFormatString');
   const summaryText = summaryInfo.summaryText ?? 'Thread summary';
   const messageCountLabel =
     typeof summaryInfo.messageCount === 'number'
@@ -55,13 +50,6 @@ export function MindroomThreadSummaryCard({
         <Text as="span" size="T200" className={css.ThreadSummaryMeta}>
           {provenanceLabel}
         </Text>
-        {summaryInfo.generatedTs && (
-          <Time
-            ts={summaryInfo.generatedTs}
-            hour24Clock={hour24Clock}
-            dateFormatString={dateFormatString}
-          />
-        )}
       </Box>
 
       <MessageTextBody

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.tsx
@@ -32,7 +32,7 @@ export function MindroomThreadSummaryCard({
       ? formatMindroomThreadSummaryMessageCount(summaryInfo.messageCount)
       : undefined;
   const provenanceLabel = messageCountLabel
-    ? `Generated from last ${messageCountLabel}`
+    ? `AI summary of last ${messageCountLabel}`
     : 'AI-generated thread summary';
 
   return (
@@ -45,11 +45,10 @@ export function MindroomThreadSummaryCard({
       <Box className={css.ThreadSummaryHeader}>
         <Box as="span" className={css.ThreadSummaryLabel}>
           <Icon size="50" src={Icons.Bulb} />
-          <Text size="T200">AI summary</Text>
+          <Text as="span" size="T200">
+            {provenanceLabel}
+          </Text>
         </Box>
-        <Text as="span" size="T200" className={css.ThreadSummaryMeta}>
-          {provenanceLabel}
-        </Text>
       </Box>
 
       <MessageTextBody

--- a/src/app/mindroom/messages/MindroomThreadSummaryCard.tsx
+++ b/src/app/mindroom/messages/MindroomThreadSummaryCard.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Box, Chip, Icon, Icons, Text } from 'folds';
+import { Box, Icon, Icons, Text } from 'folds';
 import { useSetting } from '../../state/hooks/settings';
 import { settingsAtom } from '../../state/settings';
 import { MessageEditedContent } from '../../components/message/content';
@@ -36,24 +36,25 @@ export function MindroomThreadSummaryCard({
     typeof summaryInfo.messageCount === 'number'
       ? formatMindroomThreadSummaryMessageCount(summaryInfo.messageCount)
       : undefined;
+  const provenanceLabel = messageCountLabel
+    ? `Generated from last ${messageCountLabel}`
+    : 'AI-generated thread summary';
 
   return (
     <Box
       className={css.ThreadSummaryCard}
       direction="Column"
-      gap="200"
+      gap="100"
       aria-label="AI thread summary"
     >
-      <Box className={css.ThreadSummaryMeta}>
+      <Box className={css.ThreadSummaryHeader}>
         <Box as="span" className={css.ThreadSummaryLabel}>
           <Icon size="50" src={Icons.Bulb} />
           <Text size="T200">AI summary</Text>
         </Box>
-        {messageCountLabel && !compact && (
-          <Chip variant="SurfaceVariant" radii="Pill" outlined>
-            <Text size="T200">{messageCountLabel}</Text>
-          </Chip>
-        )}
+        <Text as="span" size="T200" className={css.ThreadSummaryMeta}>
+          {provenanceLabel}
+        </Text>
         {summaryInfo.generatedTs && (
           <Time
             ts={summaryInfo.generatedTs}

--- a/src/app/mindroom/threads/MindroomRoomTimeline.tsx
+++ b/src/app/mindroom/threads/MindroomRoomTimeline.tsx
@@ -2756,7 +2756,7 @@ export function RoomTimeline({
             >
               <Box
                 direction="Column"
-                justifyContent="End"
+                justifyContent={threadId ? 'Start' : 'End'}
                 style={{
                   minHeight: '100%',
                   padding: `${config.space.S600} 0`,

--- a/src/app/mindroom/threads/__tests__/RoomTimeline.layout.test.ts
+++ b/src/app/mindroom/threads/__tests__/RoomTimeline.layout.test.ts
@@ -1,0 +1,62 @@
+import React from 'react';
+import { act } from 'react-test-renderer';
+import { describe, expect, it } from 'vitest';
+import {
+  create,
+  createControlledRoomTimelineHarness,
+  flushAsyncWork,
+  makeEvent,
+  makeRoom,
+  threadRenderStateMock,
+} from '../test-utils/RoomTimeline.test.shared';
+
+const findTimelineContentBox = (renderer: ReturnType<typeof create>) => {
+  const matches = renderer.root.findAll(
+    (node) => node.type === 'div' && node.props.style?.minHeight === '100%'
+  );
+  expect(matches).toHaveLength(1);
+  return matches[0];
+};
+
+describe('RoomTimeline layout', () => {
+  it('top-aligns short active thread timelines', async () => {
+    const { RoomTimeline } = await import('../../../features/room/RoomTimeline');
+    const ControlledRoomTimeline = createControlledRoomTimelineHarness(RoomTimeline as never);
+    const threadRoot = makeEvent('$thread-root');
+    threadRenderStateMock.threadEvents = [threadRoot];
+    const room = makeRoom({ liveEvents: [threadRoot] });
+
+    let renderer: ReturnType<typeof create> | undefined;
+
+    await act(async () => {
+      renderer = create(
+        React.createElement(ControlledRoomTimeline, {
+          room,
+          threadId: '$thread-root',
+        })
+      );
+      await flushAsyncWork(1);
+    });
+
+    expect(findTimelineContentBox(renderer!).props.justifyContent).toBe('Start');
+  });
+
+  it('keeps normal room timelines bottom-aligned', async () => {
+    const { RoomTimeline } = await import('../../../features/room/RoomTimeline');
+    const ControlledRoomTimeline = createControlledRoomTimelineHarness(RoomTimeline as never);
+    const room = makeRoom({ liveEvents: [makeEvent('$message')] });
+
+    let renderer: ReturnType<typeof create> | undefined;
+
+    await act(async () => {
+      renderer = create(
+        React.createElement(ControlledRoomTimeline, {
+          room,
+        })
+      );
+      await flushAsyncWork(1);
+    });
+
+    expect(findTimelineContentBox(renderer!).props.justifyContent).toBe('End');
+  });
+});


### PR DESCRIPTION
## Summary
- Rework AI summary cards to use plain static provenance text (`AI summary of last N messages`), remove the in-card timestamp, avoid pill/badge affordances, and keep the card compact.
- Top-align short active thread timelines so thread messages sit under the thread header instead of floating near the composer.
- Add focused regression coverage and update the fork runbook.

## Testing
- `npm test` (311 files, 2304 tests)
- `npm run typecheck`
- `npm run lint` (0 errors, 18 existing warnings)
- `npm run build` (existing Vite runtime-config, sourcemap, and chunk-size warnings)
- `node node_modules/prettier/bin-prettier.js --check FORK_CHANGES.md`
- `git diff --check`
